### PR TITLE
Update mod-kb-ebsco API tests

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
@@ -1,16 +1,16 @@
 {
 	"info": {
-		"_postman_id": "99ccb567-3a87-447f-b719-d0a9c1f0c293",
+		"_postman_id": "d5fd3cda-8f91-4a7b-8be0-b1b20a5f0886",
 		"name": "mod-kb-ebsco",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"_postman_id": "309e899e-4de5-4a2c-b28c-deb6c56f1261",
+			"_postman_id": "b6adf5e7-548a-46d2-b5aa-b05db94c02f0",
 			"name": "schemas",
 			"item": [
 				{
-					"_postman_id": "b606f126-68e8-4a4c-9221-ee71d555ec2b",
+					"_postman_id": "d7a5f5b8-f444-4fe3-bb16-2ee65e81229b",
 					"name": "JSON API schema",
 					"event": [
 						{
@@ -80,11 +80,11 @@
 			]
 		},
 		{
-			"_postman_id": "ac29f98a-0cf0-4533-8e24-c382d304e7ca",
+			"_postman_id": "58e3a96e-2393-40b7-adcb-fd831e1d2ba6",
 			"name": "authentication",
 			"item": [
 				{
-					"_postman_id": "64284fa5-88d5-40e2-ae4b-a58fbbd64a3c",
+					"_postman_id": "e60e6a9e-08ff-4867-b886-e2cc89f2a9cc",
 					"name": "/authn/login",
 					"event": [
 						{
@@ -138,11 +138,11 @@
 			]
 		},
 		{
-			"_postman_id": "40f511df-3c17-478a-8c6a-46785acfcd56",
+			"_postman_id": "6179c69b-7e5b-4637-bee0-973e87978d30",
 			"name": "setup configuration",
 			"item": [
 				{
-					"_postman_id": "012424cf-9dc1-4a7d-8263-2ca7722b91fe",
+					"_postman_id": "a6abbc85-943f-4fa3-8c39-997c737a416c",
 					"name": "Check if configuration api_credentials already exists",
 					"event": [
 						{
@@ -226,7 +226,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "94c60f11-b736-4a54-824c-500093cf1b1b",
+					"_postman_id": "8144cf30-9658-4252-b8ce-9d97809bcdc7",
 					"name": "/configurations/entries - POST RM API api_credentials",
 					"event": [
 						{
@@ -302,7 +302,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "595ae743-bb1c-4af5-adf3-94a820b5ed00",
+					"_postman_id": "e511d139-ca96-40ff-a265-2a421f8669fd",
 					"name": "First Test - Placeholder",
 					"event": [
 						{
@@ -392,11 +392,11 @@
 			]
 		},
 		{
-			"_postman_id": "e107a135-b4b2-4d38-b6f1-2c02547d1f04",
+			"_postman_id": "7b9dcac6-907e-4a68-ad87-12207c42257e",
 			"name": "setup for titles test",
 			"item": [
 				{
-					"_postman_id": "bd3df9ec-5021-4eea-8281-8411943fe493",
+					"_postman_id": "b24bda7c-fe31-4751-9621-f1c9658c2aba",
 					"name": "GET Customer Specific Provider Id",
 					"event": [
 						{
@@ -463,7 +463,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "aa1663b2-403a-4e6e-a901-6cff914951d6",
+					"_postman_id": "f6af2bd5-86b5-4bbe-8726-30d96a5625d2",
 					"name": "Create Custom Package",
 					"event": [
 						{
@@ -535,7 +535,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "447dbd53-9778-4c1a-913e-35bb791d5f2f",
+					"_postman_id": "b3afbd9c-119b-43ce-8e73-d35dde553678",
 					"name": "GET Sample Managed Package",
 					"event": [
 						{
@@ -619,11 +619,11 @@
 			]
 		},
 		{
-			"_postman_id": "3c4205d4-8164-4599-8b93-ed32f9f33f1e",
+			"_postman_id": "fcce068b-2204-4108-a5bc-bdfc9fd66dfe",
 			"name": "setup for resources test",
 			"item": [
 				{
-					"_postman_id": "937654dc-6c4e-47b4-9e7b-5d74cdcb2103",
+					"_postman_id": "9f46b441-6efb-47e8-aaf6-0fb76997322a",
 					"name": "Create Custom Title",
 					"event": [
 						{
@@ -696,7 +696,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "669ad20c-75c9-4fba-9f15-2262cef1fb75",
+					"_postman_id": "d324e034-8a00-48ae-a2dd-f1ae40bf175d",
 					"name": "Create Custom Title for duplicate check",
 					"event": [
 						{
@@ -768,7 +768,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "584e0c78-a8f0-4cab-be92-707b045ffb1b",
+					"_postman_id": "1bb9e7ff-1a98-4709-a33c-f2a45a354a34",
 					"name": "Create Custom Package",
 					"event": [
 						{
@@ -841,7 +841,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "4ca96534-5a86-4469-bc8c-2ab008d89da8",
+					"_postman_id": "ef46f37d-3309-4582-84ed-070a64a946a1",
 					"name": "GET Sample Managed Title",
 					"event": [
 						{
@@ -924,7 +924,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "ac7cebf4-ffa5-4666-9c3b-b7e384b14f5e",
+					"_postman_id": "6cce44d3-68cb-442c-bcfa-a14413d45064",
 					"name": "GET Sample Managed Resource",
 					"event": [
 						{
@@ -1030,19 +1030,19 @@
 			]
 		},
 		{
-			"_postman_id": "9b058e4e-5217-4e54-8e47-11e459c3f404",
+			"_postman_id": "2eb7ce6b-74a3-4b50-ba0e-711684ccb14f",
 			"name": "providers",
 			"item": [
 				{
-					"_postman_id": "bdead702-6ad9-408e-9ccc-155511f8a163",
+					"_postman_id": "cb3ba9d7-2269-4b60-aae8-30d4f56e03b6",
 					"name": "GET provider collection",
 					"item": [
 						{
-							"_postman_id": "4d37f2ea-face-48dc-a323-85ac4cc1a4fb",
+							"_postman_id": "2a1d8124-6b6a-458d-b08e-0aa0c4bac539",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "82874373-69f2-432a-b1db-7b0fe8e7642a",
+									"_postman_id": "513cb582-be72-4111-87a7-f6ec162684d5",
 									"name": "without query params",
 									"event": [
 										{
@@ -1178,7 +1178,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "88579431-620c-46d5-a8a8-d702b037da76",
+									"_postman_id": "556a0a64-841e-417a-af1d-5a4aa55f9ee1",
 									"name": "with valid q",
 									"event": [
 										{
@@ -1268,7 +1268,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c790bb5f-fe0f-4ba0-b6a9-a1f15cf228c2",
+									"_postman_id": "17965daf-8d91-465e-92ad-5e9ff64c3d38",
 									"name": "with count",
 									"event": [
 										{
@@ -1356,7 +1356,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5f683900-0168-4668-abfa-e6dc80971df4",
+									"_postman_id": "68354732-3b00-4157-bdee-12ba2f47d507",
 									"name": "with valid q and count",
 									"event": [
 										{
@@ -1457,7 +1457,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "085dbd1f-e2cc-4a17-9997-03c03286a02f",
+									"_postman_id": "b01aee4d-7593-4eb1-8dfe-02e1b71a5ac5",
 									"name": "sort by name",
 									"event": [
 										{
@@ -1557,11 +1557,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "9e4fb408-68c0-4b3d-a844-210a71b20d13",
+							"_postman_id": "832efcdc-0909-4af6-b765-b6ffddf03bc8",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "0e680da0-0ef3-467b-8778-40ab03e55805",
+									"_postman_id": "a2bda824-bf18-4850-b1f6-c2671f15d1ff",
 									"name": "invalid q",
 									"event": [
 										{
@@ -1639,7 +1639,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "efdb56ea-8283-412a-89d5-eab1229cd268",
+									"_postman_id": "fe6bdc0e-ffc0-4a7a-9154-53ba91465a74",
 									"name": "invalid sort param",
 									"event": [
 										{
@@ -1720,7 +1720,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "0a66e3cb-ef22-4fda-85bb-50c7013502d0",
+									"_postman_id": "3bf6ece8-44b6-417d-b1c3-45f9e3f8c472",
 									"name": "with invalid page param",
 									"event": [
 										{
@@ -1800,7 +1800,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "adaa87a0-eb9a-43a1-9e0d-0badb6882bf1",
+									"_postman_id": "854aad3a-be67-423f-9e8c-bd5c2ae6687d",
 									"name": "with count out of range",
 									"event": [
 										{
@@ -1883,15 +1883,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "1847920c-7f66-4271-99b4-e90adb2862ea",
+					"_postman_id": "ade432b0-8aeb-444a-94ff-6dcbf7bceb7f",
 					"name": "GET provider by providerId",
 					"item": [
 						{
-							"_postman_id": "a8a9ebce-9704-4e6b-920c-4a163c948d19",
+							"_postman_id": "03bb099e-8e1f-438e-a334-478b73c5c79f",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "daeb57d0-9146-46a8-a9db-0a09e2801628",
+									"_postman_id": "7ef3cf27-2e1e-4a91-9deb-33da27d66984",
 									"name": "with valid providerId",
 									"event": [
 										{
@@ -1979,7 +1979,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a49b88e8-8420-43e4-9ff6-c3dc42025ea6",
+									"_postman_id": "0383c4a2-7ed0-48f6-8038-3d8ed13cf777",
 									"name": "with valid providerId including packages",
 									"event": [
 										{
@@ -2075,11 +2075,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "be53bf7d-c1fd-4f15-b116-2935b327fad8",
+							"_postman_id": "1c4195e3-9547-4273-a6c1-fbb8b28cfd02",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "07869107-a719-4f97-8f83-dc8abf2af30a",
+									"_postman_id": "08dae2bd-af60-45dd-ba31-d6a2daf29d6a",
 									"name": "with non-existing providerId",
 									"event": [
 										{
@@ -2154,7 +2154,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "249e2654-a7b9-452a-a32c-aeb40b658104",
+									"_postman_id": "8943d347-a1e3-4f5c-944c-d94ec9d17c0f",
 									"name": "with invalid providerId",
 									"event": [
 										{
@@ -2213,7 +2213,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c309f904-a3d5-4c09-826d-68fffd2dd4cc",
+									"_postman_id": "776e2d1b-1399-437c-a292-81a5ee16e7a0",
 									"name": "with include empty",
 									"event": [
 										{
@@ -2292,15 +2292,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "8f929880-ea4e-485a-944a-397fefe59912",
+					"_postman_id": "1451a672-c703-44a3-ac73-7576fee82c6b",
 					"name": "PUT provider by providerId",
 					"item": [
 						{
-							"_postman_id": "bae0c66c-af07-44ff-905e-1d72d985dafe",
+							"_postman_id": "9c5ac6d7-c89b-45df-bc33-6ddf48f31c5d",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "d5793850-359d-4538-b29b-f09b750cfca4",
+									"_postman_id": "a272098e-e228-4b08-9c05-dbf8be22ac57",
 									"name": "update proxy - success",
 									"event": [
 										{
@@ -2382,7 +2382,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f70d95b5-9485-4608-b3c9-0e19493db092",
+									"_postman_id": "e9ff51cb-ea45-4e41-90b8-3fd4cad78ab5",
 									"name": "update provider token - success",
 									"event": [
 										{
@@ -2470,11 +2470,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "120bc764-f7ec-4d37-a16c-b4dd0e9b7d30",
+							"_postman_id": "0bf1196b-4a35-42c6-8a61-13ac84ccebbc",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "567c81e4-c12a-49ad-bae7-bb98a62d7bc4",
+									"_postman_id": "983b8687-b26a-41a9-b1b9-ed1f4e08f6e8",
 									"name": "update proxy - invalid proxy id",
 									"event": [
 										{
@@ -2555,7 +2555,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "0afb66cb-28f6-4fff-bb2e-76a4bcbdef40",
+									"_postman_id": "c984d3ff-3142-4bb3-8b29-a87df0d11280",
 									"name": "update provider token - error",
 									"event": [
 										{
@@ -2636,7 +2636,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "79a119db-323c-44bf-baf3-bc5480102c82",
+									"_postman_id": "0606af33-2c68-4e3f-9aed-dc39a2016304",
 									"name": "update request - invalid json",
 									"event": [
 										{
@@ -2705,15 +2705,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "2b081989-fb09-4784-bf9b-a3b72312caff",
+					"_postman_id": "15035765-6d1e-4f00-b676-0aae679badd0",
 					"name": "GET provider by providerId including packages",
 					"item": [
 						{
-							"_postman_id": "631c4e20-7466-4f96-a611-d0db3eedd342",
+							"_postman_id": "c64c183e-7a31-4013-a36c-5f5c7fa17049",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "b8039dc7-9e38-448e-bffd-760651cb5634",
+									"_postman_id": "2b20306e-145f-4de7-88be-7bff7ce6d164",
 									"name": "for provider that exists",
 									"event": [
 										{
@@ -2830,7 +2830,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "be56f3b5-9217-494b-bbfa-b33177a63895",
+									"_postman_id": "46ab5c38-c9ec-40d0-8e12-5943dcaf1a5c",
 									"name": "with valid q param",
 									"event": [
 										{
@@ -2920,7 +2920,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "355f6a0a-3a74-4875-9267-b9f712602e82",
+									"_postman_id": "cae025a0-8e52-480e-a79d-d16d725896b4",
 									"name": "with q and count",
 									"event": [
 										{
@@ -3020,7 +3020,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "7033427f-0c1b-4dcd-9ac8-2f367ecbd0a0",
+									"_postman_id": "7406fed5-6c23-4b1e-9d71-132a0858ec67",
 									"name": "q and count and sort by name",
 									"event": [
 										{
@@ -3123,7 +3123,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "06899c1e-8a9d-4d1b-9d3d-d892e57985d9",
+									"_postman_id": "10ab70e0-4882-4ae8-9041-5c7606911e3a",
 									"name": "valid filter[selected]",
 									"event": [
 										{
@@ -3223,7 +3223,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e1430062-5040-4693-ba7f-bd9b4dee9f1d",
+									"_postman_id": "bc98da2f-b2aa-4b46-8211-3a27bb828b4d",
 									"name": "valid filter[selected] and filter[type]",
 									"event": [
 										{
@@ -3336,11 +3336,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "99e35158-f0d9-4b3e-a2c2-6a23b297f0a1",
+							"_postman_id": "3ebd6f12-0150-486d-a801-b63133a9e7d8",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "75ccc7a5-6d4c-4394-9f87-8e1fb5564c7a",
+									"_postman_id": "039ad02a-6130-4338-902b-4d73b91818ec",
 									"name": "for non-existing provider",
 									"event": [
 										{
@@ -3416,7 +3416,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "ec085e7f-069b-4042-97d2-84fbf80f2cc0",
+									"_postman_id": "b9359dc6-aa64-4b6e-8fdf-7a94c80c9609",
 									"name": "with invalid providerId",
 									"event": [
 										{
@@ -3474,7 +3474,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "ce634ac6-f7f0-46c2-8169-701757b58a57",
+									"_postman_id": "a69191f4-cc50-4dc6-9e3b-7a8d1353e948",
 									"name": "with invalid query param",
 									"event": [
 										{
@@ -3554,7 +3554,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c8fb58c5-a054-4399-9db6-e5a334a589d1",
+									"_postman_id": "94361bbe-c53a-49d8-91ef-5496bb2b1647",
 									"name": "invalid page offset",
 									"event": [
 										{
@@ -3645,7 +3645,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "4a77f436-c773-4157-8303-418f481a0424",
+									"_postman_id": "5c29e237-9509-4aec-9f94-18039aafdce1",
 									"name": "q and sort param invalid",
 									"event": [
 										{
@@ -3731,7 +3731,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "2491ba2a-bf71-4249-952e-0bd56046353f",
+									"_postman_id": "f2081f5f-ee26-498e-9e99-3d10ef558541",
 									"name": "filter[selected] invalid value",
 									"event": [
 										{
@@ -3818,7 +3818,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "afb28e7c-0e18-4e8a-8b0a-d8870d191dd4",
+									"_postman_id": "4a9553a3-bfce-4193-af88-b1a288abb3fd",
 									"name": "invalid filter[type]",
 									"event": [
 										{
@@ -3910,7 +3910,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "edbb4e56-8b62-4d68-ac87-7493902fd667",
+									"_postman_id": "1c2ad28b-2784-4445-9995-43f8d2ddb155",
 									"name": "with count out of range",
 									"event": [
 										{
@@ -3997,19 +3997,19 @@
 			]
 		},
 		{
-			"_postman_id": "72293f95-b9a4-4ef8-b444-cc4d9c10bf4d",
+			"_postman_id": "ed0f5799-239a-490f-9f10-94c4ccc50d5e",
 			"name": "packages",
 			"item": [
 				{
-					"_postman_id": "913c9fa4-55e9-4736-b67e-8b4d4d572613",
+					"_postman_id": "68ea5176-ea67-4e92-9f1a-e09658f051c0",
 					"name": "GET package collection",
 					"item": [
 						{
-							"_postman_id": "9a8b3f9e-1ed6-467d-913b-b87818ab0803",
+							"_postman_id": "822e9dfc-a3f7-4f3a-83e2-d90f16034f66",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "b18ae576-c2a7-4866-b16d-10c6aba17096",
+									"_postman_id": "0cef7856-fdf9-40fa-af7d-9a4dfda0fb30",
 									"name": "without query params",
 									"event": [
 										{
@@ -4136,7 +4136,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5b91f08b-84ca-4748-9d47-e30dc9fcadc2",
+									"_postman_id": "aa9d1baa-046a-4340-8787-a986f8400692",
 									"name": "with valid q",
 									"event": [
 										{
@@ -4231,7 +4231,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5f21b8aa-3633-4ef7-a097-7a18ad77661c",
+									"_postman_id": "3aa07a6b-49d3-4dc6-a804-96b373a79e5b",
 									"name": "valid q and count",
 									"event": [
 										{
@@ -4326,7 +4326,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "263e34f8-d0cc-4841-bff9-27242b25d77c",
+									"_postman_id": "1b2fa76b-ec7e-4782-ab57-49ffddaee623",
 									"name": "with count",
 									"event": [
 										{
@@ -4423,7 +4423,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "d5abdc62-1162-46d1-acdf-4f411921acb0",
+									"_postman_id": "e107ce80-2cc3-447e-8899-678924580c2e",
 									"name": "valid page offset one",
 									"event": [
 										{
@@ -4520,7 +4520,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f3343512-e795-409a-8ff9-f1fb030dca82",
+									"_postman_id": "773c507f-d270-43e3-897b-6bee9eec94af",
 									"name": "valid page offset two",
 									"event": [
 										{
@@ -4612,7 +4612,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "2c7099a9-be01-4751-996e-a09e9c381042",
+									"_postman_id": "a396cc55-0eba-4edc-a9b8-547d001f7b3e",
 									"name": "with valid sort - by name",
 									"event": [
 										{
@@ -4709,7 +4709,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "ab660de1-4dd9-4b8c-bcae-1d5a376bbdc5",
+									"_postman_id": "907d0e85-1467-40f0-afc0-361f6cfa0c1b",
 									"name": "valid filter[selected] param",
 									"event": [
 										{
@@ -4814,7 +4814,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "79b24f53-b029-463b-a7e5-5774ffb65280",
+									"_postman_id": "c39940ef-8ffa-4a8c-bb4b-e3175209fa8c",
 									"name": "valid filter[type]",
 									"event": [
 										{
@@ -4919,7 +4919,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e0027fe6-df89-48fe-b5a2-947544def758",
+									"_postman_id": "d729e6e5-ba84-425e-9904-9848bd512bee",
 									"name": "valid filter[custom]",
 									"event": [
 										{
@@ -5020,11 +5020,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "cd3b9891-7eb5-45da-b606-5c6e89d25e0d",
+							"_postman_id": "0522360f-d288-4975-90bd-67acd5f77d3a",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "0d91b133-1654-4e28-8fc1-6361205de4b1",
+									"_postman_id": "4da7d755-340f-4a6c-897d-9472afb13a0a",
 									"name": "with empty search string q",
 									"event": [
 										{
@@ -5102,7 +5102,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5c4753f3-1099-44af-926e-024796697b41",
+									"_postman_id": "2ef78bb7-c307-4da6-a271-feb153ac578d",
 									"name": "invalid page param",
 									"event": [
 										{
@@ -5184,7 +5184,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "ecef5385-4c93-4485-aaeb-9076d3b2d7ba",
+									"_postman_id": "7a852aab-ca54-4939-b4a6-ca28a8876eb7",
 									"name": "invalid sort filter param",
 									"event": [
 										{
@@ -5265,7 +5265,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "49eee9ea-f6fe-4be9-962f-4fb77804aa1a",
+									"_postman_id": "f65f47bb-5844-449a-8615-806098f44d23",
 									"name": "invalid filter[selected] param",
 									"event": [
 										{
@@ -5350,7 +5350,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "6873f1fd-b84f-44fe-bf5e-da8157117f12",
+									"_postman_id": "c67b6059-0869-4ee8-b56c-ba0cb09e7397",
 									"name": "invalid filter[type]",
 									"event": [
 										{
@@ -5435,7 +5435,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c6c2652c-0330-40a4-9a0b-3cf81c144fbe",
+									"_postman_id": "3d256baa-d501-4ae1-a0b5-20685d3055fd",
 									"name": "invalid filter[custom]",
 									"event": [
 										{
@@ -5517,7 +5517,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3e900106-13bf-4cb2-989f-3414eaadceff",
+									"_postman_id": "a223f1fc-23d8-4d2f-8026-95a9411f03f5",
 									"name": "invalid filter[custom]=false",
 									"event": [
 										{
@@ -5603,7 +5603,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3ad7b631-bfed-4d67-b52e-e65d57fbf7ff",
+									"_postman_id": "a9d30ac6-6627-409b-bfdd-cb04710c39d5",
 									"name": "invalid count",
 									"event": [
 										{
@@ -5686,15 +5686,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "9a1d1389-6658-4c4b-b126-32e48121c86d",
+					"_postman_id": "f785bd81-2890-40b6-908e-3d8d1cc5aa60",
 					"name": "POST to package collection",
 					"item": [
 						{
-							"_postman_id": "7ac1ad65-5350-41a9-a845-65aed1d73898",
+							"_postman_id": "147d72bf-934c-4d52-9bf9-5e70049aafcd",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "628e7692-ea8a-4b39-a560-ff46f0f1b911",
+									"_postman_id": "d83da24f-83f8-4070-a24e-7439715c55fc",
 									"name": "create custom package for testing deletion",
 									"event": [
 										{
@@ -5819,7 +5819,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "9475838e-fdba-4cf3-8db4-e4b388f2058e",
+									"_postman_id": "071ed1b9-3d08-43d4-92df-4b285bee302d",
 									"name": "create custom package for testing deletion in PUT",
 									"event": [
 										{
@@ -5918,11 +5918,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "abb8b4cb-d5ae-492d-be28-b07dd256b9f6",
+							"_postman_id": "6d565bb5-3ee9-4d0f-885b-2472ebe6f390",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "89296db0-51b7-4bcb-a3dd-e710b7eb0d96",
+									"_postman_id": "f90c805d-9e1b-4bde-b2f8-3e0ae5e293cb",
 									"name": "with package name that already exists",
 									"event": [
 										{
@@ -6000,7 +6000,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a2958282-8c14-4776-b99c-96451f08b68e",
+									"_postman_id": "6f7d006a-85e8-4c72-aef2-378767d9ba08",
 									"name": "with invalid contentType",
 									"event": [
 										{
@@ -6062,7 +6062,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "875fcfa4-84d5-4765-ae9d-ec150ef760e0",
+									"_postman_id": "1f4f87af-af19-44b1-b133-a8067a58000d",
 									"name": "bad data for customCoverage",
 									"event": [
 										{
@@ -6133,7 +6133,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "44725927-bcef-43a3-a60d-f9786717a47d",
+									"_postman_id": "50e7bc70-d1af-431c-90ac-8afe911622ef",
 									"name": "package without name",
 									"event": [
 										{
@@ -6212,7 +6212,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "71acd14a-a543-47b7-9099-5aa193dc5ef9",
+									"_postman_id": "1c0c3374-8185-415c-9b40-9fd49dd53822",
 									"name": "package without content type",
 									"event": [
 										{
@@ -6297,15 +6297,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "fe4cc22b-714a-49c0-b354-7c0539d66afd",
+					"_postman_id": "a673be23-7ba5-4337-8c14-8d9518692361",
 					"name": "GET package by packageId",
 					"item": [
 						{
-							"_postman_id": "b63312c5-c9c5-4057-8605-2b93dcb0257d",
+							"_postman_id": "c7c6ff77-e911-4491-b79e-ee530d33bcd2",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "a573a428-c48a-41d0-8073-65cecc44fa2d",
+									"_postman_id": "c986c86b-041a-4a1b-b9a9-6b033287f4b7",
 									"name": "with valid packageId",
 									"event": [
 										{
@@ -6394,7 +6394,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "9eadb881-d595-4342-9fcc-ed09392ce2b8",
+									"_postman_id": "87d3ca01-b062-4382-9407-d10e0b07a592",
 									"name": "with valid packageId including resources",
 									"event": [
 										{
@@ -6490,11 +6490,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "37802570-b624-42a9-9fe2-d51017330c25",
+							"_postman_id": "f2fac13b-0177-4b04-a07d-398c99cb819e",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "edfb6f3e-773f-415d-8e68-aff22324c49c",
+									"_postman_id": "5dd7127b-c066-4020-a2d1-abd0b8d1ac4b",
 									"name": "with non-existing packageId",
 									"event": [
 										{
@@ -6569,7 +6569,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "409ab57a-4e2d-4e19-a69c-dd274a708a53",
+									"_postman_id": "f3799058-fdd4-4fb7-9ab3-d33a4538ea3b",
 									"name": "with invalid packageId",
 									"event": [
 										{
@@ -6644,7 +6644,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "fc7f673f-b563-4e13-88c6-e433dc7245f0",
+									"_postman_id": "72841cbf-154f-466d-9530-a881cb95b503",
 									"name": "with include empty",
 									"event": [
 										{
@@ -6717,7 +6717,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a4fb531f-9850-47f4-bc9c-94e4ecceae2e",
+									"_postman_id": "8a94811d-fcf3-4d27-8cc2-ebcc339dc23c",
 									"name": "invalid packageId without providerId",
 									"event": [
 										{
@@ -6793,7 +6793,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "9b703a9a-1f58-4239-bdba-5d2c1a015072",
+									"_postman_id": "297dd144-0d8a-46a1-ac0f-9f0077df4990",
 									"name": "invalid packageId with providerId",
 									"event": [
 										{
@@ -6874,19 +6874,19 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "fc5b8fba-2e64-404a-86b5-7be8e891b0c8",
+					"_postman_id": "39ec5553-8696-40c0-acf8-b49a2d340740",
 					"name": "PUT package by packageId",
 					"item": [
 						{
-							"_postman_id": "610c009b-180a-44e2-937f-19827f931bbf",
+							"_postman_id": "1cdaa0ea-11bd-4f07-88a1-25b57136f499",
 							"name": "Custom Package",
 							"item": [
 								{
-									"_postman_id": "dd8ded74-d3dd-48c1-8997-c48f4e2a1034",
+									"_postman_id": "b5145718-9d6f-4ac3-b164-12f6d05fb0b5",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "672e6fbf-e720-4daf-a901-bb334540b0d0",
+											"_postman_id": "a5f052ef-2121-47a9-b164-2c6b9ce1a25e",
 											"name": "update custom package",
 											"event": [
 												{
@@ -7007,7 +7007,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "9fd62161-46fc-4dff-858a-63d7740ca9bc",
+											"_postman_id": "7b7898d2-a0de-4fc4-b0f5-225a837ec7b6",
 											"name": "visibility data and coverage update",
 											"event": [
 												{
@@ -7131,11 +7131,11 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"_postman_id": "9d3f15f5-b9a3-4450-b284-5cb99869f0ad",
+									"_postman_id": "fa598ccc-d837-4d97-85d4-ecb8dc86ac7a",
 									"name": "Negative",
 									"item": [
 										{
-											"_postman_id": "f6eb3609-0bc2-4f32-a2ee-c87245a17a14",
+											"_postman_id": "6fd962b9-43e0-477d-bafb-65cfef6756e2",
 											"name": "update custom package without name",
 											"event": [
 												{
@@ -7216,7 +7216,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "0cf9eb9c-afba-40bf-bc55-47b19f20d1e9",
+											"_postman_id": "08d6393a-334b-4292-bc52-42640521d71a",
 											"name": "update custom package without contentType",
 											"event": [
 												{
@@ -7297,7 +7297,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "83699171-72ee-40b1-813a-f9f6d66be6f7",
+											"_postman_id": "9f1da113-b630-43f4-bed1-3535150bbd84",
 											"name": "update custom package with name that already exists",
 											"event": [
 												{
@@ -7387,7 +7387,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "3f9f4b5d-7995-473d-81ad-1386ab07e6b5",
+											"_postman_id": "1c2ab87d-0d25-4f34-beb3-47a551f0b30b",
 											"name": "update custom package with isSelected false should delete it",
 											"event": [
 												{
@@ -7467,7 +7467,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "4e52854d-7e8e-4d3a-9d42-805f6a698b8c",
+											"_postman_id": "3f712ec7-51c7-4ce1-a7b9-f97b9297fccc",
 											"name": "invalid contentType",
 											"event": [
 												{
@@ -7541,15 +7541,15 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "477138e2-aae5-435b-9056-657a7da5e0ee",
+							"_postman_id": "7d17351c-4c2e-4249-b878-c37fb47a39d0",
 							"name": "Managed Package",
 							"item": [
 								{
-									"_postman_id": "a1b19878-9cf0-452b-913c-89d613d6688e",
+									"_postman_id": "ee89766d-30c1-4d5e-93cd-fc8a79138982",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "74091ffc-fc9d-4d24-9639-84342dc79199",
+											"_postman_id": "a59d9553-f0fa-430d-a7db-4516c71f2604",
 											"name": "update managed package",
 											"event": [
 												{
@@ -7662,11 +7662,11 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"_postman_id": "87e7f697-94eb-49c2-beab-811c1c44ac5c",
+									"_postman_id": "10ab7886-f8cf-4517-89b0-11521c7e12e5",
 									"name": "Negative",
 									"item": [
 										{
-											"_postman_id": "4f2cc1d1-dad1-42e6-8163-2b640f1b0fba",
+											"_postman_id": "4dd7a935-d014-4e44-84cc-713e40b81900",
 											"name": "try updating managed package with isSelected false",
 											"event": [
 												{
@@ -7750,7 +7750,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "63544ab4-4dd6-4e97-bbc0-4b3a0dd994a5",
+											"_postman_id": "2a74f6dd-d5dc-4c1c-bcf2-8745f4fcd652",
 											"name": "invalid dates for coverage",
 											"event": [
 												{
@@ -7833,7 +7833,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "609421ef-a0af-4264-bb34-a78cc63e3e57",
+											"_postman_id": "6ea7f83c-759c-4eb0-bd86-2847e8035a6b",
 											"name": "invalid isSelected",
 											"event": [
 												{
@@ -7905,7 +7905,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "7669338b-ff64-4eb7-9e60-f23cccda080d",
+											"_postman_id": "521cea70-83ff-415c-9875-62ad07318960",
 											"name": "invalid isHidden",
 											"event": [
 												{
@@ -7977,7 +7977,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "57b5d461-2467-4b6e-b437-e53fe1e2b8e0",
+											"_postman_id": "6586af45-4b2c-456f-b165-ec9b75da9a5d",
 											"name": "invalid allowKbToAddTitles",
 											"event": [
 												{
@@ -8049,7 +8049,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "c863cf6f-bc4b-420f-b04d-b67613893e8c",
+											"_postman_id": "9d4bbc66-743e-4156-83d3-0fa96fa57938",
 											"name": "invalid json in request",
 											"event": [
 												{
@@ -8127,15 +8127,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "efa666a5-e839-457d-a008-773a02fd60cd",
+					"_postman_id": "923fd6e6-fbde-4683-bb06-452e6d25bec1",
 					"name": "DELETE package by packageId",
 					"item": [
 						{
-							"_postman_id": "6d9b34cd-4dea-4c04-84b1-ce047c4b56ca",
+							"_postman_id": "ee2cf217-d4ce-40ba-9118-81000246e22b",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "f45ba88a-5a2a-4ddd-b32e-45cf1b869991",
+									"_postman_id": "abda23ea-1f12-40c4-907d-d3ff9602a139",
 									"name": "Delete custom package",
 									"event": [
 										{
@@ -8193,11 +8193,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "ac1ffee1-63ea-4e45-b46a-9ea53a74b2e9",
+							"_postman_id": "8e96e75e-712d-47be-9b39-12c4084dc535",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "c8220216-0fc6-4059-848e-7084524f5ab4",
+									"_postman_id": "e55c6342-355b-47ae-92ef-4faaacf10b86",
 									"name": "invalid providerId in packageId",
 									"event": [
 										{
@@ -8260,7 +8260,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "6c10cd3e-822c-4710-b06b-2dbfa5aee97a",
+									"_postman_id": "7c92631e-48d7-48c1-9d71-87dc67c33854",
 									"name": "invalid packageId",
 									"event": [
 										{
@@ -8336,7 +8336,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "6b50e4d9-7470-4588-b19c-37a0f86a1b4b",
+									"_postman_id": "19305ce5-ccd7-4320-b159-f18459fb7add",
 									"name": "delete a managed package",
 									"event": [
 										{
@@ -8420,15 +8420,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "7fe25114-b6ee-497e-83d1-4b34a55f7576",
+					"_postman_id": "3de031d5-89d9-43dc-bb1d-bb6505edae9d",
 					"name": "GET package by packageId including resources",
 					"item": [
 						{
-							"_postman_id": "76a79fd9-b0aa-4840-9ca1-87b23ee4f855",
+							"_postman_id": "6fe1f046-9b71-4645-a6bc-3bdd2d2246fe",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "d65b6a53-360f-4367-bd26-cc77e484b4bb",
+									"_postman_id": "f6da4c24-c40c-4d55-b839-8b3482c5d1b5",
 									"name": "with valid packageId",
 									"event": [
 										{
@@ -8554,11 +8554,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "d5f8e3e2-585f-4adb-843e-633562ee3eb2",
+							"_postman_id": "2b853fae-2e6a-447e-acbf-06edfc71a599",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "0d41e15b-7a01-45a8-84bb-25554290d97f",
+									"_postman_id": "6b1a0d0f-c85a-4ac6-abe1-a57da571c85c",
 									"name": "with non-existing packageId",
 									"event": [
 										{
@@ -8634,7 +8634,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "68389473-a2f4-4cfa-b5a7-878c5698b61f",
+									"_postman_id": "a32f5c63-d6c6-479f-b1f8-799738233156",
 									"name": "with invalid packageId without providerId",
 									"event": [
 										{
@@ -8711,7 +8711,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c781286b-5f9b-450c-b449-d4f39cc9b360",
+									"_postman_id": "d2a26a26-ea8a-4a44-bb2f-9a7ebb14724b",
 									"name": "with invalid packageId and providerId",
 									"event": [
 										{
@@ -8796,19 +8796,19 @@
 			]
 		},
 		{
-			"_postman_id": "1d1f2070-dc19-46a0-ac46-8d2e3485535f",
+			"_postman_id": "c7c7f4e3-d082-4aa4-adeb-a3c2d3ab351b",
 			"name": "resources",
 			"item": [
 				{
-					"_postman_id": "744b9ecc-0ac2-4ea4-a14f-377081f3d479",
+					"_postman_id": "88408598-b20e-4f9c-98e4-40044bf498d0",
 					"name": "POST resource",
 					"item": [
 						{
-							"_postman_id": "d925c6bf-1ba9-43ff-a65c-f4aecb83180b",
+							"_postman_id": "868aef1e-deee-4ef9-b658-32edd3c50f37",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "94fbf663-dab0-474f-b058-997d49911571",
+									"_postman_id": "2f3881a0-6178-4bbe-b898-71b1b7c14588",
 									"name": "/resources POST add managed title to custom package",
 									"event": [
 										{
@@ -8921,7 +8921,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "bad2f4d0-7660-479f-a30e-8d55f31b2619",
+									"_postman_id": "5af586d8-668a-4cc2-94a9-12bbb3c153d1",
 									"name": "/resources POST add custom title to custom package",
 									"event": [
 										{
@@ -9035,11 +9035,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "9b4c9d90-c2d7-4c6f-99de-ea29c9a10c99",
+							"_postman_id": "8feea954-b091-4e86-b4ec-5841175f9398",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "4a540eb7-8512-403a-a253-b8a0cd131944",
+									"_postman_id": "4954c8a5-c845-41c4-a7ac-5847bd4d778a",
 									"name": "/resources POST add managed title to managed package",
 									"event": [
 										{
@@ -9136,7 +9136,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f5f7ac17-7f73-42ff-a6a8-4014f530b944",
+									"_postman_id": "6a8e2a4e-2158-4258-90a0-74f6bc027a8a",
 									"name": "/resources POST add custom title to managed package",
 									"event": [
 										{
@@ -9233,7 +9233,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "70a32078-4e95-4329-8941-6fb72cb0a836",
+									"_postman_id": "b0fc9ec4-dc56-4e72-a628-9d09b3907d87",
 									"name": "/resources POST invalid url",
 									"event": [
 										{
@@ -9315,7 +9315,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b3a1b76c-478a-435d-960d-93ac4e269164",
+									"_postman_id": "d53c7e68-812e-4501-9303-224d3b4f149c",
 									"name": "/resources POST invalid package id",
 									"event": [
 										{
@@ -9418,7 +9418,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f7aa20f5-d855-400c-b7b2-0e22e68659d8",
+									"_postman_id": "431d230b-323b-4f39-bbad-1d7dabb505f9",
 									"name": "/resources POST invalid titleId",
 									"event": [
 										{
@@ -9515,7 +9515,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "80e97bad-5a71-4157-81c4-ba562f7dec8f",
+									"_postman_id": "7b938385-af21-41ce-9939-300c17c66450",
 									"name": "/resources POST invalid content type",
 									"event": [
 										{
@@ -9588,15 +9588,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "0e4e4654-a125-4b4e-b1ba-6d3b5adf904a",
+					"_postman_id": "ab1649bf-9e7e-4204-b314-29f7c414de15",
 					"name": "GET resource by resourceId",
 					"item": [
 						{
-							"_postman_id": "73ef3477-a6c8-41b2-a7e7-9c6d4fcd8c52",
+							"_postman_id": "4f9a04a5-0178-4de6-af9d-646dc96ef7ac",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "caadf780-6e34-45c6-bbe9-efc465807059",
+									"_postman_id": "699e275c-0ae2-496a-b316-b060390fafa6",
 									"name": "/resources GET specific resource (managed title)",
 									"event": [
 										{
@@ -9699,7 +9699,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "20431bde-443e-4809-a83a-7d25659ac381",
+									"_postman_id": "13c51b07-fed4-4bbb-928a-f955a953a377",
 									"name": "/resources GET specific resource (custom title)",
 									"event": [
 										{
@@ -9802,7 +9802,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "1ee1f380-6745-4d78-bf25-d9d421c8909a",
+									"_postman_id": "9ee43da0-38ea-470b-8313-d413445bd45a",
 									"name": "/resources GET specific resource and include provider",
 									"event": [
 										{
@@ -9938,7 +9938,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "177b776e-7c17-4687-93bb-4b99d1d60b40",
+									"_postman_id": "32e12c7a-e287-415c-b6dc-f8192a5cd072",
 									"name": "/resources GET specific resource and include package",
 									"event": [
 										{
@@ -10074,7 +10074,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e4c52ba0-e27b-472a-8488-fdd15f01108b",
+									"_postman_id": "8d370049-4b35-41b0-95cc-896dad74d243",
 									"name": "/resources GET specific resource and include title",
 									"event": [
 										{
@@ -10210,7 +10210,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "258f7038-18b2-4cf3-b3c1-b357d1393bc2",
+									"_postman_id": "36ed311e-2f53-423f-9754-2e8b1eff3015",
 									"name": "/resources GET specific resource and include provider,package,title",
 									"event": [
 										{
@@ -10391,11 +10391,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "42b7eb1d-bb47-4788-b53e-7c4aa4bbebc5",
+							"_postman_id": "91630062-36f0-41a0-bf1a-774cf3e47475",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "809dff7d-30c3-41a9-b097-994cb0345111",
+									"_postman_id": "961a86d5-20aa-42cf-908a-db4be45336b0",
 									"name": "/resources GET invalid resource",
 									"event": [
 										{
@@ -10491,7 +10491,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3585fd8a-e99d-4087-8bf6-4e5c47394253",
+									"_postman_id": "c1b75e00-7b71-4b23-ab23-33cf8f2d7836",
 									"name": "/resources GET specific resource and invalid include",
 									"event": [
 										{
@@ -10603,19 +10603,19 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "3f6bd4d7-0de2-4fc6-8547-6856759a501d",
+					"_postman_id": "48bf96e6-8039-4c46-a566-fb56c2c17587",
 					"name": "PUT resource by resourceId",
 					"item": [
 						{
-							"_postman_id": "d95cfc08-22ff-4332-a7be-e7fc4e3b3705",
+							"_postman_id": "ff010094-f386-49af-8fbf-841c37b8542a",
 							"name": "Custom Resource",
 							"item": [
 								{
-									"_postman_id": "cf3a316d-b70a-41cf-800f-dfbf9a875d33",
+									"_postman_id": "f7c82d99-b867-4d45-b19b-9bdc66db07ea",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "21c8bf66-07a5-4ee1-9d3b-c0ad75f91783",
+											"_postman_id": "bb0c792f-becd-4b24-bbab-10c98e8b77ad",
 											"name": "/resources PUT update custom resource",
 											"event": [
 												{
@@ -10739,7 +10739,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "e89b3e25-e7da-4774-b3a8-488fad21b9ac",
+											"_postman_id": "a3580062-26f4-4880-97a2-48237218b2a6",
 											"name": "/resources PUT update custom resource - custom only fields",
 											"event": [
 												{
@@ -10886,11 +10886,11 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"_postman_id": "ad55e25b-df9f-4bcb-970f-1ca5d7f77080",
+									"_postman_id": "e2a0dbd4-0834-46fd-aed0-65d336d558f6",
 									"name": "Negative",
 									"item": [
 										{
-											"_postman_id": "d47e0bd6-23d2-41ab-b4c9-efb3f63f9014",
+											"_postman_id": "4ecea87d-c3ad-4bd3-a6e9-c4cb082e1990",
 											"name": "/resources PUT update custom resource missing identifier id",
 											"event": [
 												{
@@ -10975,7 +10975,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "3a1c5178-423b-4589-8bf6-89887dd08b9d",
+											"_postman_id": "b9432e4b-89bd-45b3-8d15-06b78c24e57e",
 											"name": "/resources PUT update custom resource invalid idenitifer subtype",
 											"event": [
 												{
@@ -11060,7 +11060,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "a433819e-cb57-496c-93e1-6531c75dd898",
+											"_postman_id": "b0c65c01-8c59-4018-9c4a-aa307bcef61b",
 											"name": "/resources PUT update custom resource invalid idenitifer type",
 											"event": [
 												{
@@ -11144,7 +11144,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "fec51d5f-bf8d-4e8e-bb2a-20cf223a4e50",
+											"_postman_id": "a4f716e1-6ba2-40fd-bced-a3303c518273",
 											"name": "/resources PUT update custom resource invalid contributor",
 											"event": [
 												{
@@ -11228,7 +11228,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "7b6e79d6-f9b4-4604-baed-ca449353186c",
+											"_postman_id": "2ccade46-ae86-4687-8b3f-0ea36b2c988c",
 											"name": "/resources PUT update custom resource invalid url",
 											"event": [
 												{
@@ -11314,7 +11314,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "7ba4f8cd-9b3d-43e9-8af9-5b59d7ee6f51",
+											"_postman_id": "9d784557-81d4-49b3-9690-610133fa0e2c",
 											"name": "/resources PUT update custom resource invalid description",
 											"event": [
 												{
@@ -11399,7 +11399,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "e8365316-f774-4e4c-ae16-5c7473ffb941",
+											"_postman_id": "d221066d-26f6-4172-b0ef-6bc8c510d241",
 											"name": "/resources PUT update custom resource invalid edition",
 											"event": [
 												{
@@ -11483,7 +11483,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "81c9675b-f67b-4d32-bd0a-1215f87b08c0",
+											"_postman_id": "92937131-149c-4aea-be11-753a6d9731dd",
 											"name": "/resources PUT update custom resource invalid publisher name",
 											"event": [
 												{
@@ -11568,7 +11568,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "2c3684ca-0c1f-4146-8549-d91ea2a8a989",
+											"_postman_id": "ca4dd252-c90e-4aca-813b-94d8dc3eabf2",
 											"name": "/resources PUT update custom resource invalid publication type",
 											"event": [
 												{
@@ -11672,7 +11672,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "12337806-c1ac-4f5c-a69e-2a986837ed69",
+											"_postman_id": "f157ab16-1892-4013-b704-2ffad46aa3e8",
 											"name": "/resources PUT update custom resource invalid peer review",
 											"event": [
 												{
@@ -11758,7 +11758,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "113ae7fe-bdf3-4924-bdfc-82c27feeecd6",
+											"_postman_id": "691894f5-f0a6-4528-9402-d10c8ff700c8",
 											"name": "/resources PUT update custom resource duplicate title name",
 											"event": [
 												{
@@ -11842,7 +11842,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "f29e0c54-8de6-491c-a775-44fe5648dac8",
+											"_postman_id": "f4dfd723-894b-41d9-8ea3-fa2d392bedb1",
 											"name": "/resources PUT update custom resource Invalid name",
 											"event": [
 												{
@@ -11926,7 +11926,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "2f5c3c70-398c-4626-962c-b384ca18bd66",
+											"_postman_id": "617f07fd-cf98-47f3-b2a3-4f5ddd92a6f0",
 											"name": "/resources PUT update custom resource Invalid proxy",
 											"event": [
 												{
@@ -12010,7 +12010,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "8c7efbb9-f9a7-4118-975a-4b21e8cc5fbd",
+											"_postman_id": "5ec0d78a-d64b-48eb-bca7-b8f58644b375",
 											"name": "/resources PUT update custom resource Invalid coverageStatement",
 											"event": [
 												{
@@ -12094,7 +12094,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "a5095352-ee12-4209-8b39-66aa1ab5963d",
+											"_postman_id": "0dacde6f-dfcc-46ca-a209-7120fa199fa3",
 											"name": "/resources PUT update custom resource Invalid customCoverages",
 											"event": [
 												{
@@ -12177,7 +12177,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "f2b23975-e24c-4293-91c0-f5573afc26fe",
+											"_postman_id": "81ec191f-c357-4321-8ea1-a665d75f6f3d",
 											"name": "/resources PUT update custom resource Invalid embargoValue",
 											"event": [
 												{
@@ -12259,7 +12259,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "7bbc4c0e-a306-48af-ad12-f37f184242d1",
+											"_postman_id": "fadf0f6c-bd01-4870-bb2e-4a844ee23802",
 											"name": "/resources PUT update custom resource Invalid embargoUnit",
 											"event": [
 												{
@@ -12342,7 +12342,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "befda6f4-b592-4697-b2a9-9024ceab903f",
+											"_postman_id": "164c997e-ea2c-431c-aea0-c3432e92720b",
 											"name": "/resources PUT update custom resource Invalid visibilityData",
 											"event": [
 												{
@@ -12431,15 +12431,15 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "c8f47c72-8a85-418d-a545-56796e4ecbe1",
+							"_postman_id": "8e026956-658a-4f4c-86b9-e931b37d976a",
 							"name": "Managed Resource",
 							"item": [
 								{
-									"_postman_id": "6a448c95-c38b-40b5-8915-6290da8ade97",
+									"_postman_id": "190c6682-18b2-48dc-811a-edb9b8a82b7e",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "cf6a449f-633d-4c23-880b-024b76246daf",
+											"_postman_id": "0b701293-07d2-42c6-aaf5-78a0a9caa867",
 											"name": "/resources PUT update managed resource",
 											"event": [
 												{
@@ -12561,30 +12561,23 @@
 												}
 											},
 											"response": []
-										}
-									],
-									"_postman_isSubFolder": true
-								},
-								{
-									"_postman_id": "890fc452-0165-4a17-84c1-7c715abf1a19",
-									"name": "Negative",
-									"item": [
+										},
 										{
-											"_postman_id": "5c7009c2-ba55-48b8-bd74-da47f71b61ad",
+											"_postman_id": "54df8ebc-f818-482c-a3e3-bb94e185677f",
 											"name": "/resources PUT update managed resource in custom package - custom resource only fields",
 											"event": [
 												{
 													"listen": "test",
 													"script": {
-														"id": "d1da6f65-9451-4d12-8b1c-4c63b5557ce1",
+														"id": "a7c53527-ac95-41d1-bc8e-61c912de678e",
 														"type": "text/javascript",
 														"exec": [
-															"// This type of request gets rejected since we cannot update custom fields in a managed title",
-															"pm.test(\"Status is 422\", function () {",
-															"    pm.response.to.have.status(422);",
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
 															"});",
 															"",
 															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.ok;",
 															"    pm.response.to.be.withBody;",
 															"    pm.response.to.be.json; ",
 															"});",
@@ -12596,28 +12589,37 @@
 															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
-															"//Ensure that errors array is not empty",
-															"pm.test('Ensure that errors array is not empty', function() {",
-															"    pm.expect(jsonData.errors).to.be.an('array').that.is.not.empty;",
+															"",
+															"//Get the first record",
+															"let firstRecord = jsonData.data;",
+															"    ",
+															"// Test that attributes have the expected keys",
+															"let firstAttributes = firstRecord.attributes;",
+															"pm.test('expected attributes are present in a record', function() {",
+															"    pm.expect(firstAttributes).to.be.an('object');",
+															"    pm.expect(firstAttributes).to.include.all.keys(\"description\", \"edition\", \"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"coverageStatement\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"vendorId\", \"vendorName\", \"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
 															"});",
 															"",
-															"//Ensure that we get the expected error message",
-															"pm.test('Ensure that errors title is as expected', function() {",
-															"    pm.expect(jsonData.errors[0].title).eq('Invalid titleName');",
-															"    pm.expect(jsonData.errors[0].detail).eq('Titlename must be blank');",
-															"    pm.expect(jsonData.errors[1].title).eq('Invalid isPeerReviewed');",
-															"    pm.expect(jsonData.errors[1].detail).eq('Ispeerreviewed must be blank');",
-															"    pm.expect(jsonData.errors[2].title).eq('Invalid pubType');",
-															"    pm.expect(jsonData.errors[2].detail).eq('Pubtype must be blank');",
-															"    pm.expect(jsonData.errors[3].title).eq('Invalid publisherName');",
-															"    pm.expect(jsonData.errors[3].detail).eq('Publishername must be blank');",
-															"    pm.expect(jsonData.errors[4].title).eq('Invalid edition');",
-															"    pm.expect(jsonData.errors[4].detail).eq('Edition must be blank');",
-															"    pm.expect(jsonData.errors[5].title).eq('Invalid description');",
-															"    pm.expect(jsonData.errors[5].detail).eq('Description must be blank');",
-															"    pm.expect(jsonData.errors[6].title).eq('Invalid url');",
-															"    pm.expect(jsonData.errors[6].detail).eq('Url must be blank');",
-															"});"
+															"pm.test(\"data type is as expected\", function () {",
+															"    pm.expect(firstRecord.type).eq(\"resources\");",
+															"});",
+															"",
+															"//description should be null because user is not allowed to update description for a managed resource",
+															"pm.test(\"description should be null\", function () {",
+															"   pm.expect(firstAttributes.description).to.eql(null);",
+															"});",
+															"",
+															"//edition should be null because user is not allowed to update edition for a managed resource",
+															"pm.test(\"edition should be null\", function () {",
+															"   pm.expect(firstAttributes.edition).to.eql(null);",
+															"});",
+															"",
+															"//isPeerReviewed should be false because user is not allowed to update isPeerReviewed for a managed resource",
+															"pm.test(\"isPeerReviewed should be null\", function () {",
+															"   pm.expect(firstAttributes.isPeerReviewed).to.be.false;",
+															"});",
+															"",
+															""
 														]
 													}
 												},
@@ -12669,20 +12671,21 @@
 											"response": []
 										},
 										{
-											"_postman_id": "0deebf3e-50e6-4b14-9fdc-88659db8f07e",
+											"_postman_id": "1296c2b8-d53a-4bc3-bb0c-c1d2857f8857",
 											"name": "/resources PUT update managed resource in managed package - custom resource only fields",
 											"event": [
 												{
 													"listen": "test",
 													"script": {
-														"id": "512861e8-efa9-46a4-93f2-f1595ece76bf",
+														"id": "da14ec73-71ad-4cad-9f15-629abd7a7178",
 														"type": "text/javascript",
 														"exec": [
-															"// This type of request gets rejected since we cannot update custom fields in a managed title",
-															"pm.test(\"Status is 422\", function () {",
-															"    pm.response.to.have.status(422);",
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
 															"});",
+															"",
 															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.ok;",
 															"    pm.response.to.be.withBody;",
 															"    pm.response.to.be.json; ",
 															"});",
@@ -12695,28 +12698,33 @@
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
-															"//Ensure that errors array is not empty",
-															"pm.test('Ensure that errors array is not empty', function() {",
-															"    pm.expect(jsonData.errors).to.be.an('array').that.is.not.empty;",
+															"//Get the first record",
+															"let firstRecord = jsonData.data;",
+															"    ",
+															"// Test that attributes have the expected keys",
+															"let firstAttributes = firstRecord.attributes;",
+															"pm.test('expected attributes are present in a record', function() {",
+															"    pm.expect(firstAttributes).to.be.an('object');",
+															"    pm.expect(firstAttributes).to.include.all.keys(\"description\", \"edition\", \"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"coverageStatement\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"vendorId\", \"vendorName\", \"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
 															"});",
 															"",
-															"//Ensure that we get the expected error message",
-															"//Ensure that we get the expected error message",
-															"pm.test('Ensure that errors title is as expected', function() {",
-															"    pm.expect(jsonData.errors[0].title).eq('Invalid titleName');",
-															"    pm.expect(jsonData.errors[0].detail).eq('Titlename must be blank');",
-															"    pm.expect(jsonData.errors[1].title).eq('Invalid isPeerReviewed');",
-															"    pm.expect(jsonData.errors[1].detail).eq('Ispeerreviewed must be blank');",
-															"    pm.expect(jsonData.errors[2].title).eq('Invalid pubType');",
-															"    pm.expect(jsonData.errors[2].detail).eq('Pubtype must be blank');",
-															"    pm.expect(jsonData.errors[3].title).eq('Invalid publisherName');",
-															"    pm.expect(jsonData.errors[3].detail).eq('Publishername must be blank');",
-															"    pm.expect(jsonData.errors[4].title).eq('Invalid edition');",
-															"    pm.expect(jsonData.errors[4].detail).eq('Edition must be blank');",
-															"    pm.expect(jsonData.errors[5].title).eq('Invalid description');",
-															"    pm.expect(jsonData.errors[5].detail).eq('Description must be blank');",
-															"    pm.expect(jsonData.errors[6].title).eq('Invalid url');",
-															"    pm.expect(jsonData.errors[6].detail).eq('Url must be blank');",
+															"pm.test(\"data type is as expected\", function () {",
+															"    pm.expect(firstRecord.type).eq(\"resources\");",
+															"});",
+															"",
+															"//description should be null because user is not allowed to update description for a managed resource",
+															"pm.test(\"description should be null\", function () {",
+															"   pm.expect(firstAttributes.description).to.eql(null);",
+															"});",
+															"",
+															"//edition should be null because user is not allowed to update edition for a managed resource",
+															"pm.test(\"edition should be null\", function () {",
+															"   pm.expect(firstAttributes.edition).to.eql(null);",
+															"});",
+															"",
+															"//isPeerReviewed should be false because user is not allowed to update isPeerReviewed for a managed resource",
+															"pm.test(\"isPeerReviewed should be null\", function () {",
+															"   pm.expect(firstAttributes.isPeerReviewed).to.be.false;",
 															"});"
 														]
 													}
@@ -12767,9 +12775,16 @@
 												}
 											},
 											"response": []
-										},
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"_postman_id": "e1767dd4-cf82-49e2-9b35-47a6747bfd12",
+									"name": "Negative",
+									"item": [
 										{
-											"_postman_id": "94a3fe14-28ca-4d5c-b18b-e3a4c78de03c",
+											"_postman_id": "8b37b5b0-6003-4794-b083-bbb673dcd91b",
 											"name": "/resources PUT update managed resource invalid JSON",
 											"event": [
 												{
@@ -12844,7 +12859,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "4f21ed8b-7f43-4635-8533-224e11a8de8d",
+											"_postman_id": "cb9353ab-f39a-409d-843f-16aef1e43ab3",
 											"name": "/resources PUT update managed resource coverageStatement if not selected",
 											"event": [
 												{
@@ -12940,7 +12955,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "e90d2d0a-bb20-4d09-b8d1-364e66f0dd32",
+											"_postman_id": "1869bd9c-52a7-41cc-a867-c489d3798bdb",
 											"name": "/resources PUT update managed resource embargo if not selected",
 											"event": [
 												{
@@ -13040,7 +13055,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "100d123e-2039-4e87-bf50-9fb007d32df7",
+											"_postman_id": "59496569-5362-435e-93d8-1875c7b85219",
 											"name": "/resources PUT update managed resource custom coverage if not selected",
 											"event": [
 												{
@@ -13138,7 +13153,7 @@
 											"response": []
 										},
 										{
-											"_postman_id": "98281114-bbec-4388-a802-2ab75043c7e4",
+											"_postman_id": "79407081-d0bb-4092-af91-bd0ec7e2d200",
 											"name": "/resources PUT update managed resource visibility if not selected",
 											"event": [
 												{
@@ -13267,15 +13282,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "95516a52-e220-48a2-9b16-80fa01cf546d",
+					"_postman_id": "cd228a8e-e3c5-4e0a-beb1-ae823066a6fe",
 					"name": "DELETE resource by resourceId",
 					"item": [
 						{
-							"_postman_id": "e70b6c7f-f5c9-4d54-a301-1a3995d88b0d",
+							"_postman_id": "bec2d3ae-2d4b-4321-a3c7-0293b4c21e3e",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "f4d8c299-43c0-4d98-850f-53ea60761976",
+									"_postman_id": "2fa46151-577d-4d9e-ae27-0243241c5c53",
 									"name": "/resources DELETE specific resource (custom title)",
 									"event": [
 										{
@@ -13325,7 +13340,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "4e30044d-f1eb-4abe-80d5-92728dc858b3",
+									"_postman_id": "361721e5-2329-411a-9d14-040d93dc5021",
 									"name": "/resources DELETE specific resource (managed title)",
 									"event": [
 										{
@@ -13377,11 +13392,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "62f0412f-1ecc-4435-9af3-f22ade5ca7df",
+							"_postman_id": "0dc70075-b732-4526-b34c-9e328f3e7781",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "fe114d95-c649-460b-a8cc-28d8d8a72f25",
+									"_postman_id": "5b8bf3c8-f517-4aba-a096-143a06326715",
 									"name": "/resources DELETE previously deleted resource id",
 									"event": [
 										{
@@ -13466,7 +13481,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f1e16d22-f00c-4ab4-99e4-8de7f5eeda3b",
+									"_postman_id": "42939b1c-b53c-46fe-bbcc-f817c44d78ca",
 									"name": "/resources DELETE managed title in managed package",
 									"event": [
 										{
@@ -13552,7 +13567,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a5bcb2b4-798b-4470-9ab7-380823c2adb9",
+									"_postman_id": "eba19f7d-c06a-4ea6-a552-571f0531c5d0",
 									"name": "/resources DELETE invalid id",
 									"event": [
 										{
@@ -13648,19 +13663,19 @@
 			]
 		},
 		{
-			"_postman_id": "c50065eb-be20-41e0-823f-c70227f7bdb7",
+			"_postman_id": "7a8b7cdf-ecb8-4d34-83d5-d5fd0459ad3a",
 			"name": "titles",
 			"item": [
 				{
-					"_postman_id": "9d5e9994-a26b-42bc-bf8e-cde5d31afb2f",
+					"_postman_id": "25c8a78a-2fec-4527-8e60-7e9309e399c5",
 					"name": "GET title collection",
 					"item": [
 						{
-							"_postman_id": "9e0c4136-e9af-43f2-beee-0f02d178fa94",
+							"_postman_id": "2fa39884-64cf-4236-9606-cc3a67a54b47",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "6143d35a-7d08-46aa-928d-b202b02b4a73",
+									"_postman_id": "5b3f5891-03fd-4e23-8e26-41b76518104d",
 									"name": "/titles query only",
 									"event": [
 										{
@@ -13776,7 +13791,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "07480784-4de2-4261-9476-18c290a3e2af",
+									"_postman_id": "05dbd9c9-d64f-4f16-a544-bb3babae943e",
 									"name": "/titles query with name sort",
 									"event": [
 										{
@@ -13898,7 +13913,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "0f533679-8ef2-4f33-bd3f-0a418c5b5fa6",
+									"_postman_id": "911253c3-1170-45d9-8291-7f99fa0509c7",
 									"name": "/titles query with relevance sort",
 									"event": [
 										{
@@ -14022,7 +14037,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "59892bf7-b8c3-42d1-ae12-89fa54f95661",
+									"_postman_id": "289ae048-7a14-471a-bd83-198ada2e4aea",
 									"name": "/titles filter[name]",
 									"event": [
 										{
@@ -14139,7 +14154,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "980e2b1e-be17-46fb-abf4-5aa4aded5260",
+									"_postman_id": "c6279b9a-6583-474b-90a7-3d305a1f4fcc",
 									"name": "/titles filter[publisher]",
 									"event": [
 										{
@@ -14255,7 +14270,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "968e7816-d2b3-46c3-bc1f-e7b92486b55f",
+									"_postman_id": "559c2069-41bf-44e6-b9c2-d05990390d4d",
 									"name": "/titles filter[subject]",
 									"event": [
 										{
@@ -14379,7 +14394,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f24d0ffb-7304-4c98-a430-22e1091ab0a3",
+									"_postman_id": "3e88f3e9-c3cb-4388-aa85-1bb7f639cba4",
 									"name": "/titles filter[isxn]",
 									"event": [
 										{
@@ -14502,7 +14517,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a641ee0c-791f-4787-b444-5febf88ba709",
+									"_postman_id": "1949680a-f36f-4be1-a4e3-fa793a1f65ff",
 									"name": "/titles filter for no results",
 									"event": [
 										{
@@ -14600,7 +14615,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "2fce54bc-cfb8-45ec-a9e9-1cb3132dd44c",
+									"_postman_id": "ee93531a-6a8c-4e39-8ea5-7088cf684b07",
 									"name": "/titles filter[type]&filter[name]",
 									"event": [
 										{
@@ -14725,7 +14740,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "9c80dfd9-b1e7-4a2f-aad2-71fa1858cca6",
+									"_postman_id": "eefaf68f-50f8-4f8c-8ed6-0d5089a164df",
 									"name": "/titles paging",
 									"event": [
 										{
@@ -14859,11 +14874,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "345dfe52-c6a3-45d7-88c0-e091f9b105a2",
+							"_postman_id": "dea16804-b351-4a28-8a62-41f1f4cf150a",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "d2059cd2-29ab-4f8b-bc92-53837871729c",
+									"_postman_id": "f989038a-48d7-49cd-ae47-ac1880b28000",
 									"name": "/titles no parameters",
 									"event": [
 										{
@@ -14952,7 +14967,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "99b9b6be-495d-4e95-85b9-da8d2f6cf0b5",
+									"_postman_id": "a27c7977-3d52-432b-aadb-7940b14cca43",
 									"name": "/titles empty query",
 									"event": [
 										{
@@ -15044,7 +15059,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5fe9b2c3-82c5-4b5a-9b67-1e0569127986",
+									"_postman_id": "e2cbdcda-b466-4f24-8781-448982c5275d",
 									"name": "/titles empty query with sort only",
 									"event": [
 										{
@@ -15134,7 +15149,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "bc10ee6c-09d3-4c87-a2f9-67a0071c3efa",
+									"_postman_id": "2378e88b-e157-4dfc-bdce-30bcf59005ae",
 									"name": "/titles q&filter[name] conflicting query parameters",
 									"event": [
 										{
@@ -15230,7 +15245,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "21190474-1885-4da7-8324-0c47320a8059",
+									"_postman_id": "b1ead93e-6be8-4f15-9622-a4986b0e3225",
 									"name": "/titles filter[isxn] &filter[name] conflicting filter parameters",
 									"event": [
 										{
@@ -15326,7 +15341,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "fb3d4a0d-24e2-4799-88b7-75dcc347ffa5",
+									"_postman_id": "b6fe43e1-201d-45e2-9f56-9f950ff86888",
 									"name": "/titles paging invalid too large",
 									"event": [
 										{
@@ -15430,7 +15445,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "758533cb-eedd-4c6f-9bdc-a4e8d0399af0",
+									"_postman_id": "d37817cf-67bb-468d-a2d8-c8aa735a5868",
 									"name": "/titles paging invalid negative",
 									"event": [
 										{
@@ -15527,7 +15542,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "17f77be2-8550-47ac-b74e-bb8ecce68373",
+									"_postman_id": "b472b427-567e-45e4-ad9d-43ffa596ace0",
 									"name": "/titles paging invalid non numeric",
 									"event": [
 										{
@@ -15631,15 +15646,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "9ce0c373-b0e2-4a91-ae47-6c3b2effa59f",
+					"_postman_id": "37b4db76-a750-488b-b7c0-dc972c788dcc",
 					"name": "GET title by  titleid",
 					"item": [
 						{
-							"_postman_id": "c64c1bd1-f9eb-487d-96c7-4ec99638c4fa",
+							"_postman_id": "445faf5f-1b6e-48b6-9664-a5bbba456240",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "a50e21e0-52a9-45cb-b5b6-54315ebb3143",
+									"_postman_id": "b02d5e62-27ed-48ac-94ca-0fb826b21163",
 									"name": "/titles GET specific title",
 									"event": [
 										{
@@ -15744,7 +15759,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "086a22ff-24df-4066-9ef7-b3ecb60c170a",
+									"_postman_id": "405269c6-4906-47e2-af38-5f06f2c61ead",
 									"name": "/titles GET specific title and include resources",
 									"event": [
 										{
@@ -15870,7 +15885,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3bb0093c-1da5-4293-b06a-8d7626a97052",
+									"_postman_id": "0ba0f0f0-2f2a-4b37-a06c-29ddb0b5026b",
 									"name": "/titles GET specific title and include resources bad value",
 									"event": [
 										{
@@ -15992,11 +16007,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "580ff7a3-2926-47a4-a27f-3d7eb46b522c",
+							"_postman_id": "16f3b92b-8f12-4e4e-bdaf-c96e957c212e",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "1fb39837-174a-45d9-8b29-278d581514a3",
+									"_postman_id": "066b096f-8908-4e9c-8609-378d0699cac9",
 									"name": "/titles GET non existing title",
 									"event": [
 										{
@@ -16088,15 +16103,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "62849a51-9176-4aaf-91b7-903e1b45e081",
+					"_postman_id": "fc91c4f9-29bd-4c2f-893e-de8f7d35861d",
 					"name": "POST title",
 					"item": [
 						{
-							"_postman_id": "373831c8-7d27-46c5-a407-c2491e4c481d",
+							"_postman_id": "d239a686-9aea-45ea-87bd-7b107f2191d4",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "39a2f36a-aa59-4fb3-88aa-a3c521994aa7",
+									"_postman_id": "fa7f796a-ce33-4eeb-a55f-b0d7048fc1c8",
 									"name": "/titles POST valid",
 									"event": [
 										{
@@ -16249,11 +16264,11 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "b591c649-c5f8-4b69-99f7-e457162fa1ed",
+							"_postman_id": "a753bceb-b6c3-421e-b211-6901b86afb96",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "d00f29a4-d430-44a7-bf13-9e41128c287c",
+									"_postman_id": "4fa3245c-88da-42eb-b1b0-d963acb959f3",
 									"name": "/titles POST provider not found",
 									"event": [
 										{
@@ -16343,7 +16358,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "8c6afccb-499e-4be4-acff-2f5a87e3addc",
+									"_postman_id": "fd249bb6-ce54-46a9-9942-5563d8c57c8d",
 									"name": "/titles POST duplicate title",
 									"event": [
 										{
@@ -16432,7 +16447,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "716809e0-b8ea-4f21-ab50-5dfa2e4e46ca",
+									"_postman_id": "8b0cf5fb-409e-43f5-b855-71780f69aaf1",
 									"name": "/titles POST missing title name",
 									"event": [
 										{
@@ -16520,7 +16535,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "4ccb9803-4a1f-4ead-a389-e65d267292f7",
+									"_postman_id": "567c0d0d-6fe4-48cd-9e06-03a2dd558e96",
 									"name": "/titles POST long name",
 									"event": [
 										{
@@ -16618,7 +16633,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "4778ce0f-e862-48e6-8b2a-daf2d5dc71cc",
+									"_postman_id": "baddfbbf-fc6b-4e64-9490-c06de7813e21",
 									"name": "/titles POST missing publication type",
 									"event": [
 										{
@@ -16705,7 +16720,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3902e952-c261-432c-82a2-f5a336bb5b2a",
+									"_postman_id": "e026137a-7b9d-4dba-8162-280cd41a0998",
 									"name": "/titles POST non existing publication type",
 									"event": [
 										{
@@ -16812,7 +16827,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "57a049e1-f876-4ca1-a13d-dfefdcc255ec",
+									"_postman_id": "8c3953d9-7d59-4420-b4c0-5766af00bfb3",
 									"name": "/titles POST missing resource",
 									"event": [
 										{
@@ -16900,7 +16915,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "07f8de8a-81c2-4e11-8960-6f4b8d4e6a1f",
+									"_postman_id": "877542e0-7eea-4e0b-b67f-03b980fc3ed1",
 									"name": "/titles POST missing package id",
 									"event": [
 										{
@@ -16988,7 +17003,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "ef755d4b-dc5e-43cf-8ca9-8d2127499d17",
+									"_postman_id": "534ab114-e5b8-481e-9b48-307c2aadad95",
 									"name": "/titles POST cannot add custom title to managed resource",
 									"event": [
 										{
@@ -17074,7 +17089,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "fa84d312-f4e2-4881-8247-40d5c08b459e",
+									"_postman_id": "59a1c0a5-51ee-4ebb-b941-38bff84f3a3d",
 									"name": "/titles POST long publisher name",
 									"event": [
 										{
@@ -17172,7 +17187,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e1e47ac2-379a-4376-ae52-446b2ef8eaef",
+									"_postman_id": "65e88e7f-f32a-4c7e-8b2e-ddcdd7419457",
 									"name": "/titles POST invalid isPeerReviewed",
 									"event": [
 										{
@@ -17269,7 +17284,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "806923d4-814b-4748-a969-f93b0df18a02",
+									"_postman_id": "8c5f62d6-568c-49d1-8de0-065381000150",
 									"name": "/titles POST invalid edition",
 									"event": [
 										{
@@ -17367,7 +17382,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b27c6023-60ed-435b-8043-d3ffa32d86b3",
+									"_postman_id": "e2a4f18c-cbc8-42ee-b4b2-0dc5bb4994a7",
 									"name": "/titles POST invalid description",
 									"event": [
 										{
@@ -17466,7 +17481,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "44b5db75-cd52-4072-b596-a1cd5b998415",
+									"_postman_id": "397b3e0f-b24c-41f2-b5bd-ad834568255f",
 									"name": "/titles POST invalid contributor type",
 									"event": [
 										{
@@ -17562,7 +17577,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "6a5ce2d5-7e02-4f99-85a8-bd3ee5d7f0e8",
+									"_postman_id": "6cc8aeb7-0b78-4349-b9be-0c78a20b27c5",
 									"name": "/titles POST numeric identifier id",
 									"event": [
 										{
@@ -17659,7 +17674,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5f42ba59-91a6-42fe-8e9f-f7d8782d2e23",
+									"_postman_id": "b78e9c91-f926-4ee6-99ec-d4776b0a0433",
 									"name": "/titles POST long identifier id",
 									"event": [
 										{
@@ -17756,7 +17771,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "d0de517c-9e5b-4d83-8aaa-0d2d575e9816",
+									"_postman_id": "88d8e047-a545-47d6-a707-eac77137a46b",
 									"name": "/titles POST missing identifier id",
 									"event": [
 										{
@@ -17853,7 +17868,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f2c01b8a-60ab-41b8-b7c2-31d7ff5d4798",
+									"_postman_id": "bed599e8-6051-4339-ba6e-a472da48dce7",
 									"name": "/titles POST invalid identifier type",
 									"event": [
 										{
@@ -17950,7 +17965,7 @@
 									"response": []
 								},
 								{
-									"_postman_id": "94e250ad-478b-483f-9dd6-ab8c1edd1e04",
+									"_postman_id": "f33fa5c4-c23d-4eb6-8f20-4c7546f3fe09",
 									"name": "/titles POST invalid identifier subtype",
 									"event": [
 										{
@@ -18056,11 +18071,11 @@
 			]
 		},
 		{
-			"_postman_id": "275f6b06-320d-470e-a16f-8e20299f8f0c",
+			"_postman_id": "8d638516-bacb-43f2-88e0-ac9da25ec329",
 			"name": "tear-down resources test",
 			"item": [
 				{
-					"_postman_id": "c613ba56-01ae-43b3-a810-100dd8ecb70a",
+					"_postman_id": "87dff418-d284-4649-801e-95ad0beaa40d",
 					"name": "Delete Custom Package",
 					"event": [
 						{
@@ -18150,11 +18165,11 @@
 			]
 		},
 		{
-			"_postman_id": "50c6fbf7-7b4e-4415-8668-6a8e04194264",
+			"_postman_id": "c9160000-8719-4ccc-9a57-fc6ee2829ead",
 			"name": "tear-down titles test",
 			"item": [
 				{
-					"_postman_id": "30b39492-0910-4122-9926-d06a5511b4b0",
+					"_postman_id": "04fdb7a8-4c90-4b64-ba51-47717fe20a93",
 					"name": "Delete Custom Package",
 					"event": [
 						{
@@ -18244,11 +18259,11 @@
 			]
 		},
 		{
-			"_postman_id": "6517546c-36c0-45a7-9a5b-ad780aab72a1",
+			"_postman_id": "deaf6a17-6bea-40cb-bf05-1eb6bb136e04",
 			"name": "tear-down configuration",
 			"item": [
 				{
-					"_postman_id": "087cd023-7029-42c9-9453-9ec62d1a405f",
+					"_postman_id": "05035816-8b7c-4d8f-9d1e-b999949c1f10",
 					"name": "Check if configuration RM API api_credentials exists and should delete",
 					"event": [
 						{
@@ -18326,7 +18341,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "4b82cb4a-4ceb-427e-a9cb-4dd9cf700edd",
+					"_postman_id": "a8b8bc90-baa3-4ff4-96d9-7ab8cef9c278",
 					"name": "/configurations/entries - Clean-up RM API api_credentials",
 					"event": [
 						{
@@ -18395,7 +18410,7 @@
 					"response": []
 				},
 				{
-					"_postman_id": "869bcb82-b70c-4d2a-b419-7653a8eddc09",
+					"_postman_id": "fa227829-7095-4a2f-b088-2580de1b8b11",
 					"name": "Reset Variables",
 					"event": [
 						{


### PR DESCRIPTION
Certain mod-kb-ebsco API tests started to fail after we changed the approach of validating updates to managed resources when the user passes fields of custom resources. Reason for why we had to change the approach is mentioned here: https://github.com/folio-org/mod-kb-ebsco/pull/195

This PR modifies the API tests to align with the above mentioned fix in mod-kb-ebsco.