### PR TITLE
Update mod-kb-ebsco tests due to new location for KB configuration

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
@@ -18480,7 +18480,7 @@
 									"let jsonData = pm.response.json();",
 									"let customerIdExists = pm.environment.get(\"customerIdExists\");",
 									"if((jsonData !==null && jsonData.configs.length >0) && customerIdExists) {",
-									"    //custoemr id previously existed -- DO NOT DELETE (end execution)",
+									"    //customer id previously existed -- DO NOT DELETE (end execution)",
 									"    postman.setNextRequest(\"Reset Variables\");",
 									"}",
 									""

--- a/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
@@ -1,16 +1,14 @@
 {
 	"info": {
-		"_postman_id": "d5fd3cda-8f91-4a7b-8be0-b1b20a5f0886",
+		"_postman_id": "dba6bf5c-6174-49a7-97fa-b3ba26fe5c9a",
 		"name": "mod-kb-ebsco",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"_postman_id": "b6adf5e7-548a-46d2-b5aa-b05db94c02f0",
 			"name": "schemas",
 			"item": [
 				{
-					"_postman_id": "d7a5f5b8-f444-4fe3-bb16-2ee65e81229b",
 					"name": "JSON API schema",
 					"event": [
 						{
@@ -80,11 +78,9 @@
 			]
 		},
 		{
-			"_postman_id": "58e3a96e-2393-40b7-adcb-fd831e1d2ba6",
 			"name": "authentication",
 			"item": [
 				{
-					"_postman_id": "e60e6a9e-08ff-4867-b886-e2cc89f2a9cc",
 					"name": "/authn/login",
 					"event": [
 						{
@@ -138,17 +134,15 @@
 			]
 		},
 		{
-			"_postman_id": "6179c69b-7e5b-4637-bee0-973e87978d30",
 			"name": "setup configuration",
 			"item": [
 				{
-					"_postman_id": "a6abbc85-943f-4fa3-8c39-997c737a416c",
-					"name": "Check if configuration api_credentials already exists",
+					"name": "Check if  url exists",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "87b49287-6267-4f65-bfcd-90aec9f493e6",
+								"id": "b6a548cd-23a5-4b8c-9bf9-622e404e5f04",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status is 200\", function () {",
@@ -162,11 +156,326 @@
 									"",
 									"var jsonData = pm.response.json();",
 									"",
-									"pm.environment.set(\"apiCredentialsExist\", false);",
+									"pm.environment.set(\"apiUrlExists\", false);",
 									"",
 									"if(jsonData!==null && jsonData.configs.length!==0) {",
-									"    pm.environment.set(\"apiCredentialsExist\", true);",
-									"    //\"api_credentials exists -- do not overwrite\");",
+									"    pm.environment.set(\"apiUrlExists\", true);",
+									"    //\"rm api url exists -- do not overwrite\");",
+									"    postman.setNextRequest(\"Check if customerId exists\");",
+									"}",
+									"",
+									"",
+									"",
+									""
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d665ae85-57e5-40c5-a197-48a2b098fc0a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.url)",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(module==EKB and configName==api_access and code==kb.ebsco.url)"
+								}
+							]
+						},
+						"description": "Check if rm api url has already been configured for test user.  If so, do not want to overwrite existing configuration settings"
+					},
+					"response": []
+				},
+				{
+					"name": "/configurations/entries - POST RM API URL",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5c5c18b8-178f-4395-9e60-5313f2d03260",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "1999127b-87cf-45b8-a245-be854e138af4",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"Success test on json response\", function() {",
+									"    pm.response.to.be.json;",
+									"});",
+									"",
+									"pm.test(\"Status is 201 - configuration entry successfully created for rm api url\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Content-Type header has expected value\", function () {",
+									"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/json\");",
+									"});",
+									"",
+									"//Store rm-api-url-id temporarily for clean-up purpose",
+									"let body = JSON.parse(responseBody);",
+									"pm.environment.set(\"rm-api-url-id\", body.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": " {\r\n    \"module\": \"EKB\",\r\n    \"configName\": \"api_access\",\r\n    \"code\": \"kb.ebsco.url\",\r\n    \"description\": \"EBSCO RM-API URL\",\r\n    \"enabled\": true,\r\n    \"value\": \"https://sandbox.ebsco.io\"\r\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check if customerId exists",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6cf60b97-d5e9-4028-86ff-9b20ecc32dba",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response must be valid and have a body\", function () {",
+									"    pm.response.to.be.withBody;",
+									"    pm.response.to.be.json; ",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.environment.set(\"customerIdExists\", false);",
+									"",
+									"if(jsonData!==null && jsonData.configs.length!==0) {",
+									"    pm.environment.set(\"customerIdExists\", true);",
+									"     //\"rm api customer id exists -- do not overwrite\");",
+									"    postman.setNextRequest(\"Check if apiKey exists\");",
+									"}",
+									"",
+									"",
+									"",
+									""
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d665ae85-57e5-40c5-a197-48a2b098fc0a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.customerId)",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(module==EKB and configName==api_access and code==kb.ebsco.customerId)"
+								}
+							]
+						},
+						"description": "Check if rm api url has already been configured for test user.  If so, do not want to overwrite existing configuration settings"
+					},
+					"response": []
+				},
+				{
+					"name": "/configurations/entries - POST RM API api_customer id",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5c5c18b8-178f-4395-9e60-5313f2d03260",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "23f25d7b-cbf3-4053-9fc3-35f06a3fffcc",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"Success test on json response\", function() {",
+									"    pm.response.to.be.json;",
+									"});",
+									"",
+									"pm.test(\"Status is 201 - configuration entry successfully created for rm api customer id\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Content-Type header has expected value\", function () {",
+									"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/json\");",
+									"});",
+									"",
+									"//Store rm-api-customer-id temporarily for clean-up purpose",
+									"let body = JSON.parse(responseBody);",
+									"pm.environment.set(\"rm-api-customer-id\", body.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": " {\r\n    \"module\": \"EKB\",\r\n    \"configName\": \"api_access\",\r\n    \"code\": \"kb.ebsco.customerId\",\r\n    \"description\": \"EBSCO RM-API Customer ID\",\r\n    \"enabled\": true,\r\n    \"value\": \"{{custid}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries"
+							]
+						},
+						"description": "Create customer id as part of configuration"
+					},
+					"response": []
+				},
+				{
+					"name": "Check if apiKey exists",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "30b0b57f-a25a-41b2-9390-f1e72c241b4c",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response must be valid and have a body\", function () {",
+									"    pm.response.to.be.withBody;",
+									"    pm.response.to.be.json; ",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.environment.set(\"apiKeyExists\", false);",
+									"",
+									"if(jsonData!==null && jsonData.configs.length!==0) {",
+									"    pm.environment.set(\"apiKeyExists\", true);",
+									"     //\"rm api key exists -- do not overwrite\");",
 									"    postman.setNextRequest(\"First Test - Placeholder\");",
 									"}",
 									"",
@@ -204,7 +513,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==KB_EBSCO and configName==api_credentials and code==kb.ebsco.credentials)",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.apiKey)",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -217,17 +526,16 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "(module==KB_EBSCO and configName==api_credentials and code==kb.ebsco.credentials)"
+									"value": "(module==EKB and configName==api_access and code==kb.ebsco.apiKey)"
 								}
 							]
 						},
