### PR TITLE
Fix failing API title tests in mod-kb-ebsco

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "dba6bf5c-6174-49a7-97fa-b3ba26fe5c9a",
+		"_postman_id": "490bbbea-93b4-47c6-9e92-32b3f212a496",
 		"name": "mod-kb-ebsco",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1200,7 +1200,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?q=abc",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=abc\n",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -1212,7 +1212,7 @@
 							],
 							"query": [
 								{
-									"key": "q",
+									"key": "filter[name]",
 									"value": "abc\n"
 								}
 							]
@@ -13874,7 +13874,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?q=american",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=american",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -13886,7 +13886,7 @@
 											],
 											"query": [
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": "american"
 												}
 											]
@@ -13991,7 +13991,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?q=american&sort=name",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=american&sort=name",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -14003,7 +14003,7 @@
 											],
 											"query": [
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": "american"
 												},
 												{
@@ -14114,7 +14114,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?q=american&sort=relevance",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=american&sort=relevance",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -14126,7 +14126,7 @@
 											],
 											"query": [
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": "american"
 												},
 												{
@@ -14937,7 +14937,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=2&q=american&sort=name",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=2&filter[name]=american&sort=name",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -14953,7 +14953,7 @@
 													"value": "2"
 												},
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": "american"
 												},
 												{
@@ -15130,7 +15130,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?q=",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -15142,7 +15142,7 @@
 											],
 											"query": [
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": ""
 												}
 											]
@@ -15233,101 +15233,6 @@
 												{
 													"key": "sort",
 													"value": "name"
-												}
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "/titles q&filter[name] conflicting query parameters",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "27065342-b8b3-4b39-b5fe-93c729922e05",
-												"type": "text/javascript",
-												"exec": [
-													"pm.test(\"Status is 400\", function () {",
-													"    pm.response.to.have.status(400);",
-													"});",
-													"",
-													"pm.test(\"Response must have a json body\", function () {",
-													"    pm.response.to.be.badRequest;",
-													"    pm.response.to.have.jsonBody();",
-													"});",
-													"",
-													"var jsonData = pm.response.json();",
-													"",
-													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});",
-													"",
-													"//verify headers",
-													"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
-													"    pm.response.to.have.header(\"Content-Type\");",
-													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
-													"});",
-													"",
-													"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
-													"    pm.response.to.have.header(\"Transfer-Encoding\");",
-													"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
-													"});",
-													"",
-													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-													"});",
-													"",
-													"pm.test(\"Errors array contains 1 entries\", function () {",
-													"    pm.expect(jsonData.errors.length).to.eql(1);",
-													"    pm.expect(jsonData.errors[0].title).to.equal(\"Conflicting query parameters\");",
-													"});",
-													"",
-													"",
-													"",
-													"",
-													""
-												]
-											}
-										}
-									],
-									"request": {
-										"method": "GET",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?q=american&filter[name]=american",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"eholdings",
-												"titles"
-											],
-											"query": [
-												{
-													"key": "q",
-													"value": "american"
-												},
-												{
-													"key": "filter[name]",
-													"value": "american"
 												}
 											]
 										}
@@ -15504,7 +15409,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=2147483648&q=american&sort=name",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=2147483648&filter[name]=american&sort=name",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -15520,7 +15425,7 @@
 													"value": "2147483648"
 												},
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": "american"
 												},
 												{
@@ -15604,7 +15509,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=-1&q=academic",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=-1&filter[name]=academic",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -15620,7 +15525,7 @@
 													"value": "-1"
 												},
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": "academic"
 												}
 											]
@@ -15701,7 +15606,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=a&q=academic",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?page=a&filter[name]=academic",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -15717,7 +15622,7 @@
 													"value": "a"
 												},
 												{
-													"key": "q",
+													"key": "filter[name]",
 													"value": "academic"
 												}
 											]


### PR DESCRIPTION
We made the following change https://github.com/folio-org/mod-kb-ebsco/pull/211 to mod-kb-ebsco as part of cleaning up some code related to titles endpoint which led to these api test failures. 

This PR fixes those failing API tests.