### PR TITLE
add mod-gobi /validate tests

### DIFF
--- a/mod-gobi/mod-gobi.postman_collection.json
+++ b/mod-gobi/mod-gobi.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b1629ac1-a699-47a0-9970-8c2295eb40c1",
+		"_postman_id": "8ee526df-0fba-4880-a0d5-e978b00a9797",
 		"name": "mod-gobi",
 		"description": "Tests for mod-gobi",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -126,11 +126,98 @@
 		},
 		{
 			"name": "Positive Tests",
-			"item": []
+			"item": [
+				{
+					"name": "/validate",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": ""
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/order - ListedElectronicMonograph",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": ""
+						}
+					},
+					"response": []
+				}
+			]
 		},
 		{
 			"name": "Negative Tests",
-			"item": []
+			"item": [
+				{
+					"name": "/validate - user with no permission",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "cfecec07-a5bd-4016-892a-839851275005",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Passing in a token that's associated with a user who doesn't have permission\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "pm.test(\"Passing in a token that's associated with a user who doesn't have permission\", function () {\n    pm.response.to.have.status(401);\n});\n"
+							},
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/gobi/validate",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"gobi",
+								"validate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/validate - with no Okapi token",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": ""
+						}
+					},
+					"response": []
+				}
+			]
 		},
 		{
 			"name": "Cleanup",
@@ -173,7 +260,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/vendor/{{vendorId}}",
 							"protocol": "{{protocol}}",

--- a/mod-gobi/mod-gobi.postman_collection.json
+++ b/mod-gobi/mod-gobi.postman_collection.json
@@ -129,24 +129,110 @@
 			"item": [
 				{
 					"name": "/validate",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c6566d89-e8ea-4fca-a388-d40938eb27f0",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						}
+					],
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "content-type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "apiKey SHAzQkdpVndqR19mczAwMDAwMDAwX2ZzMDAwMDAwMDA",
+								"disabled": true
+							}
+						],
 						"body": {},
 						"url": {
-							"raw": ""
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/gobi/validate",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"gobi",
+								"validate"
+							]
 						}
 					},
 					"response": []
 				},
 				{
 					"name": "/order - ListedElectronicMonograph",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "969f0328-aa57-43a4-9bb9-ba008d15e635",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"    pm.expect(postman.getResponseHeader(\"Content-Type\")).to.equal(\"application/xml\")",
+									"});",
+									"",
+									"",
+									"pm.test(\"A PO number is returned in the response\", function(){",
+									"    pm.expect(pm.response.text()).to.include(\"PoLineNumber\")",
+									"})"
+								]
+							}
+						}
+					],
 					"request": {
-						"method": "GET",
-						"header": [],
-						"body": {},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/xml"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "<PurchaseOrder>\n  <CustomerDetail>\n    <BaseAccount>5095</BaseAccount>\n    <SubAccount>509596</SubAccount>\n  </CustomerDetail>\n  <Order>\n    <ListedElectronicMonograph>\n      <collection>\n        <record>\n          <leader>00585nam  22001813  4500</leader>\n          <controlfield tag=\"001\"></controlfield>\n          <controlfield tag=\"003\">NhCcYBP</controlfield>\n          <controlfield tag=\"005\">20150813163447.0</controlfield>\n          <controlfield tag=\"006\">m||||||||d||||||||</controlfield>\n          <controlfield tag=\"007\">cr||||||||||||</controlfield>\n          <controlfield tag=\"008\">150813q2012    xx |||||o|||||||| | eng d</controlfield>\n          <datafield tag=\"020\" ind1=\" \" ind2=\" \">\n            <subfield code=\"a\">9780817913465 (electronic bk.)</subfield>\n          </datafield>\n          <datafield tag=\"035\" ind1=\" \" ind2=\" \">\n            <subfield code=\"a\">(OCoLC)808344423</subfield>\n          </datafield>\n          <datafield tag=\"040\" ind1=\" \" ind2=\" \">\n            <subfield code=\"a\">NhCcYBP</subfield>\n            <subfield code=\"c\">NhCcYBP</subfield>\n          </datafield>\n          <datafield tag=\"100\" ind1=\" \" ind2=\" \">\n            <subfield code=\"a\">ANDERSON, KENNETH, 1956-</subfield>\n          </datafield>\n          <datafield tag=\"245\" ind1=\"0\" ind2=\"0\">\n            <subfield code=\"a\">LIVING WITH THE UN</subfield>\n            <subfield code=\"h\">[electronic resource] :</subfield>\n            <subfield code=\"b\">AMERICAN RESPONSIBILITIES AND INTERNATIONAL ORDER.</subfield>\n          </datafield>\n          <datafield tag=\"260\" ind1=\" \" ind2=\" \">\n            <subfield code=\"a\">STANFORD :</subfield>\n            <subfield code=\"b\">HOOVER INSTITUTION PRESS,</subfield>\n            <subfield code=\"c\">2012.</subfield>\n          </datafield>\n          <datafield tag=\"490\" ind1=\"0\" ind2=\" \">\n            <subfield code=\"a\">HOOVER INSTITUTION PRESS PUBLICATION.</subfield>\n            <subfield code=\"v\">609</subfield>\n          </datafield>\n        </record>\n      </collection>\n      <OrderDetail>\n        <BatchPONumber />\n        <ItemPONumber>.o22310460</ItemPONumber>\n        <FundCode>xnath</FundCode>\n        <MappedFundCode />\n        <OrderNotes />\n        <OtherLocalId>.o22310460</OtherLocalId>\n        <Location>NATH</Location>\n        <Quantity>1</Quantity>\n        <YBPOrderKey>99952919209</YBPOrderKey>\n        <OrderPlaced>2013-03-20T14:35:35</OrderPlaced>\n        <ListPrice>\n          <Amount>14.95</Amount>\n          <Currency>USD</Currency>\n        </ListPrice>\n        <PurchaseOption>\n          <VendorPOCode>EBRSU</VendorPOCode>\n          <Code>SU</Code>\n          <Description>Gobi</Description>\n          <VendorCode>GOBI</VendorCode>\n        </PurchaseOption>\n      </OrderDetail>\n    </ListedElectronicMonograph>\n  </Order>\n</PurchaseOrder>"
+						},
 						"url": {
-							"raw": ""
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/gobi/orders",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"gobi",
+								"orders"
+							]
 						}
 					},
 					"response": []
