### PR TITLE
Correct malformed JSON

### DIFF
--- a/mod-users/mod-users.postman_collection.json
+++ b/mod-users/mod-users.postman_collection.json
@@ -1,13 +1,12 @@
 {
 	"info": {
-		"_postman_id": "b395dd70-08c8-49bf-af28-1db6954662b6",
+		"_postman_id": "b80f7021-1536-4531-bf85-aceca3d26659",
 		"name": "mod-users",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "schemas",
-			"description": null,
 			"item": [
 				{
 					"name": "error.schema",
@@ -637,7 +636,6 @@
 		},
 		{
 			"name": "authentication",
-			"description": null,
 			"item": [
 				{
 					"name": "authn/login",
@@ -694,7 +692,6 @@
 		},
 		{
 			"name": "groups",
-			"description": null,
 			"item": [
 				{
 					"name": "/groups",
@@ -3022,7 +3019,6 @@
 		},
 		{
 			"name": "addresstypes",
-			"description": null,
 			"item": [
 				{
 					"name": "/addresstypes",
@@ -3862,7 +3858,6 @@
 		},
 		{
 			"name": "proxiesfor",
-			"description": null,
 			"item": [
 				{
 					"name": "/proxiesfor",
@@ -4686,7 +4681,6 @@
 		},
 		{
 			"name": "users",
-			"description": null,
 			"item": [
 				{
 					"name": "/users",
@@ -4825,7 +4819,6 @@
 							"listen": "test",
 							"script": {
 								"id": "eef0e512-f998-4d91-a0ec-0beac953cf96",
-								"type": "text/javascript",
 								"exec": [
 									"var response = JSON.parse(responseBody);",
 									"pm.environment.set(\"newuserid\", response.id);",
@@ -4911,14 +4904,14 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "f9954452-6b48-4f1c-8a90-625a1012b006",
-								"type": "text/javascript",
 								"exec": [
 									"pm.sendRequest({",
 									"    url: pm.environment.get('protocol') + '://' + pm.environment.get('url') + ':' + pm.environment.get('okapiport') + '/groups' ,",
@@ -4932,7 +4925,8 @@
 									"     pm.environment.set('newusergroupid', res.json().usergroups[0].id);",
 									"    }",
 									"});"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4954,7 +4948,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"username\": \"posttestuser\",\r\n  \"id\": \"1123aaa0721bbb0804ccc\",\r\n  \"active\": true,\r\n  \"type\": \"patron\",\r\n   \"patronGroup\":\"{{newusergroupid}}\"\r\n },\r\n  \"personal\": {\r\n    \"lastName\": \"user\",\r\n    \"firstName\": \"posttest\",\r\n    \"email\": \"up@biblioteka.pl\",\r\n  }\r\n}"
+							"raw": "{\r\n  \"username\": \"posttestuser\",\r\n  \"id\": \"{{$guid}}\",\r\n  \"active\": true,\r\n  \"type\": \"patron\",\r\n  \"patronGroup\":\"{{newusergroupid}}\",\r\n  \"personal\": {\r\n    \"lastName\": \"user\",\r\n    \"firstName\": \"posttest\",\r\n    \"email\": \"up@biblioteka.pl\"\r\n  }\r\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users",


### PR DESCRIPTION
The latest build of mod-users requires the "id" field to be an actual UUID, whereas older builds would take any string since this is ignored as it is written to the DB and a new UUID is returned. For some reason, "id" is a required field in the user schema which means that the client needs to send something and the schema does not enforce UUID format via a pattern. The documentation does indicate "id" must be a UUID. It appears that a UUID without the '-' characters is accepted, as the example in the API doc shows. Anyway, this test works now.