### PR TITLE
Fix mod-kb-ebsco tests

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c52885f3-ac10-4c97-9887-91a75268b1cd",
+		"_postman_id": "3f0e7d2c-9182-430d-afaa-4d3a7962347c",
 		"name": "mod-kb-ebsco",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1258,7 +1258,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "12fa0e02-d004-4f9c-8551-25cd6c86e54c",
+												"id": "eb98be54-cc50-4a39-90f8-f5f8094aa6aa",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -1283,10 +1283,9 @@
 													"if(response.data) {",
 													"    let len = response.data.length;",
 													"    if(len > 0){",
-													"        //Test that 12 records equal to count are in response",
-													"        //This should be re-visited after https://issues.folio.org/browse/UIEH-466 is fixed.",
-													"        pm.test('no count provided', function(){",
-													"            pm.expect(len).eq(25);",
+													"        //Test that 12 records equal to or less than count are in response",
+													"        pm.test('number of records less than or equal to count', function(){",
+													"            pm.expect(len).to.be.at.most(15);",
 													"        });",
 													"        ",
 													"        //Get the first record",
@@ -1346,7 +1345,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "ea07511a-4daa-45ed-88ab-4283d2e4d4b1",
+												"id": "cbe1cd5e-491c-4d04-b141-57df864b14aa",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -1371,10 +1370,9 @@
 													"if(response.data) {",
 													"    let len = response.data.length;",
 													"    if(len > 0){",
-													"        //Test that 5 records equal to count are in response",
-													"        //This should be re-visited after https://issues.folio.org/browse/UIEH-466 is fixed.",
-													"        pm.test('no count provided', function(){",
-													"            pm.expect(len).eq(13);",
+													"        //Test that number of records returned are less than or equal to count",
+													"        pm.test('number of provider records returned are less than or equal to count', function(){",
+													"            pm.expect(len).to.be.at.most(5);",
 													"        });",
 													"        ",
 													"        //Get the first record",
@@ -1774,6 +1772,79 @@
 												{
 													"key": "page",
 													"value": "abc"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with count out of range",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "7d486b5a-f089-4b32-9095-ececf2e3ae6c",
+												"type": "text/javascript",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"pm.test('Ensure that errors array is not empty', function() {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"});",
+													"",
+													"//Ensure that we get the expected error message",
+													"pm.test('Ensure that errors title is as expected', function() {",
+													"    pm.expect(response.errors[0].title).eq('Parameter Count is outside the range 1-100');",
+													"});"
+												]
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers?count=120",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers"
+											],
+											"query": [
+												{
+													"key": "count",
+													"value": "120"
 												}
 											]
 										}
@@ -2817,7 +2888,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "58e9ec08-a08c-41db-be0b-a8f000e0b9c5",
+												"id": "48432b4d-f7c2-4f08-b9e9-8f1eac8b921c",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -2842,10 +2913,10 @@
 													"if(response.data) {",
 													"    let len = response.data.length;",
 													"    if(len > 0){",
-													"        //Test that 5 records equal to count are in response",
+													"        //Test that number of records returned are less than or equal to count",
 													"        //This should be re-visited after https://issues.folio.org/browse/UIEH-466 is fixed.",
-													"        pm.test('count matches whats passed in query', function(){",
-													"            pm.expect(len).eq(14);",
+													"        pm.test('number of records returned are less than or equal to count', function(){",
+													"            pm.expect(len).to.be.at.most(5);",
 													"        });",
 													"        ",
 													"        //Get the first record",
@@ -3529,12 +3600,12 @@
 									"response": []
 								},
 								{
-									"name": "q and count and sort param invalid",
+									"name": "q and sort param invalid",
 									"event": [
 										{
 											"listen": "test",
 											"script": {
-												"id": "702efc5b-d641-45a4-b56a-ded0132a8787",
+												"id": "1681ef9a-06f2-4a09-8dd1-6dca2e1a00a8",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -3543,11 +3614,29 @@
 													"",
 													"let response = pm.response.json();",
 													"",
-													"//This should actually be a 400",
-													"//Revisit this aftet fix for https://issues.folio.org/browse/UIEH-469 is in.",
 													"pm.test(\"Status is 400\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});"
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Ensure that appropriate error message is given",
+													"    pm.test('Ensure that expected error messages are seen', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Invalid sortFilter');",
+													"        pm.expect(response.errors[0].detail).to.eq('Sortfilter Invalid Query Parameter for sort');",
+													"    });",
+													"}"
 												]
 											}
 										}
@@ -3601,7 +3690,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "8ddea341-1b5f-4bc3-9eac-35718e16c28e",
+												"id": "f1a0ae87-540c-47b8-a003-2975d04ce8cc",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -3611,10 +3700,29 @@
 													"let response = pm.response.json();",
 													"",
 													"//This should actually be a 400",
-													"//Revisit this aftet fix for https://issues.folio.org/browse/UIEH-470 is in.",
 													"pm.test(\"Status is 400\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});"
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Ensure that appropriate error message is given",
+													"    pm.test('Ensure that expected error messages are seen', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Invalid selectedFilter');",
+													"        pm.expect(response.errors[0].detail).to.eq('Selectedfilter Invalid Query Parameter for filter[selected]');",
+													"    });",
+													"}"
 												]
 											}
 										}
@@ -3668,7 +3776,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "071bbffa-aa6a-4987-9a02-9216acbbffb1",
+												"id": "87060553-7e9d-49b6-ae25-d615196b7643",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -3696,7 +3804,8 @@
 													"",
 													"    //Ensure that appropriate error message is being returned",
 													"    pm.test('Ensure that appropriate error message is returned', function() {",
