### PR TITLE
Update mod-codex-ekb tests to suit breaking changes

### DIFF
--- a/mod-codex-ekb/mod-codex-ekb.postman_collection.json
+++ b/mod-codex-ekb/mod-codex-ekb.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d19f3403-4035-411c-bead-4f4d8a6955db",
+		"_postman_id": "12e3c8ff-636d-4a16-b925-b1be1375b826",
 		"name": "mod-codex-ekb",
 		"description": "Variables defined for mod-codex-ekb module api testing.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -8,7 +8,6 @@
 	"item": [
 		{
 			"name": "Setup Configuration",
-			"description": "",
 			"item": [
 				{
 					"name": "Check if apiURL exists and generate okapi token",
@@ -526,7 +525,6 @@
 		},
 		{
 			"name": "mod-codex-ekb",
-			"description": "Tests for the /codex-instances end point.",
 			"item": [
 				{
 					"name": "Get instance collection schema  and generate environment variables",
@@ -941,7 +939,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(title=zaz*)",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(title=guz*)",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -953,7 +951,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "(title=zaz*)"
+									"value": "(title=guz*)"
 								}
 							]
 						},
@@ -1868,6 +1866,7 @@
 					"response": []
 				}
 			],
+			"description": "Tests for the /codex-instances end point.",
 			"event": [
 				{
 					"listen": "prerequest",
@@ -1893,7 +1892,6 @@
 		},
 		{
 			"name": "Tear-Down Configuration",
-			"description": "",
 			"item": [
 				{
 					"name": "Check if apiKey exists to delete",
@@ -2439,43 +2437,37 @@
 			"id": "0e5e3c25-0114-43c3-8a68-a7feb5088887",
 			"key": "schemaLocation",
 			"value": "https://raw.githubusercontent.com/folio-org",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
 			"id": "27a1360d-5d4a-4e35-bfd6-31cf0714e0ef",
 			"key": "modName",
 			"value": "raml",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
 			"id": "eeca50ba-9c58-465c-bd49-28086629b31c",
 			"key": "commitId",
 			"value": "7596a06a9b4ee5c2d296e7d528146d6d30c3151f",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
 			"id": "9248429b-bdad-43de-ac73-1071a39ce6ae",
 			"key": "schemaInstances",
 			"value": "instanceCollection.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
 			"id": "6741a39c-5851-4d3d-80c6-d18effd28304",
 			"key": "schemaInstance",
 			"value": "instance.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
 			"id": "3992aef8-da1d-4d1d-af5a-5b41325f22db",
 			"key": "rInfoSchema",
 			"value": "resultInfo.schema",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		}
 	]
 }


### PR DESCRIPTION
mod-codex-ekb build in FSE devQA is failing due to failing tests in mod-codex-ekb. One of the existing tests was searching for `title=zaz*` and expecting results to be empty but RM API returns a title in results for that search string. Updated the search string to `title=guz*` that returns 0 results as of today to make these tests pass. I am not sure if we should have tests of this sort in the long run.