### PR TITLE
Update failing API tests in mod-codex-ekb

### DIFF
--- a/mod-codex-ekb/mod-codex-ekb.postman_collection.json
+++ b/mod-codex-ekb/mod-codex-ekb.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "12e3c8ff-636d-4a16-b925-b1be1375b826",
+		"_postman_id": "2b3c4194-d417-4208-98a3-fb600cf02974",
 		"name": "mod-codex-ekb",
 		"description": "Variables defined for mod-codex-ekb module api testing.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -885,25 +885,25 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "49794727-3025-49c9-a099-d173654284b8",
+								"id": "24a825cb-e978-457e-b522-08975c1f3c95",
 								"type": "text/javascript",
 								"exec": [
 									"let obj = pm.response.json();",
 									"let emptyInstanceList = 0;",
-									"pm.test(\"Verify query search results in 0 total records when title does not exist\", function () {",
+									"pm.test(\"Verify query search results in 0 total records when title with given search params does not exist\", function () {",
 									"    pm.expect(obj.resultInfo.totalRecords).to.equal(0);",
 									"});",
 									"",
-									"pm.test(\"Verify query search results in empty instances list when title does not exist\", function () {",
+									"pm.test(\"Verify query search results in empty instances list when title with given search params does not exist\", function () {",
 									"    pm.expect(obj.instances.length).to.equal(emptyInstanceList);",
 									"});",
 									"",
-									"pm.test(\"Success test on json response when title does not exist\", function() {",
+									"pm.test(\"Success test on json response when title with given search params does not exist\", function() {",
 									"    pm.response.to.be.ok;",
 									"    pm.response.to.be.json;",
 									"});",
 									"",
-									"pm.test(\"Response status is 200 when title does not exist\", function () {",
+									"pm.test(\"Response status is 200 when title with given search params does not exist\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
@@ -939,7 +939,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(title=guz*)",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(id=123)",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -951,7 +951,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "(title=guz*)"
+									"value": "(id=123)"
 								}
 							]
 						},
@@ -1218,12 +1218,11 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e529d50e-4d76-4052-a843-c0c0ef39ac2d",
+								"id": "c9605b2d-e93b-4fd8-a9d5-f438f093970a",
 								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"400 Bad Request - malformed query parameter\", function () {",
-									"    pm.response.to.have.status(500);    //Should return 400",
-									"    //https://issues.folio.org/browse/MODCXEKB-59",
+									"    pm.response.to.have.status(400);    //Should return 400",
 									"});",
 									"",
 									"pm.test(\"X-Okapi-Trace header has expected value\", function () {",


### PR DESCRIPTION
Two issues have been addressed in mod-codex-ekb:
https://issues.folio.org/browse/MODCXEKB-59
https://issues.folio.org/browse/MODCXEKB-64

The implementation/fixes for the above resulted in 3 failing tests: 
1. Tests that search for a non-existing title(Eg: title=guz*) and expect results to be 0 but after implementation of https://issues.folio.org/browse/MODCXEKB-64, this test will no longer pass as we'll always get results with wildcard characters. Change it to something like (Eg: id=123) so that it'll always consistently return 0 results. id here is isxn which can never be of a format like `123`
2. Another test was failing because its expecting a 500 response but after https://issues.folio.org/browse/MODCXEKB-59 is fixed, it now returns a 400 which is expected response. 

This PR fixes the tests above.