-													"        pm.expect(response.errors[0].title).to.eq('Invalid value for contenttype. Acceptable values are: All, AggregatedFullText, AbstractAndIndex, EBook, EJournal, Print, Unknown, OnlineReference');",
+													"        pm.expect(response.errors[0].title).to.eq('Invalid contentTypeFilter');",
+													"        pm.expect(response.errors[0].detail).to.eq('Contenttypefilter Invalid Query Parameter for filter[type]');",
 													"    });",
 													"}",
 													"",
@@ -3746,6 +3855,81 @@
 												{
 													"key": "filter[type]",
 													"value": "unsupported"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with count out of range",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "461f1d29-f4ec-417d-ad4e-e02eb5ccfe2b",
+												"type": "text/javascript",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"pm.test('Ensure that errors array is not empty', function() {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"});",
+													"",
+													"//Ensure that we get the expected error message",
+													"pm.test('Ensure that errors title is as expected', function() {",
+													"    pm.expect(response.errors[0].title).eq('Parameter Count is outside the range 1-100.');",
+													"});"
+												]
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?count=120",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "count",
+													"value": "120"
 												}
 											]
 										}
@@ -6310,7 +6494,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "b0cc477c-0860-44d4-a047-d9b7d686fed3",
+												"id": "94ac8c29-1a6b-46cf-a9f2-3c7f9acf4285",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -6337,7 +6521,9 @@
 													"    });",
 													"",
 													"    //Test that we get expected error message",
-													"    //This test should be written after https://issues.folio.org/browse/UIEH-464 is fixed.",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package and provider id are required');",
+													"    });",
 													"}",
 													""
 												]
@@ -6454,7 +6640,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "1b52cd90-08e2-4599-b7cf-fb8693a48fca",
+												"id": "0cd4ab39-0383-435d-9d53-ab821668fbd3",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -6468,23 +6654,23 @@
 													"    pm.response.to.have.status(400);",
 													"});",
 													"",
-													"//This test should be revisited after https://issues.folio.org/browse/UIEH-464 is fixed.",
-													"//Commenting this out because schema validation fails for now",
-													"/*pm.test(\"Validate schema\", function () {",
+													"",
+													"pm.test(\"Validate schema\", function () {",
 													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
 													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});*/",
+													"});",
 													"",
-													"//Ensure that errors array is *not* empty but for now, we get empty",
-													"//This test should be revisited after https://issues.folio.org/browse/UIEH-464 is fixed.",
+													"//Ensure that errors array is *not* empty",
 													"if(response.errors) {",
 													"        pm.test('Ensure that errors array is not empty', function() {",
-													"        pm.expect(response.errors).to.be.an('array').that.is.empty;",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
 													"    });",
 													"",
 													"    //Test that we get expected error message",
-													"    //This test should be written after https://issues.folio.org/browse/UIEH-464 is fixed.",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package and provider id are required');",
+													"    });",
 													"}",
 													""
 												]
@@ -8267,7 +8453,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "17299dad-5187-405b-b3d4-0750ed903d4d",
+												"id": "0fc407a0-f0a4-4f01-9b56-ee07d29089ca",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
@@ -8283,20 +8469,21 @@
 													"});",
 													"",
 													"//Validate response against json api schema",
-													"/*pm.test(\"Validate schema\", function () {",
+													"pm.test(\"Validate schema\", function () {",
 													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
 													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});*/",
+													"});",
 													"//Ensure that errors array is *not* empty",
-													"//This test should be revisted after https://issues.folio.org/browse/UIEH-464 is fixed",
 													"if(response.errors) {",
 													"    pm.test('Ensure that errors array is not empty', function() {",
-													"        pm.expect(response.errors).to.be.an('array').that.is.empty;",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
 													"    });",
 													"",
 													"    //Test that we get expected error message",
-													"    //This test should be revisted after https://issues.folio.org/browse/UIEH-464 is fixed ",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package and provider id are required');",
+													"    });",
 													"}",
 													""
 												]
@@ -8939,7 +9126,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "bd3f9efd-a325-446c-9daa-f14933911933",
+												"id": "0f0cb914-4fd1-4981-b03d-417c4ea4951c",
 												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"Status is 400\", function () {",
@@ -8972,15 +9159,18 @@
 													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
 													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
 													"});",
-													"// https://issues.folio.org/browse/UIEH-464",
-													"// Error Messages are not helpful with different terminology",
-													"pm.test(\"Errors array contains 4 entries\", function () {",
-													"    pm.expect(jsonData.errors.length).to.eql(4);",
-													"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid value for orderby. Acceptable values are: Relevance, 0, PackageName, 1\");",
-													"    pm.expect(jsonData.errors[1].title).to.equal(\"Parameter Count is missing.\");",
-													"    pm.expect(jsonData.errors[2].title).to.equal(\"Parameter Offset is missing.\");",
-													"    pm.expect(jsonData.errors[3].title).to.equal(\"Parameter OrderBy is missing.\");",
-													"});",
+													"",
+													"//Ensure that errors array is *not* empty",
+													"if(jsonData.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(jsonData.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(jsonData.errors[0].title).to.eq('Package and provider id are required');",
+													"    });",
+													"}",
 													"",
 													""
 												]


### PR DESCRIPTION
Multiple fixes went into mod-kb-ebsco this week as a result of which API tests started to fail. This PR fixes the tests.

Issues in mod-kb-ebsco that were fixed that led to these failures are:
- https://issues.folio.org/browse/UIEH-495
- https://issues.folio.org/browse/UIEH-466
- https://issues.folio.org/browse/UIEH-470
- https://issues.folio.org/browse/UIEH-427