@@ -178,7 +264,7 @@
 						"header": [
 							{
 								"key": "x-okapi-token",
-								"value": "pm.test(\"Passing in a token that's associated with a user who doesn't have permission\", function () {\n    pm.response.to.have.status(401);\n});\n"
+								"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiJlZjY3NmRiOS1kMjMxLTQ3OWEtYmI5MS1mNjVlYjRiMTc4NzIiLCJ0ZW5hbnQiOiJmczAwMDAwMDAwIiwiaWF0IjoxNTM2NzI1MTc1fQ.RphE1xHdEctiZU1AFHT2SFPXz-tWO129V_2L1DCmQ1sMxkVQLBkvy8B3hBzDaLbOpfqwTEW4vHPBSJ28WNeopA"
 							},
 							{
 								"key": "x-okapi-tenant",
@@ -207,12 +293,46 @@
 				},
 				{
 					"name": "/validate - with no Okapi token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fbb18ac2-ef0d-4155-b224-f05522eab603",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Calling gobi/validate without a token\", function () {",
+									"    pm.response.to.have.status(403);",
+									"    pm.expect(pm.response.text()).to.equal(\"Access requires permission: gobi.item.post\")",
+									"});",
+									""
+								]
+							}
+						}
+					],
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
 						"body": {},
 						"url": {
-							"raw": ""
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/gobi/validate",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"gobi",
+								"validate"
+							]
 						}
 					},
 					"response": []


### PR DESCRIPTION
Created **validate** tests for 204, 403, 401 cases. 
Will add more tests, especially 403 - forbidden, insufficient privileges - when there's an agreement of how to go about setting up the test. 
I was going to add tests for **orders** but kept getting back 504, might be related to Okapi failures, pausing on this effort for now. There's a JIRA for writing **orders** API tests so this work could be done there. 