-						"description": "Check if api_credentials have already been configured for test user.  If so, do not want to overwrite existing configuration settings"
+						"description": "Check if rm api url has already been configured for test user.  If so, do not want to overwrite existing configuration settings"
 					},
 					"response": []
 				},
 				{
-					"_postman_id": "8144cf30-9658-4252-b8ce-9d97809bcdc7",
-					"name": "/configurations/entries - POST RM API api_credentials",
+					"name": "/configurations/entries - POST RM API apiKey",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -242,7 +550,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a687d689-a054-4e70-b7d6-7d8cbb94165a",
+								"id": "732d3a7c-3a6f-4f9b-b904-9cc6887ccdc3",
 								"type": "text/javascript",
 								"exec": [
 									"",
@@ -250,7 +558,7 @@
 									"    pm.response.to.be.json;",
 									"});",
 									"",
-									"pm.test(\"Status is 201 - configuration entry successfully created for api_credentials\", function () {",
+									"pm.test(\"Status is 201 - configuration entry successfully created for rm api customer id\", function () {",
 									"    pm.response.to.have.status(201);",
 									"});",
 									"",
@@ -258,9 +566,9 @@
 									"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/json\");",
 									"});",
 									"",
-									"//Store api_credentials configuration id temporarily for clean-up purpose",
+									"//Store rm-api-key-id temporarily for clean-up purpose",
 									"let body = JSON.parse(responseBody);",
-									"pm.environment.set(\"api-credentials-id\", body.id);"
+									"pm.environment.set(\"rm-api-key-id\", body.id);"
 								]
 							}
 						}
@@ -283,7 +591,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": " {\n    \"module\": \"KB_EBSCO\",\n    \"configName\": \"api_credentials\",\n    \"code\": \"kb.ebsco.credentials\",\n    \"description\": \"EBSCO Credentials\",\n    \"enabled\": true,\n    \"value\": \"customer-id={{custid}}&api-key={{rmapi_api_key}}\"\n}"
+							"raw": " {\r\n    \"module\": \"EKB\",\r\n    \"configName\": \"api_access\",\r\n    \"code\": \"kb.ebsco.apiKey\",\r\n    \"description\": \"EBSCO RM-API API Key\",\r\n    \"enabled\": true,\r\n    \"value\": \"{{rmapi_api_key}}\"\r\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries",
@@ -302,7 +610,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "e511d139-ca96-40ff-a265-2a421f8669fd",
 					"name": "First Test - Placeholder",
 					"event": [
 						{
@@ -347,7 +654,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==KB_EBSCO and configName==api_credentials and code==kb.ebsco.credentials)",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.url)",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -360,7 +667,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "(module==KB_EBSCO and configName==api_credentials and code==kb.ebsco.credentials)"
+									"value": "(module==EKB and configName==api_access and code==kb.ebsco.url)"
 								}
 							]
 						}
@@ -392,11 +699,9 @@
 			]
 		},
 		{
-			"_postman_id": "7b9dcac6-907e-4a68-ad87-12207c42257e",
 			"name": "setup for titles test",
 			"item": [
 				{
-					"_postman_id": "b24bda7c-fe31-4751-9621-f1c9658c2aba",
 					"name": "GET Customer Specific Provider Id",
 					"event": [
 						{
@@ -463,7 +768,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "f6af2bd5-86b5-4bbe-8726-30d96a5625d2",
 					"name": "Create Custom Package",
 					"event": [
 						{
@@ -535,7 +839,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "b3afbd9c-119b-43ce-8e73-d35dde553678",
 					"name": "GET Sample Managed Package",
 					"event": [
 						{
@@ -619,11 +922,9 @@
 			]
 		},
 		{
-			"_postman_id": "fcce068b-2204-4108-a5bc-bdfc9fd66dfe",
 			"name": "setup for resources test",
 			"item": [
 				{
-					"_postman_id": "9f46b441-6efb-47e8-aaf6-0fb76997322a",
 					"name": "Create Custom Title",
 					"event": [
 						{
@@ -696,7 +997,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "d324e034-8a00-48ae-a2dd-f1ae40bf175d",
 					"name": "Create Custom Title for duplicate check",
 					"event": [
 						{
@@ -768,7 +1068,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "1bb9e7ff-1a98-4709-a33c-f2a45a354a34",
 					"name": "Create Custom Package",
 					"event": [
 						{
@@ -841,7 +1140,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "ef46f37d-3309-4582-84ed-070a64a946a1",
 					"name": "GET Sample Managed Title",
 					"event": [
 						{
@@ -924,7 +1222,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "6cce44d3-68cb-442c-bcfa-a14413d45064",
 					"name": "GET Sample Managed Resource",
 					"event": [
 						{
@@ -1030,19 +1327,15 @@
 			]
 		},
 		{
-			"_postman_id": "2eb7ce6b-74a3-4b50-ba0e-711684ccb14f",
 			"name": "providers",
 			"item": [
 				{
-					"_postman_id": "cb3ba9d7-2269-4b60-aae8-30d4f56e03b6",
 					"name": "GET provider collection",
 					"item": [
 						{
-							"_postman_id": "2a1d8124-6b6a-458d-b08e-0aa0c4bac539",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "513cb582-be72-4111-87a7-f6ec162684d5",
 									"name": "without query params",
 									"event": [
 										{
@@ -1178,7 +1471,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "556a0a64-841e-417a-af1d-5a4aa55f9ee1",
 									"name": "with valid q",
 									"event": [
 										{
@@ -1268,7 +1560,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "17965daf-8d91-465e-92ad-5e9ff64c3d38",
 									"name": "with count",
 									"event": [
 										{
@@ -1356,7 +1647,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "68354732-3b00-4157-bdee-12ba2f47d507",
 									"name": "with valid q and count",
 									"event": [
 										{
@@ -1457,7 +1747,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b01aee4d-7593-4eb1-8dfe-02e1b71a5ac5",
 									"name": "sort by name",
 									"event": [
 										{
@@ -1557,11 +1846,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "832efcdc-0909-4af6-b765-b6ffddf03bc8",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "a2bda824-bf18-4850-b1f6-c2671f15d1ff",
 									"name": "invalid q",
 									"event": [
 										{
@@ -1639,7 +1926,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "fe6bdc0e-ffc0-4a7a-9154-53ba91465a74",
 									"name": "invalid sort param",
 									"event": [
 										{
@@ -1720,7 +2006,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3bf6ece8-44b6-417d-b1c3-45f9e3f8c472",
 									"name": "with invalid page param",
 									"event": [
 										{
@@ -1800,7 +2085,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "854aad3a-be67-423f-9e8c-bd5c2ae6687d",
 									"name": "with count out of range",
 									"event": [
 										{
@@ -1883,15 +2167,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "ade432b0-8aeb-444a-94ff-6dcbf7bceb7f",
 					"name": "GET provider by providerId",
 					"item": [
 						{
-							"_postman_id": "03bb099e-8e1f-438e-a334-478b73c5c79f",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "7ef3cf27-2e1e-4a91-9deb-33da27d66984",
 									"name": "with valid providerId",
 									"event": [
 										{
@@ -1979,7 +2260,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "0383c4a2-7ed0-48f6-8038-3d8ed13cf777",
 									"name": "with valid providerId including packages",
 									"event": [
 										{
@@ -2075,11 +2355,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "1c4195e3-9547-4273-a6c1-fbb8b28cfd02",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "08dae2bd-af60-45dd-ba31-d6a2daf29d6a",
 									"name": "with non-existing providerId",
 									"event": [
 										{
@@ -2154,7 +2432,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "8943d347-a1e3-4f5c-944c-d94ec9d17c0f",
 									"name": "with invalid providerId",
 									"event": [
 										{
@@ -2213,7 +2490,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "776e2d1b-1399-437c-a292-81a5ee16e7a0",
 									"name": "with include empty",
 									"event": [
 										{
@@ -2292,15 +2568,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "1451a672-c703-44a3-ac73-7576fee82c6b",
 					"name": "PUT provider by providerId",
 					"item": [
 						{
-							"_postman_id": "9c5ac6d7-c89b-45df-bc33-6ddf48f31c5d",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "a272098e-e228-4b08-9c05-dbf8be22ac57",
 									"name": "update proxy - success",
 									"event": [
 										{
@@ -2382,7 +2655,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e9ff51cb-ea45-4e41-90b8-3fd4cad78ab5",
 									"name": "update provider token - success",
 									"event": [
 										{
@@ -2470,11 +2742,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "0bf1196b-4a35-42c6-8a61-13ac84ccebbc",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "983b8687-b26a-41a9-b1b9-ed1f4e08f6e8",
 									"name": "update proxy - invalid proxy id",
 									"event": [
 										{
@@ -2555,7 +2825,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c984d3ff-3142-4bb3-8b29-a87df0d11280",
 									"name": "update provider token - error",
 									"event": [
 										{
@@ -2636,7 +2905,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "0606af33-2c68-4e3f-9aed-dc39a2016304",
 									"name": "update request - invalid json",
 									"event": [
 										{
@@ -2705,15 +2973,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "15035765-6d1e-4f00-b676-0aae679badd0",
 					"name": "GET provider by providerId including packages",
 					"item": [
 						{
-							"_postman_id": "c64c183e-7a31-4013-a36c-5f5c7fa17049",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "2b20306e-145f-4de7-88be-7bff7ce6d164",
 									"name": "for provider that exists",
 									"event": [
 										{
@@ -2830,7 +3095,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "46ab5c38-c9ec-40d0-8e12-5943dcaf1a5c",
 									"name": "with valid q param",
 									"event": [
 										{
@@ -2920,7 +3184,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "cae025a0-8e52-480e-a79d-d16d725896b4",
 									"name": "with q and count",
 									"event": [
 										{
@@ -3020,7 +3283,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "7406fed5-6c23-4b1e-9d71-132a0858ec67",
 									"name": "q and count and sort by name",
 									"event": [
 										{
@@ -3123,7 +3385,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "10ab70e0-4882-4ae8-9041-5c7606911e3a",
 									"name": "valid filter[selected]",
 									"event": [
 										{
@@ -3223,7 +3484,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "bc98da2f-b2aa-4b46-8211-3a27bb828b4d",
 									"name": "valid filter[selected] and filter[type]",
 									"event": [
 										{
@@ -3336,11 +3596,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "3ebd6f12-0150-486d-a801-b63133a9e7d8",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "039ad02a-6130-4338-902b-4d73b91818ec",
 									"name": "for non-existing provider",
 									"event": [
 										{
@@ -3416,7 +3674,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b9359dc6-aa64-4b6e-8fdf-7a94c80c9609",
 									"name": "with invalid providerId",
 									"event": [
 										{
@@ -3474,7 +3731,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a69191f4-cc50-4dc6-9e3b-7a8d1353e948",
 									"name": "with invalid query param",
 									"event": [
 										{
@@ -3554,7 +3810,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "94361bbe-c53a-49d8-91ef-5496bb2b1647",
 									"name": "invalid page offset",
 									"event": [
 										{
@@ -3645,7 +3900,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5c29e237-9509-4aec-9f94-18039aafdce1",
 									"name": "q and sort param invalid",
 									"event": [
 										{
@@ -3731,7 +3985,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f2081f5f-ee26-498e-9e99-3d10ef558541",
 									"name": "filter[selected] invalid value",
 									"event": [
 										{
@@ -3818,7 +4071,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "4a9553a3-bfce-4193-af88-b1a288abb3fd",
 									"name": "invalid filter[type]",
 									"event": [
 										{
@@ -3910,7 +4162,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "1c2ad28b-2784-4445-9995-43f8d2ddb155",
 									"name": "with count out of range",
 									"event": [
 										{
@@ -3997,19 +4248,15 @@
 			]
 		},
 		{
-			"_postman_id": "ed0f5799-239a-490f-9f10-94c4ccc50d5e",
 			"name": "packages",
 			"item": [
 				{
-					"_postman_id": "68ea5176-ea67-4e92-9f1a-e09658f051c0",
 					"name": "GET package collection",
 					"item": [
 						{
-							"_postman_id": "822e9dfc-a3f7-4f3a-83e2-d90f16034f66",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "0cef7856-fdf9-40fa-af7d-9a4dfda0fb30",
 									"name": "without query params",
 									"event": [
 										{
@@ -4136,7 +4383,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "aa9d1baa-046a-4340-8787-a986f8400692",
 									"name": "with valid q",
 									"event": [
 										{
@@ -4231,7 +4477,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3aa07a6b-49d3-4dc6-a804-96b373a79e5b",
 									"name": "valid q and count",
 									"event": [
 										{
@@ -4326,7 +4571,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "1b2fa76b-ec7e-4782-ab57-49ffddaee623",
 									"name": "with count",
 									"event": [
 										{
@@ -4423,7 +4667,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e107ce80-2cc3-447e-8899-678924580c2e",
 									"name": "valid page offset one",
 									"event": [
 										{
@@ -4520,7 +4763,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "773c507f-d270-43e3-897b-6bee9eec94af",
 									"name": "valid page offset two",
 									"event": [
 										{
@@ -4612,7 +4854,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a396cc55-0eba-4edc-a9b8-547d001f7b3e",
 									"name": "with valid sort - by name",
 									"event": [
 										{
@@ -4709,7 +4950,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "907d0e85-1467-40f0-afc0-361f6cfa0c1b",
 									"name": "valid filter[selected] param",
 									"event": [
 										{
@@ -4814,7 +5054,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c39940ef-8ffa-4a8c-bb4b-e3175209fa8c",
 									"name": "valid filter[type]",
 									"event": [
 										{
@@ -4919,7 +5158,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "d729e6e5-ba84-425e-9904-9848bd512bee",
 									"name": "valid filter[custom]",
 									"event": [
 										{
@@ -5020,11 +5258,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "0522360f-d288-4975-90bd-67acd5f77d3a",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "4da7d755-340f-4a6c-897d-9472afb13a0a",
 									"name": "with empty search string q",
 									"event": [
 										{
@@ -5102,7 +5338,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "2ef78bb7-c307-4da6-a271-feb153ac578d",
 									"name": "invalid page param",
 									"event": [
 										{
@@ -5184,7 +5419,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "7a852aab-ca54-4939-b4a6-ca28a8876eb7",
 									"name": "invalid sort filter param",
 									"event": [
 										{
@@ -5265,7 +5499,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f65f47bb-5844-449a-8615-806098f44d23",
 									"name": "invalid filter[selected] param",
 									"event": [
 										{
@@ -5350,7 +5583,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c67b6059-0869-4ee8-b56c-ba0cb09e7397",
 									"name": "invalid filter[type]",
 									"event": [
 										{
@@ -5435,7 +5667,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3d256baa-d501-4ae1-a0b5-20685d3055fd",
 									"name": "invalid filter[custom]",
 									"event": [
 										{
@@ -5517,7 +5748,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a223f1fc-23d8-4d2f-8026-95a9411f03f5",
 									"name": "invalid filter[custom]=false",
 									"event": [
 										{
@@ -5603,7 +5833,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a9d30ac6-6627-409b-bfdd-cb04710c39d5",
 									"name": "invalid count",
 									"event": [
 										{
@@ -5686,15 +5915,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "f785bd81-2890-40b6-908e-3d8d1cc5aa60",
 					"name": "POST to package collection",
 					"item": [
 						{
-							"_postman_id": "147d72bf-934c-4d52-9bf9-5e70049aafcd",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "d83da24f-83f8-4070-a24e-7439715c55fc",
 									"name": "create custom package for testing deletion",
 									"event": [
 										{
@@ -5819,7 +6045,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "071ed1b9-3d08-43d4-92df-4b285bee302d",
 									"name": "create custom package for testing deletion in PUT",
 									"event": [
 										{
@@ -5918,11 +6143,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "6d565bb5-3ee9-4d0f-885b-2472ebe6f390",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "f90c805d-9e1b-4bde-b2f8-3e0ae5e293cb",
 									"name": "with package name that already exists",
 									"event": [
 										{
@@ -6000,7 +6223,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "6f7d006a-85e8-4c72-aef2-378767d9ba08",
 									"name": "with invalid contentType",
 									"event": [
 										{
@@ -6062,7 +6284,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "1f4f87af-af19-44b1-b133-a8067a58000d",
 									"name": "bad data for customCoverage",
 									"event": [
 										{
@@ -6133,7 +6354,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "50e7bc70-d1af-431c-90ac-8afe911622ef",
 									"name": "package without name",
 									"event": [
 										{
@@ -6212,7 +6432,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "1c0c3374-8185-415c-9b40-9fd49dd53822",
 									"name": "package without content type",
 									"event": [
 										{
@@ -6297,15 +6516,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "a673be23-7ba5-4337-8c14-8d9518692361",
 					"name": "GET package by packageId",
 					"item": [
 						{
-							"_postman_id": "c7c6ff77-e911-4491-b79e-ee530d33bcd2",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "c986c86b-041a-4a1b-b9a9-6b033287f4b7",
 									"name": "with valid packageId",
 									"event": [
 										{
@@ -6394,7 +6610,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "87d3ca01-b062-4382-9407-d10e0b07a592",
 									"name": "with valid packageId including resources",
 									"event": [
 										{
@@ -6490,11 +6705,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "f2fac13b-0177-4b04-a07d-398c99cb819e",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "5dd7127b-c066-4020-a2d1-abd0b8d1ac4b",
 									"name": "with non-existing packageId",
 									"event": [
 										{
@@ -6569,7 +6782,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f3799058-fdd4-4fb7-9ab3-d33a4538ea3b",
 									"name": "with invalid packageId",
 									"event": [
 										{
@@ -6644,7 +6856,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "72841cbf-154f-466d-9530-a881cb95b503",
 									"name": "with include empty",
 									"event": [
 										{
@@ -6717,7 +6928,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "8a94811d-fcf3-4d27-8cc2-ebcc339dc23c",
 									"name": "invalid packageId without providerId",
 									"event": [
 										{
@@ -6793,7 +7003,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "297dd144-0d8a-46a1-ac0f-9f0077df4990",
 									"name": "invalid packageId with providerId",
 									"event": [
 										{
@@ -6874,19 +7083,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "39ec5553-8696-40c0-acf8-b49a2d340740",
 					"name": "PUT package by packageId",
 					"item": [
 						{
-							"_postman_id": "1cdaa0ea-11bd-4f07-88a1-25b57136f499",
 							"name": "Custom Package",
 							"item": [
 								{
-									"_postman_id": "b5145718-9d6f-4ac3-b164-12f6d05fb0b5",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "a5f052ef-2121-47a9-b164-2c6b9ce1a25e",
 											"name": "update custom package",
 											"event": [
 												{
@@ -7007,7 +7212,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "7b7898d2-a0de-4fc4-b0f5-225a837ec7b6",
 											"name": "visibility data and coverage update",
 											"event": [
 												{
@@ -7131,11 +7335,9 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"_postman_id": "fa598ccc-d837-4d97-85d4-ecb8dc86ac7a",
 									"name": "Negative",
 									"item": [
 										{
-											"_postman_id": "6fd962b9-43e0-477d-bafb-65cfef6756e2",
 											"name": "update custom package without name",
 											"event": [
 												{
@@ -7216,7 +7418,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "08d6393a-334b-4292-bc52-42640521d71a",
 											"name": "update custom package without contentType",
 											"event": [
 												{
@@ -7297,7 +7498,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "9f1da113-b630-43f4-bed1-3535150bbd84",
 											"name": "update custom package with name that already exists",
 											"event": [
 												{
@@ -7387,7 +7587,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "1c2ab87d-0d25-4f34-beb3-47a551f0b30b",
 											"name": "update custom package with isSelected false should delete it",
 											"event": [
 												{
@@ -7467,7 +7666,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "3f712ec7-51c7-4ce1-a7b9-f97b9297fccc",
 											"name": "invalid contentType",
 											"event": [
 												{
@@ -7541,15 +7739,12 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "7d17351c-4c2e-4249-b878-c37fb47a39d0",
 							"name": "Managed Package",
 							"item": [
 								{
-									"_postman_id": "ee89766d-30c1-4d5e-93cd-fc8a79138982",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "a59d9553-f0fa-430d-a7db-4516c71f2604",
 											"name": "update managed package",
 											"event": [
 												{
@@ -7662,11 +7857,9 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"_postman_id": "10ab7886-f8cf-4517-89b0-11521c7e12e5",
 									"name": "Negative",
 									"item": [
 										{
-											"_postman_id": "4dd7a935-d014-4e44-84cc-713e40b81900",
 											"name": "try updating managed package with isSelected false",
 											"event": [
 												{
@@ -7750,7 +7943,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "2a74f6dd-d5dc-4c1c-bcf2-8745f4fcd652",
 											"name": "invalid dates for coverage",
 											"event": [
 												{
@@ -7833,7 +8025,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "6ea7f83c-759c-4eb0-bd86-2847e8035a6b",
 											"name": "invalid isSelected",
 											"event": [
 												{
@@ -7905,7 +8096,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "521cea70-83ff-415c-9875-62ad07318960",
 											"name": "invalid isHidden",
 											"event": [
 												{
@@ -7977,7 +8167,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "6586af45-4b2c-456f-b165-ec9b75da9a5d",
 											"name": "invalid allowKbToAddTitles",
 											"event": [
 												{
@@ -8049,7 +8238,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "9d4bbc66-743e-4156-83d3-0fa96fa57938",
 											"name": "invalid json in request",
 											"event": [
 												{
@@ -8127,15 +8315,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "923fd6e6-fbde-4683-bb06-452e6d25bec1",
 					"name": "DELETE package by packageId",
 					"item": [
 						{
-							"_postman_id": "ee2cf217-d4ce-40ba-9118-81000246e22b",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "abda23ea-1f12-40c4-907d-d3ff9602a139",
 									"name": "Delete custom package",
 									"event": [
 										{
@@ -8193,11 +8378,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "8e96e75e-712d-47be-9b39-12c4084dc535",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "e55c6342-355b-47ae-92ef-4faaacf10b86",
 									"name": "invalid providerId in packageId",
 									"event": [
 										{
@@ -8260,7 +8443,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "7c92631e-48d7-48c1-9d71-87dc67c33854",
 									"name": "invalid packageId",
 									"event": [
 										{
@@ -8336,7 +8518,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "19305ce5-ccd7-4320-b159-f18459fb7add",
 									"name": "delete a managed package",
 									"event": [
 										{
@@ -8420,15 +8601,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "3de031d5-89d9-43dc-bb1d-bb6505edae9d",
 					"name": "GET package by packageId including resources",
 					"item": [
 						{
-							"_postman_id": "6fe1f046-9b71-4645-a6bc-3bdd2d2246fe",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "f6da4c24-c40c-4d55-b839-8b3482c5d1b5",
 									"name": "with valid packageId",
 									"event": [
 										{
@@ -8554,11 +8732,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "2b853fae-2e6a-447e-acbf-06edfc71a599",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "6b1a0d0f-c85a-4ac6-abe1-a57da571c85c",
 									"name": "with non-existing packageId",
 									"event": [
 										{
@@ -8634,7 +8810,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a32f5c63-d6c6-479f-b1f8-799738233156",
 									"name": "with invalid packageId without providerId",
 									"event": [
 										{
@@ -8711,7 +8886,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "d2a26a26-ea8a-4a44-bb2f-9a7ebb14724b",
 									"name": "with invalid packageId and providerId",
 									"event": [
 										{
@@ -8796,19 +8970,15 @@
 			]
 		},
 		{
-			"_postman_id": "c7c7f4e3-d082-4aa4-adeb-a3c2d3ab351b",
 			"name": "resources",
 			"item": [
 				{
-					"_postman_id": "88408598-b20e-4f9c-98e4-40044bf498d0",
 					"name": "POST resource",
 					"item": [
 						{
-							"_postman_id": "868aef1e-deee-4ef9-b658-32edd3c50f37",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "2f3881a0-6178-4bbe-b898-71b1b7c14588",
 									"name": "/resources POST add managed title to custom package",
 									"event": [
 										{
@@ -8921,7 +9091,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "5af586d8-668a-4cc2-94a9-12bbb3c153d1",
 									"name": "/resources POST add custom title to custom package",
 									"event": [
 										{
@@ -9035,11 +9204,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "8feea954-b091-4e86-b4ec-5841175f9398",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "4954c8a5-c845-41c4-a7ac-5847bd4d778a",
 									"name": "/resources POST add managed title to managed package",
 									"event": [
 										{
@@ -9136,7 +9303,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "6a8e2a4e-2158-4258-90a0-74f6bc027a8a",
 									"name": "/resources POST add custom title to managed package",
 									"event": [
 										{
@@ -9233,7 +9399,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b0fc9ec4-dc56-4e72-a628-9d09b3907d87",
 									"name": "/resources POST invalid url",
 									"event": [
 										{
@@ -9315,7 +9480,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "d53c7e68-812e-4501-9303-224d3b4f149c",
 									"name": "/resources POST invalid package id",
 									"event": [
 										{
@@ -9418,7 +9582,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "431d230b-323b-4f39-bbad-1d7dabb505f9",
 									"name": "/resources POST invalid titleId",
 									"event": [
 										{
@@ -9515,7 +9678,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "7b938385-af21-41ce-9939-300c17c66450",
 									"name": "/resources POST invalid content type",
 									"event": [
 										{
@@ -9588,15 +9750,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "ab1649bf-9e7e-4204-b314-29f7c414de15",
 					"name": "GET resource by resourceId",
 					"item": [
 						{
-							"_postman_id": "4f9a04a5-0178-4de6-af9d-646dc96ef7ac",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "699e275c-0ae2-496a-b316-b060390fafa6",
 									"name": "/resources GET specific resource (managed title)",
 									"event": [
 										{
@@ -9699,7 +9858,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "13c51b07-fed4-4bbb-928a-f955a953a377",
 									"name": "/resources GET specific resource (custom title)",
 									"event": [
 										{
@@ -9802,7 +9960,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "9ee43da0-38ea-470b-8313-d413445bd45a",
 									"name": "/resources GET specific resource and include provider",
 									"event": [
 										{
@@ -9938,7 +10095,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "32e12c7a-e287-415c-b6dc-f8192a5cd072",
 									"name": "/resources GET specific resource and include package",
 									"event": [
 										{
@@ -10074,7 +10230,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "8d370049-4b35-41b0-95cc-896dad74d243",
 									"name": "/resources GET specific resource and include title",
 									"event": [
 										{
@@ -10210,7 +10365,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "36ed311e-2f53-423f-9754-2e8b1eff3015",
 									"name": "/resources GET specific resource and include provider,package,title",
 									"event": [
 										{
@@ -10391,11 +10545,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "91630062-36f0-41a0-bf1a-774cf3e47475",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "961a86d5-20aa-42cf-908a-db4be45336b0",
 									"name": "/resources GET invalid resource",
 									"event": [
 										{
@@ -10491,7 +10643,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c1b75e00-7b71-4b23-ab23-33cf8f2d7836",
 									"name": "/resources GET specific resource and invalid include",
 									"event": [
 										{
@@ -10603,19 +10754,15 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "48bf96e6-8039-4c46-a566-fb56c2c17587",
 					"name": "PUT resource by resourceId",
 					"item": [
 						{
-							"_postman_id": "ff010094-f386-49af-8fbf-841c37b8542a",
 							"name": "Custom Resource",
 							"item": [
 								{
-									"_postman_id": "f7c82d99-b867-4d45-b19b-9bdc66db07ea",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "bb0c792f-becd-4b24-bbab-10c98e8b77ad",
 											"name": "/resources PUT update custom resource",
 											"event": [
 												{
@@ -10739,7 +10886,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "a3580062-26f4-4880-97a2-48237218b2a6",
 											"name": "/resources PUT update custom resource - custom only fields",
 											"event": [
 												{
@@ -10886,11 +11032,9 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"_postman_id": "e2a0dbd4-0834-46fd-aed0-65d336d558f6",
 									"name": "Negative",
 									"item": [
 										{
-											"_postman_id": "4ecea87d-c3ad-4bd3-a6e9-c4cb082e1990",
 											"name": "/resources PUT update custom resource missing identifier id",
 											"event": [
 												{
@@ -10975,7 +11119,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "b9432e4b-89bd-45b3-8d15-06b78c24e57e",
 											"name": "/resources PUT update custom resource invalid idenitifer subtype",
 											"event": [
 												{
@@ -11060,7 +11203,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "b0c65c01-8c59-4018-9c4a-aa307bcef61b",
 											"name": "/resources PUT update custom resource invalid idenitifer type",
 											"event": [
 												{
@@ -11144,7 +11286,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "a4f716e1-6ba2-40fd-bced-a3303c518273",
 											"name": "/resources PUT update custom resource invalid contributor",
 											"event": [
 												{
@@ -11228,7 +11369,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "2ccade46-ae86-4687-8b3f-0ea36b2c988c",
 											"name": "/resources PUT update custom resource invalid url",
 											"event": [
 												{
@@ -11314,7 +11454,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "9d784557-81d4-49b3-9690-610133fa0e2c",
 											"name": "/resources PUT update custom resource invalid description",
 											"event": [
 												{
@@ -11399,7 +11538,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "d221066d-26f6-4172-b0ef-6bc8c510d241",
 											"name": "/resources PUT update custom resource invalid edition",
 											"event": [
 												{
@@ -11483,7 +11621,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "92937131-149c-4aea-be11-753a6d9731dd",
 											"name": "/resources PUT update custom resource invalid publisher name",
 											"event": [
 												{
@@ -11568,7 +11705,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "ca4dd252-c90e-4aca-813b-94d8dc3eabf2",
 											"name": "/resources PUT update custom resource invalid publication type",
 											"event": [
 												{
@@ -11672,7 +11808,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "f157ab16-1892-4013-b704-2ffad46aa3e8",
 											"name": "/resources PUT update custom resource invalid peer review",
 											"event": [
 												{
@@ -11758,7 +11893,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "691894f5-f0a6-4528-9402-d10c8ff700c8",
 											"name": "/resources PUT update custom resource duplicate title name",
 											"event": [
 												{
@@ -11842,7 +11976,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "f4dfd723-894b-41d9-8ea3-fa2d392bedb1",
 											"name": "/resources PUT update custom resource Invalid name",
 											"event": [
 												{
@@ -11926,7 +12059,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "617f07fd-cf98-47f3-b2a3-4f5ddd92a6f0",
 											"name": "/resources PUT update custom resource Invalid proxy",
 											"event": [
 												{
@@ -12010,7 +12142,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "5ec0d78a-d64b-48eb-bca7-b8f58644b375",
 											"name": "/resources PUT update custom resource Invalid coverageStatement",
 											"event": [
 												{
@@ -12094,7 +12225,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "0dacde6f-dfcc-46ca-a209-7120fa199fa3",
 											"name": "/resources PUT update custom resource Invalid customCoverages",
 											"event": [
 												{
@@ -12177,7 +12307,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "81ec191f-c357-4321-8ea1-a665d75f6f3d",
 											"name": "/resources PUT update custom resource Invalid embargoValue",
 											"event": [
 												{
@@ -12259,7 +12388,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "fadf0f6c-bd01-4870-bb2e-4a844ee23802",
 											"name": "/resources PUT update custom resource Invalid embargoUnit",
 											"event": [
 												{
@@ -12342,7 +12470,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "164c997e-ea2c-431c-aea0-c3432e92720b",
 											"name": "/resources PUT update custom resource Invalid visibilityData",
 											"event": [
 												{
@@ -12431,15 +12558,12 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "8e026956-658a-4f4c-86b9-e931b37d976a",
 							"name": "Managed Resource",
 							"item": [
 								{
-									"_postman_id": "190c6682-18b2-48dc-811a-edb9b8a82b7e",
 									"name": "Positive",
 									"item": [
 										{
-											"_postman_id": "0b701293-07d2-42c6-aaf5-78a0a9caa867",
 											"name": "/resources PUT update managed resource",
 											"event": [
 												{
@@ -12563,7 +12687,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "54df8ebc-f818-482c-a3e3-bb94e185677f",
 											"name": "/resources PUT update managed resource in custom package - custom resource only fields",
 											"event": [
 												{
@@ -12671,7 +12794,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "1296c2b8-d53a-4bc3-bb0c-c1d2857f8857",
 											"name": "/resources PUT update managed resource in managed package - custom resource only fields",
 											"event": [
 												{
@@ -12780,11 +12902,9 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"_postman_id": "e1767dd4-cf82-49e2-9b35-47a6747bfd12",
 									"name": "Negative",
 									"item": [
 										{
-											"_postman_id": "8b37b5b0-6003-4794-b083-bbb673dcd91b",
 											"name": "/resources PUT update managed resource invalid JSON",
 											"event": [
 												{
@@ -12859,7 +12979,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "cb9353ab-f39a-409d-843f-16aef1e43ab3",
 											"name": "/resources PUT update managed resource coverageStatement if not selected",
 											"event": [
 												{
@@ -12955,7 +13074,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "1869bd9c-52a7-41cc-a867-c489d3798bdb",
 											"name": "/resources PUT update managed resource embargo if not selected",
 											"event": [
 												{
@@ -13055,7 +13173,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "59496569-5362-435e-93d8-1875c7b85219",
 											"name": "/resources PUT update managed resource custom coverage if not selected",
 											"event": [
 												{
@@ -13153,7 +13270,6 @@
 											"response": []
 										},
 										{
-											"_postman_id": "79407081-d0bb-4092-af91-bd0ec7e2d200",
 											"name": "/resources PUT update managed resource visibility if not selected",
 											"event": [
 												{
@@ -13282,15 +13398,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "cd228a8e-e3c5-4e0a-beb1-ae823066a6fe",
 					"name": "DELETE resource by resourceId",
 					"item": [
 						{
-							"_postman_id": "bec2d3ae-2d4b-4321-a3c7-0293b4c21e3e",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "2fa46151-577d-4d9e-ae27-0243241c5c53",
 									"name": "/resources DELETE specific resource (custom title)",
 									"event": [
 										{
@@ -13340,7 +13453,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "361721e5-2329-411a-9d14-040d93dc5021",
 									"name": "/resources DELETE specific resource (managed title)",
 									"event": [
 										{
@@ -13392,11 +13504,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "0dc70075-b732-4526-b34c-9e328f3e7781",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "5b8bf3c8-f517-4aba-a096-143a06326715",
 									"name": "/resources DELETE previously deleted resource id",
 									"event": [
 										{
@@ -13481,7 +13591,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "42939b1c-b53c-46fe-bbcc-f817c44d78ca",
 									"name": "/resources DELETE managed title in managed package",
 									"event": [
 										{
@@ -13567,7 +13676,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "eba19f7d-c06a-4ea6-a552-571f0531c5d0",
 									"name": "/resources DELETE invalid id",
 									"event": [
 										{
@@ -13663,19 +13771,15 @@
 			]
 		},
 		{
-			"_postman_id": "7a8b7cdf-ecb8-4d34-83d5-d5fd0459ad3a",
 			"name": "titles",
 			"item": [
 				{
-					"_postman_id": "25c8a78a-2fec-4527-8e60-7e9309e399c5",
 					"name": "GET title collection",
 					"item": [
 						{
-							"_postman_id": "2fa39884-64cf-4236-9606-cc3a67a54b47",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "5b3f5891-03fd-4e23-8e26-41b76518104d",
 									"name": "/titles query only",
 									"event": [
 										{
@@ -13791,7 +13895,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "05dbd9c9-d64f-4f16-a544-bb3babae943e",
 									"name": "/titles query with name sort",
 									"event": [
 										{
@@ -13913,7 +14016,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "911253c3-1170-45d9-8291-7f99fa0509c7",
 									"name": "/titles query with relevance sort",
 									"event": [
 										{
@@ -14037,7 +14139,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "289ae048-7a14-471a-bd83-198ada2e4aea",
 									"name": "/titles filter[name]",
 									"event": [
 										{
@@ -14154,7 +14255,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "c6279b9a-6583-474b-90a7-3d305a1f4fcc",
 									"name": "/titles filter[publisher]",
 									"event": [
 										{
@@ -14270,7 +14370,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "559c2069-41bf-44e6-b9c2-d05990390d4d",
 									"name": "/titles filter[subject]",
 									"event": [
 										{
@@ -14394,7 +14493,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "3e88f3e9-c3cb-4388-aa85-1bb7f639cba4",
 									"name": "/titles filter[isxn]",
 									"event": [
 										{
@@ -14517,7 +14615,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "1949680a-f36f-4be1-a4e3-fa793a1f65ff",
 									"name": "/titles filter for no results",
 									"event": [
 										{
@@ -14615,7 +14712,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "ee93531a-6a8c-4e39-8ea5-7088cf684b07",
 									"name": "/titles filter[type]&filter[name]",
 									"event": [
 										{
@@ -14740,7 +14836,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "eefaf68f-50f8-4f8c-8ed6-0d5089a164df",
 									"name": "/titles paging",
 									"event": [
 										{
@@ -14874,11 +14969,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "dea16804-b351-4a28-8a62-41f1f4cf150a",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "f989038a-48d7-49cd-ae47-ac1880b28000",
 									"name": "/titles no parameters",
 									"event": [
 										{
@@ -14967,7 +15060,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "a27c7977-3d52-432b-aadb-7940b14cca43",
 									"name": "/titles empty query",
 									"event": [
 										{
@@ -15059,7 +15151,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e2cbdcda-b466-4f24-8781-448982c5275d",
 									"name": "/titles empty query with sort only",
 									"event": [
 										{
@@ -15149,7 +15240,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "2378e88b-e157-4dfc-bdce-30bcf59005ae",
 									"name": "/titles q&filter[name] conflicting query parameters",
 									"event": [
 										{
@@ -15245,7 +15335,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b1ead93e-6be8-4f15-9622-a4986b0e3225",
 									"name": "/titles filter[isxn] &filter[name] conflicting filter parameters",
 									"event": [
 										{
@@ -15341,7 +15430,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b6fe43e1-201d-45e2-9f56-9f950ff86888",
 									"name": "/titles paging invalid too large",
 									"event": [
 										{
@@ -15445,7 +15533,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "d37817cf-67bb-468d-a2d8-c8aa735a5868",
 									"name": "/titles paging invalid negative",
 									"event": [
 										{
@@ -15542,7 +15629,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b472b427-567e-45e4-ad9d-43ffa596ace0",
 									"name": "/titles paging invalid non numeric",
 									"event": [
 										{
@@ -15646,15 +15732,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "37b4db76-a750-488b-b7c0-dc972c788dcc",
 					"name": "GET title by  titleid",
 					"item": [
 						{
-							"_postman_id": "445faf5f-1b6e-48b6-9664-a5bbba456240",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "b02d5e62-27ed-48ac-94ca-0fb826b21163",
 									"name": "/titles GET specific title",
 									"event": [
 										{
@@ -15759,7 +15842,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "405269c6-4906-47e2-af38-5f06f2c61ead",
 									"name": "/titles GET specific title and include resources",
 									"event": [
 										{
@@ -15885,7 +15967,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "0ba0f0f0-2f2a-4b37-a06c-29ddb0b5026b",
 									"name": "/titles GET specific title and include resources bad value",
 									"event": [
 										{
@@ -16007,11 +16088,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "16f3b92b-8f12-4e4e-bdaf-c96e957c212e",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "066b096f-8908-4e9c-8609-378d0699cac9",
 									"name": "/titles GET non existing title",
 									"event": [
 										{
@@ -16103,15 +16182,12 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"_postman_id": "fc91c4f9-29bd-4c2f-893e-de8f7d35861d",
 					"name": "POST title",
 					"item": [
 						{
-							"_postman_id": "d239a686-9aea-45ea-87bd-7b107f2191d4",
 							"name": "Positive",
 							"item": [
 								{
-									"_postman_id": "fa7f796a-ce33-4eeb-a55f-b0d7048fc1c8",
 									"name": "/titles POST valid",
 									"event": [
 										{
@@ -16264,11 +16340,9 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"_postman_id": "a753bceb-b6c3-421e-b211-6901b86afb96",
 							"name": "Negative",
 							"item": [
 								{
-									"_postman_id": "4fa3245c-88da-42eb-b1b0-d963acb959f3",
 									"name": "/titles POST provider not found",
 									"event": [
 										{
@@ -16358,7 +16432,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "fd249bb6-ce54-46a9-9942-5563d8c57c8d",
 									"name": "/titles POST duplicate title",
 									"event": [
 										{
@@ -16447,7 +16520,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "8b0cf5fb-409e-43f5-b855-71780f69aaf1",
 									"name": "/titles POST missing title name",
 									"event": [
 										{
@@ -16535,7 +16607,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "567c0d0d-6fe4-48cd-9e06-03a2dd558e96",
 									"name": "/titles POST long name",
 									"event": [
 										{
@@ -16633,7 +16704,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "baddfbbf-fc6b-4e64-9490-c06de7813e21",
 									"name": "/titles POST missing publication type",
 									"event": [
 										{
@@ -16720,7 +16790,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e026137a-7b9d-4dba-8162-280cd41a0998",
 									"name": "/titles POST non existing publication type",
 									"event": [
 										{
@@ -16827,7 +16896,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "8c3953d9-7d59-4420-b4c0-5766af00bfb3",
 									"name": "/titles POST missing resource",
 									"event": [
 										{
@@ -16915,7 +16983,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "877542e0-7eea-4e0b-b67f-03b980fc3ed1",
 									"name": "/titles POST missing package id",
 									"event": [
 										{
@@ -17003,7 +17070,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "534ab114-e5b8-481e-9b48-307c2aadad95",
 									"name": "/titles POST cannot add custom title to managed resource",
 									"event": [
 										{
@@ -17089,7 +17155,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "59a1c0a5-51ee-4ebb-b941-38bff84f3a3d",
 									"name": "/titles POST long publisher name",
 									"event": [
 										{
@@ -17187,7 +17252,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "65e88e7f-f32a-4c7e-8b2e-ddcdd7419457",
 									"name": "/titles POST invalid isPeerReviewed",
 									"event": [
 										{
@@ -17284,7 +17348,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "8c5f62d6-568c-49d1-8de0-065381000150",
 									"name": "/titles POST invalid edition",
 									"event": [
 										{
@@ -17382,7 +17445,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "e2a4f18c-cbc8-42ee-b4b2-0dc5bb4994a7",
 									"name": "/titles POST invalid description",
 									"event": [
 										{
@@ -17481,7 +17543,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "397b3e0f-b24c-41f2-b5bd-ad834568255f",
 									"name": "/titles POST invalid contributor type",
 									"event": [
 										{
@@ -17577,7 +17638,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "6cc8aeb7-0b78-4349-b9be-0c78a20b27c5",
 									"name": "/titles POST numeric identifier id",
 									"event": [
 										{
@@ -17674,7 +17734,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "b78e9c91-f926-4ee6-99ec-d4776b0a0433",
 									"name": "/titles POST long identifier id",
 									"event": [
 										{
@@ -17771,7 +17830,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "88d8e047-a545-47d6-a707-eac77137a46b",
 									"name": "/titles POST missing identifier id",
 									"event": [
 										{
@@ -17868,7 +17926,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "bed599e8-6051-4339-ba6e-a472da48dce7",
 									"name": "/titles POST invalid identifier type",
 									"event": [
 										{
@@ -17965,7 +18022,6 @@
 									"response": []
 								},
 								{
-									"_postman_id": "f33fa5c4-c23d-4eb6-8f20-4c7546f3fe09",
 									"name": "/titles POST invalid identifier subtype",
 									"event": [
 										{
@@ -18071,11 +18127,9 @@
 			]
 		},
 		{
-			"_postman_id": "8d638516-bacb-43f2-88e0-ac9da25ec329",
 			"name": "tear-down resources test",
 			"item": [
 				{
-					"_postman_id": "87dff418-d284-4649-801e-95ad0beaa40d",
 					"name": "Delete Custom Package",
 					"event": [
 						{
@@ -18165,11 +18219,9 @@
 			]
 		},
 		{
-			"_postman_id": "c9160000-8719-4ccc-9a57-fc6ee2829ead",
 			"name": "tear-down titles test",
 			"item": [
 				{
-					"_postman_id": "04fdb7a8-4c90-4b64-ba51-47717fe20a93",
 					"name": "Delete Custom Package",
 					"event": [
 						{
@@ -18259,17 +18311,15 @@
 			]
 		},
 		{
-			"_postman_id": "deaf6a17-6bea-40cb-bf05-1eb6bb136e04",
 			"name": "tear-down configuration",
 			"item": [
 				{
-					"_postman_id": "05035816-8b7c-4d8f-9d1e-b999949c1f10",
-					"name": "Check if configuration RM API api_credentials exists and should delete",
+					"name": "Check if configuration RM API url exists and should delete",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "ba8b153a-e935-435f-af73-278b3f707953",
+								"id": "ebc0ca22-5260-42d7-b578-c8ff1a2fe889",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status is 200\", function () {",
@@ -18283,10 +18333,10 @@
 									"});",
 									"",
 									"let jsonData = pm.response.json();",
-									"let apiCredentialsExist = pm.environment.get(\"apiCredentialsExist\");",
-									"if((jsonData !==null && jsonData.configs.length >0) && apiCredentialsExist) {",
-									"    //Api credentials previously existed -- DO NOT DELETE (end execution)",
-									"    postman.setNextRequest(\"Reset Variables\");",
+									"let apiUrlExists = pm.environment.get(\"apiUrlExists\");",
+									"if((jsonData !==null && jsonData.configs.length >0) && apiUrlExists) {",
+									"    //Api url previously existed -- DO NOT DELETE (end execution)",
+									"    postman.setNextRequest(\"Check if configuration RM API customerid exists and should delete\");",
 									"}",
 									""
 								]
@@ -18320,7 +18370,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==KB_EBSCO and configName==api_credentials and code==kb.ebsco.credentials)",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.url)",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -18333,7 +18383,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "(module==KB_EBSCO and configName==api_credentials and code==kb.ebsco.credentials)"
+									"value": "(module==EKB and configName==api_access and code==kb.ebsco.url)"
 								}
 							]
 						}
@@ -18341,7 +18391,6 @@
 					"response": []
 				},
 				{
-					"_postman_id": "a8b8bc90-baa3-4ff4-96d9-7ab8cef9c278",
 					"name": "/configurations/entries - Clean-up RM API api_credentials",
 					"event": [
 						{
@@ -18393,7 +18442,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries/{{api-credentials-id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries/{{rm-api-url-id}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -18402,7 +18451,7 @@
 							"path": [
 								"configurations",
 								"entries",
-								"{{api-credentials-id}}"
+								"{{rm-api-url-id}"
 							]
 						},
 						"description": "Clean-up RM-API Key configuration"
@@ -18410,7 +18459,296 @@
 					"response": []
 				},
 				{
-					"_postman_id": "fa227829-7095-4a2f-b088-2580de1b8b11",
+					"name": "Check if configuration RM API customerid exists and should delete",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7886c216-80c5-4093-8f4e-96d01b2cc90e",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response must be valid and have a body\", function () {",
+									"    pm.response.to.be.ok; ",
+									"    pm.response.to.be.withBody;",
+									"    pm.response.to.be.json; ",
+									"});",
+									"",
+									"let jsonData = pm.response.json();",
+									"let customerIdExists = pm.environment.get(\"customerIdExists\");",
+									"if((jsonData !==null && jsonData.configs.length >0) && customerIdExists) {",
+									"    //custoemr id previously existed -- DO NOT DELETE (end execution)",
+									"    postman.setNextRequest(\"Reset Variables\");",
+									"}",
+									""
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "9e850480-32fc-4384-92fb-1faf179e993b",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.customerId)",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(module==EKB and configName==api_access and code==kb.ebsco.customerId)"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/configurations/entries - Clean-up RM API customer id",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "4e9417a7-609d-42de-bb41-87a93d38ba65",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "45e87c73-961f-4262-973c-e6b5d8acac73",
+								"type": "text/javascript",
+								"exec": [
+									"//Clean-up RM API Key configuration created during POST",
+									"pm.test(\"Verify RM API URL deletion with status 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									"",
+									"pm.test(\"'x-okapi-permissions' header is present\", function () {",
+									"    pm.response.to.have.header(\"x-okapi-permissions\");",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries/{{rm-api-customer-id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries",
+								"{{rm-api-customer-id}}"
+							]
+						},
+						"description": "Clean-up RM-API Key configuration"
+					},
+					"response": []
+				},
+				{
+					"name": "Check if configuration RM API apiKey exists and should delete",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f89139b1-5bc1-47f2-82e4-7dcaf0513b1f",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response must be valid and have a body\", function () {",
+									"    pm.response.to.be.ok; ",
+									"    pm.response.to.be.withBody;",
+									"    pm.response.to.be.json; ",
+									"});",
+									"",
+									"let jsonData = pm.response.json();",
+									"let apiKeyExists = pm.environment.get(\"apiKeyExists\");",
+									"if((jsonData !==null && jsonData.configs.length >0) && apiKeyExists) {",
+									"    //Api key previously existed -- DO NOT DELETE (end execution)",
+									"    postman.setNextRequest(\"Reset Variables\");",
+									"}",
+									""
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "9e850480-32fc-4384-92fb-1faf179e993b",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.apiKey)",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(module==EKB and configName==api_access and code==kb.ebsco.apiKey)"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/configurations/entries - Clean-up RM API Key",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "4e9417a7-609d-42de-bb41-87a93d38ba65",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "45e87c73-961f-4262-973c-e6b5d8acac73",
+								"type": "text/javascript",
+								"exec": [
+									"//Clean-up RM API Key configuration created during POST",
+									"pm.test(\"Verify RM API URL deletion with status 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									"",
+									"pm.test(\"'x-okapi-permissions' header is present\", function () {",
+									"    pm.response.to.have.header(\"x-okapi-permissions\");",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries/{{rm-api-key-id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"configurations",
+								"entries",
+								"{{rm-api-key-id}}"
+							]
+						},
+						"description": "Clean-up RM-API Key configuration"
+					},
+					"response": []
+				},
+				{
 					"name": "Reset Variables",
 					"event": [
 						{
@@ -18430,13 +18768,17 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "a4a909f0-41ab-4fd9-9bc7-da0e8c4055f8",
+								"id": "9e4453a6-7061-4d96-90e2-f2eac533c754",
 								"type": "text/javascript",
 								"exec": [
 									"// Reset all environment level variables that may have been setup in the tests",
 									"pm.environment.unset(\"schema_jsonapi_content\");",
-									"pm.environment.unset(\"apiCredentialsExist\");",
-									"pm.environment.unset(\"api-credentials-id\");",
+									"pm.environment.unset(\"apiUrlExists\");",
+									"pm.environment.unset(\"rm-api-url-id\");",
+									"pm.environment.unset(\"customerIdExists\");",
+									"pm.environment.unset(\"rm-api-customer-id\");",
+									"pm.environment.unset(\"apiKeyExists\");",
+									"pm.environment.unset(\"rm-api-key-id\");",
 									"pm.environment.unset(\"custom-providerid\");",
 									"pm.environment.unset(\"custom-packageid\");",
 									"pm.environment.unset(\"name-sort-id1\");",
@@ -18560,15 +18902,21 @@
 	],
 	"variable": [
 		{
-			"id": "dc2048eb-ddb9-4448-91b0-7391d10a5ffc",
+			"id": "57356f66-4efb-40b5-957d-2450f8316abf",
 			"key": "custid",
 			"value": "apidvgvmt",
 			"type": "string"
 		},
 		{
-			"id": "10bb31b0-b5a0-4356-81ef-c3b3b2b9e779",
+			"id": "ba6a58e0-35b1-4963-a125-d6b0bacf17b9",
 			"key": "packageId",
 			"value": "583-4345",
+			"type": "string"
+		},
+		{
+			"id": "9eee344d-9ec2-415b-b190-f70aba0bd65a",
+			"key": "rmapi_api_key",
+			"value": "",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
Mod-kb-ebsco has been updated to use the same location for KB credentials as it used by mod-codex-ekb. https://issues.folio.org/browse/MODKBEBSCO-6 has details of changes.

Due to this change, update mod-kb-ebsco tests:
(1)Update setup configuration to look for configuration settings in new location which is shared with mod-codex-ekb:
`GET /configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.url)`
`GET /configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.customerId)`
`configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.apiKey)`
(2) Update tear-down configuration to use new locations for configuration as well