### PR TITLE
Fix mod-inventory-storage locations API tests

### DIFF
--- a/mod-inventory-storage/mod-inventory-storage-location.postman_collection.json
+++ b/mod-inventory-storage/mod-inventory-storage-location.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "8ed472c2-f44c-4da3-8478-30103d290493",
+		"_postman_id": "3dec2ab4-3eec-4c42-846f-e9f0353e4d41",
 		"name": "mod-inventory-storage-location",
 		"description": "Test: \n/location-units/institutions\n/location-units/campuses\n/location-units/libraries\n/location\n",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -8,11 +8,9 @@
 	"item": [
 		{
 			"name": "Setup",
-			"description": null,
 			"item": [
 				{
 					"name": "Getting response schemas",
-					"description": null,
 					"item": [
 						{
 							"name": "parameters.schema",
@@ -546,6 +544,95 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "servicepoint.json",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "e705b107-9958-4aee-8a5a-52ae5d617f67",
+										"exec": [
+											"pm.test(pm.variables.get(\"schema_service_point\") + \" GET OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.environment.set(\"schema_service_point_content\", responseBody);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{schema_loc}}/{{mod_name}}/{{mod_version}}/ramls/{{schema_service_point}}",
+									"host": [
+										"{{schema_loc}}"
+									],
+									"path": [
+										"{{mod_name}}",
+										"{{mod_version}}",
+										"ramls",
+										"{{schema_service_point}}"
+									]
+								},
+								"description": "This is to get servicepoint.json to be used in later tests."
+							},
+							"response": []
+						},
+						{
+							"name": "servicepoints.json",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "f5f826ad-c5c5-4908-b7dd-c55b071a036a",
+										"exec": [
+											"pm.test(pm.variables.get(\"schema_service_points\") + \" GET OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.environment.set(\"schema_service_points_content\", responseBody);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{schema_loc}}/{{mod_name}}/{{mod_version}}/ramls/{{schema_service_points}}",
+									"host": [
+										"{{schema_loc}}"
+									],
+									"path": [
+										"{{mod_name}}",
+										"{{mod_version}}",
+										"ramls",
+										"{{schema_service_points}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -604,8 +691,7 @@
 			]
 		},
 		{
-			"name": "Happy path - /location -units/institutions",
-			"description": null,
+			"name": "Happy path - /location-units/institutions",
 			"item": [
 				{
 					"name": "/location-units/institutions 200",
@@ -1434,7 +1520,6 @@
 		},
 		{
 			"name": "Negative tests - /location-units/institutions",
-			"description": null,
 			"item": [
 				{
 					"name": "/location-units/institutions 422 - duplicate entry",
@@ -2458,7 +2543,6 @@
 		},
 		{
 			"name": "Happy path - /location-units/campuses",
-			"description": null,
 			"item": [
 				{
 					"name": "/location-units/campuses 200",
@@ -3280,7 +3364,6 @@
 		},
 		{
 			"name": "Negative tests - /location-units/campuses",
-			"description": null,
 			"item": [
 				{
 					"name": "/location-units/campuses 422 - duplicate entry",
@@ -4387,7 +4470,6 @@
 		},
 		{
 			"name": "Happy path - /location-units/libraries",
-			"description": null,
 			"item": [
 				{
 					"name": "/location-units/libraries200",
@@ -5209,7 +5291,6 @@
 		},
 		{
 			"name": "Negative tests - /location-units/libraries",
-			"description": null,
 			"item": [
 				{
 					"name": "/location-units/libraries 422 - duplicate entry",
@@ -6313,8 +6394,1796 @@
 			]
 		},
 		{
+			"name": "Happy path - /service-points",
+			"item": [
+				{
+					"name": "/service-points 200",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "0ac312d2-c505-41c6-9493-f047b4107a88",
+								"exec": [
+									"let jsonData = JSON.parse(responseBody);",
+									"",
+									"if(jsonData.servicepoints.length > 0){",
+									"   pm.environment.set(\"originalservicepointscount\", jsonData.totalRecords);",
+									"}",
+									"",
+									"pm.test(\"Returns status 200\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.have.jsonBody();",
+									"});",
+									"",
+									"pm.test(\"Contains data\", function () {",
+									" pm.expect(jsonData.servicepoints.length > 0).to.be.true;",
+									"});",
+									"",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 201",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "51e56114-b15a-46d4-9f32-bb5f86e2ef3a",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"console.log(\"id\" + jsonData.id);",
+									"",
+									"pm.environment.set(\"testservicepointid\", jsonData.id);",
+									"",
+									"pm.test(\"Status code is OK\", function () {",
+									"    pm.response.to.have.status(201);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"});   ",
+									"    ",
+									"pm.test(\"Response contains correct data\", function () {    ",
+									"    pm.response.to.have.jsonBody(\"id\", jsonData.id);",
+									"    pm.response.to.have.jsonBody(\"name\", pm.environment.get(\"testservicepointname\"));",
+									"    pm.response.to.have.jsonBody(\"code\", pm.environment.get(\"testservicepointcode\"));",
+									"    pm.response.to.have.jsonBody(\"discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
+									"});  ",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									"",
+									"pm.test(\"'Location' header is present\", function () {",
+									"    pm.response.to.have.header(\"location\");",
+									"    pm.response.to.have.header(\"location\", \"/service-points/\" + jsonData.id)",
+									"});    ",
+									"    ",
+									"pm.test(\"Verify schema\", function () {    ",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_point_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "c59d7b9c-931f-4316-9a71-b49cde0c4686",
+								"exec": [
+									"pm.environment.set(\"testservicepointname\", \"test service point\");",
+									"pm.environment.set(\"testservicepointcode\", \"TSP\");",
+									"pm.environment.set(\"testdiscoverydisplayname\", \"Test Service Point Discovery Name\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 200",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fe52b9b2-fc8c-496a-b4ba-d60d47f7581d",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"",
+									"pm.test(\"Returns status 200\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.have.jsonBody();",
+									" });",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_point_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									"",
+									"pm.test(\"Response contains correct data\", function () {    ",
+									"    pm.response.to.have.jsonBody(\"id\", pm.environment.get(\"testservicepointid\"));",
+									"    pm.response.to.have.jsonBody(\"name\", pm.environment.get(\"testservicepointname\"));",
+									"    pm.response.to.have.jsonBody(\"code\", pm.environment.get(\"testservicepointcode\"));",
+									"    pm.response.to.have.jsonBody(\"discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
+									"}); ",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{testservicepointid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 200 -- query by name",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "1935b1ad-26ee-4b0c-8b4a-d39d06163d22",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"",
+									"pm.test(\"Returns status 200\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.have.jsonBody();",
+									" });",
+									"",
+									"",
+									"pm.test(\"Response contains correct data\", function () {    ",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].id\", pm.environment.get(\"testservicepointid\"));",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].name\", pm.environment.get(\"testservicepointname\"));",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].code\", pm.environment.get(\"testservicepointcode\"));",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
+									"}); ",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?query=(name=={{testservicepointname}})",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(name=={{testservicepointname}})"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 200 -- query by code",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5e9d1a17-d422-4c77-8d9a-636beb0dba79",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"",
+									"pm.test(\"Returns status 200\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.have.jsonBody();",
+									" });",
+									"",
+									"",
+									"pm.test(\"Response contains correct data\", function () {    ",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].id\", pm.environment.get(\"testservicepointid\"));",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].name\", pm.environment.get(\"testservicepointname\"));",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].code\", pm.environment.get(\"testservicepointcode\"));",
+									"    pm.response.to.have.jsonBody(\"servicepoints[0].discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
+									"}); ",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?query=(code=={{testservicepointcode}})",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(code=={{testservicepointcode}})"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points?limit={{limit}}&offset=1 200",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "250579b6-88d1-4ef5-b10c-55e7b4d78e5e",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"",
+									"pm.test(\"/service-points GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.have.jsonBody();",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});   ",
+									"",
+									"pm.test(\"Returned correct number of records\", function () {",
+									"       pm.expect(jsonData.servicepoints.length == pm.environment.get(\"originalservicepointscount\")).to.be.true;",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "35c5c253-ec2c-4f52-844e-0e6e62af9292",
+								"exec": [
+									"let limit = pm.environment.get(\"originalservicepointscount\");",
+									"",
+									"if (limit === 0) {",
+									"    limit = 2;",
+									"} ",
+									"",
+									"pm.variables.set(\"limit\", limit);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?limit={{limit}}&offset=1",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								},
+								{
+									"key": "offset",
+									"value": "1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 200 -- query by non-existing code",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "695d4b17-2b97-4e34-9359-99edcb749106",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"",
+									"pm.test(\"Returns status 200\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.have.jsonBody();",
+									" });",
+									"",
+									"pm.test(\"No results found\", function() {",
+									"    pm.expect(jsonData.servicepoints.length).to.equal(0);",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?query=(code=foo)",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(code=foo)"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 204",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "11e0eeda-4264-413f-be22-b6519994a27a",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(\"No Content\");",
+									"});   ",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b61e6f94-aa53-48e3-8580-88d3bee438ca",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{testservicepointid}}\",\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\",\n  \"description\": \"test\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{testservicepointid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 200 - verify update",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b726e9e1-15e0-4fd3-9f3f-503d4dd7278a",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"",
+									"pm.test(\"Returns status 200\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.have.jsonBody();",
+									" });",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_point_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									"",
+									"pm.test(\"Response contains correct data\", function () {",
+									"    pm.response.to.have.jsonBody(\"id\", pm.environment.get(\"testservicepointid\"));",
+									"    pm.response.to.have.jsonBody(\"name\", pm.environment.get(\"testservicepointname\"));",
+									"    pm.response.to.have.jsonBody(\"code\", pm.environment.get(\"testservicepointcode\"));",
+									"    pm.response.to.have.jsonBody(\"discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
+									"    pm.response.to.have.jsonBody(\"description\", \"test\");",
+									"}); ",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "bac8c4f9-1a1f-4c62-8dba-6fd368a5243e",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{testservicepointid}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "6a66f184-ae55-457f-898a-fb849dc0071c",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "1460d85b-4fa7-4228-9488-69872e103009",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Negative tests - service-points",
+			"item": [
+				{
+					"name": "/service-points 403",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "cd09c669-305a-42a5-8eba-bb5d8617223e",
+								"exec": [
+									"pm.test(\"/service-points POST not OK without token\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "1681e8da-8dd5-4e99-884b-02975459a972",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}\n"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 422  - missing required name field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "12e4592d-fb73-4485-a3d5-8ee636ed582f",
+								"exec": [
+									"pm.test(\"/service-points POST not OK without required name field\", function () {",
+									"    pm.response.to.have.status(422);",
+									"    pm.response.json;",
+									"});",
+									"",
+									"pm.test(\"Correct error message returned\", function () {",
+									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"may not be null\");",
+									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"name\");",
+									"    ",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    ",
+									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
+									"    if (schema_parameters.id) {",
+									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
+									"    }",
+									"    ",
+									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
+									"    if (schema_error.id) {",
+									"        tv4.addSchema(schema_error.id, schema_error);",
+									"    }",
+									"    ",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 422  - missing required code field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2ce774b3-be46-4abc-991f-1374d8db85bc",
+								"exec": [
+									"pm.test(\"/service-points POST not OK without required code field\", function () {",
+									"    pm.response.to.have.status(422);",
+									"    pm.response.json;",
+									"});",
+									"",
+									"pm.test(\"Correct error message returned\", function () {",
+									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"may not be null\");",
+									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"code\");",
+									"    ",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    let jsonData  = pm.response.json();",
+									"    ",
+									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
+									"    if (schema_parameters.id) {",
+									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
+									"    }",
+									"    ",
+									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
+									"    if (schema_error.id) {",
+									"        tv4.addSchema(schema_error.id, schema_error);",
+									"    }",
+									"    ",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 422  - missing required discoveryDisplayName field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5a9bc104-f4be-470d-9108-be03002d1448",
+								"exec": [
+									"pm.test(\"/service-points POST not OK without required discoveryDisplayName field\", function () {",
+									"    pm.response.to.have.status(422);",
+									"    pm.response.json;",
+									"});",
+									"",
+									"pm.test(\"Correct error message returned\", function () {",
+									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"may not be null\");",
+									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"discoveryDisplayName\");",
+									"    ",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
+									"    if (schema_parameters.id) {",
+									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
+									"    }",
+									"    ",
+									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
+									"    if (schema_error.id) {",
+									"        tv4.addSchema(schema_error.id, schema_error);",
+									"    }",
+									"    ",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 400 No payload",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c2d75f84-abdd-4d1f-ae0d-98959ef42edf",
+								"exec": [
+									"pm.test(\"/service-points POST returns 400 without request payload\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.response.to.be.clientError;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "ec7e42ca-d200-4851-940e-deb7952d8da4",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 400 Not well formed JSON payload",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd0c3f3c-9ca5-4469-b380-0e7c6b436f6a",
+								"exec": [
+									"pm.test(\"/service-points POST returns 400 with not well formed JSON payload\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.response.to.be.clientError;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "0284f909-befc-4c76-9bb1-7ae350f06365",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "\"name\""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 400 - limit  -1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "35539344-e4fe-4b0a-b1a1-9749f94ccbec",
+								"exec": [
+									"pm.test(\"Returns status 400 when limit -1\", function () {",
+									"    // pm.response.to.have.status(\"Bad Request\");",
+									"    pm.response.to.have.status(500); // See https://issues.folio.org/browse/MODINVSTOR-211",
+									"    pm.response.to.have.body;",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d4e24c44-537a-4f1a-85ef-368898375f74",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?limit=-1",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "-1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 400 - limit  exeeds max int value",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "20adaa64-17f8-439e-a183-4df49ab6c44a",
+								"exec": [
+									"pm.test(\"Returns status 400 when limit exeeds max value for integer\", function () {",
+									"    pm.response.to.have.status(\"Bad Request\");",
+									"    pm.response.to.have.body;",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d4e24c44-537a-4f1a-85ef-368898375f74",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?limit=2147483648",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "2147483648"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 403 With tenant but no token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "0c6a5e63-9c58-43d3-9b45-0f76ee016e44",
+								"exec": [
+									"pm.test(\"/service-points GET returns 403 without token\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points 403 No tenant and no token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "390653f0-11e4-45e4-ac6d-d8169dd26470",
+								"exec": [
+									"pm.test(\"/service-points GET returns 403 without token\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 403",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b57d51c3-ed85-4c4c-91c8-d2f3cdadca36",
+								"exec": [
+									"pm.test(\"/service-points GET not OK without token\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "0df983f4-f9f0-4a9b-95ea-83eb71b5dc99",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{testservicepointid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 404",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "49c93149-94b1-4011-8c9d-8c5d037edc9a",
+								"exec": [
+									"pm.test(\"/service-points GET not OK for non-existing id\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "0df983f4-f9f0-4a9b-95ea-83eb71b5dc99",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{$guid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{$guid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 403",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9e0f01eb-1b35-424d-9279-7a04c482b2fa",
+								"exec": [
+									"pm.test(\"/service-points/{id} PUT not OK without token\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "ad106953-c49e-4848-8bb4-114af0cd2ce2",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\",\n  \"pickupLocation\": true\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{$guid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{$guid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/foo 404",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "98a01d7f-e81c-4ae1-95c6-e445e9f1bcba",
+								"exec": [
+									"pm.test(\"/service-points/{id} PUT not OK for non-existing id\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "51aa7ff2-5b02-4e88-a346-dc3d99619ba8",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\",\n  \"pickupLocation\": true\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/foo",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"foo"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 403",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "75deb0cb-a138-43e4-98e9-cd9be1317ff7",
+								"exec": [
+									"pm.test(\"/service-points/{id} DELETE not OK without token\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{$guid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{$guid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 404",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "82f012e9-9223-4b89-8e58-a9eb734bfac9",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"/locations/{id} DELETE not OK for non-existing id\", function () {",
+									"    // TODO: https://issues.folio.org/browse/MODINVSTOR-81",
+									"    // pm.response.to.have.status(404);",
+									"    pm.response.to.have.status(204);",
+									"});",
+									""
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations/{{$guid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"locations",
+								"{{$guid}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "dafb86aa-c382-41dc-8592-d9e30798ab68",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "01a30f26-acb9-4982-a304-90fd3715fd73",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
 			"name": "Happy path - locations",
-			"description": null,
 			"item": [
 				{
 					"name": "/locations 200",
@@ -6323,7 +8192,6 @@
 							"listen": "test",
 							"script": {
 								"id": "0ac312d2-c505-41c6-9493-f047b4107a88",
-								"type": "text/javascript",
 								"exec": [
 									"let jsonData = JSON.parse(responseBody);",
 									"",
@@ -6343,9 +8211,10 @@
 									"",
 									"",
 									"pm.test(\"Validate schema\", function () {",
-									"     tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
 									"    tv4.addSchema(\"location.json\", JSON.parse(pm.environment.get(\"schema_location_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_locations_content\")))).to.be.true;",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_locations_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"});",
 									"",
 									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
@@ -6353,17 +8222,18 @@
 									"});",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6404,7 +8274,6 @@
 							"listen": "test",
 							"script": {
 								"id": "51e56114-b15a-46d4-9f32-bb5f86e2ef3a",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"console.log(\"id\" + jsonData.id);",
@@ -6424,6 +8293,8 @@
 									"    pm.response.to.have.jsonBody(\"institutionId\", pm.environment.get(\"testinstitutionid\"));",
 									"    pm.response.to.have.jsonBody(\"campusId\", pm.environment.get(\"testcampusid\"));",
 									"    pm.response.to.have.jsonBody(\"libraryId\", pm.environment.get(\"testlibraryid\"));",
+									"    pm.response.to.have.jsonBody(\"primaryServicePoint\", pm.environment.get(\"testservicepointid\"));",
+									"    pm.response.to.have.jsonBody(\"servicePointIds[0]\", pm.environment.get(\"testservicepointid\"));",
 									"});  ",
 									"",
 									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
@@ -6441,18 +8312,19 @@
 									"});",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "c59d7b9c-931f-4316-9a71-b49cde0c4686",
-								"type": "text/javascript",
 								"exec": [
 									"pm.environment.set(\"testlocationname\", \"test location name\");",
 									"pm.environment.set(\"testlocationcode\", \"TLC\");"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6470,7 +8342,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{testlocationname}}\",\n  \"code\": \"{{testlocationcode}}\",\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid}}\",\n  \"libraryId\": \"{{testlibraryid}}\"\n \n}"
+							"raw": "{\n  \"name\": \"{{testlocationname}}\",\n  \"code\": \"{{testlocationcode}}\",\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid}}\",\n  \"libraryId\": \"{{testlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -6493,7 +8365,6 @@
 							"listen": "test",
 							"script": {
 								"id": "df435d6e-c449-4f68-8a5a-2021ba67d831",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"console.log(\"id\" + jsonData.id);",
@@ -6522,17 +8393,18 @@
 									"});",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "20f8be3b-ad0e-4527-bb71-8a07c53129c0",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6550,7 +8422,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"second test location with invalid campusids\",\n  \"code\": \"SecTestLibrary\",\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid2}}\",\n  \"libraryId\": \"{{testlibraryid}}\"\n \n}"
+							"raw": "{\n  \"name\": \"second test location with invalid campusids\",\n  \"code\": \"SecTestLibrary\",\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid2}}\",\n  \"libraryId\": \"{{testlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -6573,7 +8445,6 @@
 							"listen": "test",
 							"script": {
 								"id": "e876a58e-faa3-49a5-a0e2-8d0f8168b735",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"console.log(\"id\" + jsonData.id);",
@@ -6602,17 +8473,18 @@
 									"});",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "20f8be3b-ad0e-4527-bb71-8a07c53129c0",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6630,7 +8502,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"third test location with invalid campusids\",\n  \"code\": \"ThirdTestLibrary\",\n  \"institutionId\": \"{{testinstitutionid2}}\",\n  \"campusId\": \"{{testcampusid2}}\",\n  \"libraryId\": \"{{testlibraryid}}\"\n \n}"
+							"raw": "{\n  \"name\": \"third test location with invalid campusids\",\n  \"code\": \"ThirdTestLibrary\",\n  \"institutionId\": \"{{testinstitutionid2}}\",\n  \"campusId\": \"{{testcampusid2}}\",\n  \"libraryId\": \"{{testlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -6653,7 +8525,6 @@
 							"listen": "test",
 							"script": {
 								"id": "e309f703-2e28-40f1-a7b2-27ed6a72e9d3",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"console.log(\"id\" + jsonData.id);",
@@ -6681,17 +8552,18 @@
 									"});",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "20f8be3b-ad0e-4527-bb71-8a07c53129c0",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6709,7 +8581,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"forth test location with invalid campusids\",\n  \"code\": \"ForthTestLibrary\",\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid2}}\",\n  \"libraryId\": \"{{testlibraryid2}}\"\n \n}"
+							"raw": "{\n  \"name\": \"forth test location with invalid campusids\",\n  \"code\": \"ForthTestLibrary\",\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid2}}\",\n  \"libraryId\": \"{{testlibraryid2}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -6732,7 +8604,6 @@
 							"listen": "test",
 							"script": {
 								"id": "fe52b9b2-fc8c-496a-b4ba-d60d47f7581d",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"",
@@ -6753,23 +8624,25 @@
 									"    pm.response.to.have.jsonBody(\"institutionId\", pm.environment.get(\"testinstitutionid\"));",
 									"    pm.response.to.have.jsonBody(\"campusId\", pm.environment.get(\"testcampusid\"));",
 									"    pm.response.to.have.jsonBody(\"libraryId\", pm.environment.get(\"testlibraryid\"));",
+									"    pm.response.to.have.jsonBody(\"primaryServicePoint\", pm.environment.get(\"testservicepointid\"));",
 									"}); ",
 									"",
 									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
 									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6811,7 +8684,6 @@
 							"listen": "test",
 							"script": {
 								"id": "1935b1ad-26ee-4b0c-8b4a-d39d06163d22",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"",
@@ -6828,6 +8700,7 @@
 									"    pm.response.to.have.jsonBody(\"locations[0].institutionId\", pm.environment.get(\"testinstitutionid\"));",
 									"    pm.response.to.have.jsonBody(\"locations[0].campusId\", pm.environment.get(\"testcampusid\"));",
 									"    pm.response.to.have.jsonBody(\"locations[0].libraryId\", pm.environment.get(\"testlibraryid\"));",
+									"    pm.response.to.have.jsonBody(\"locations[0].primaryServicePoint\", pm.environment.get(\"testservicepointid\"));",
 									"}); ",
 									"",
 									"pm.test(\"Validate schema\", function () {",
@@ -6836,17 +8709,18 @@
 									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_locations_content\")))).to.be.true;",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6893,7 +8767,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5e9d1a17-d422-4c77-8d9a-636beb0dba79",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"",
@@ -6910,6 +8783,7 @@
 									"    pm.response.to.have.jsonBody(\"locations[0].institutionId\", pm.environment.get(\"testinstitutionid\"));",
 									"    pm.response.to.have.jsonBody(\"locations[0].campusId\", pm.environment.get(\"testcampusid\"));",
 									"    pm.response.to.have.jsonBody(\"locations[0].libraryId\", pm.environment.get(\"testlibraryid\"));",
+									"    pm.response.to.have.jsonBody(\"locations[0].primaryServicePoint\", pm.environment.get(\"testservicepointid\"));",
 									"}); ",
 									"",
 									"pm.test(\"Validate schema\", function () {",
@@ -6918,17 +8792,18 @@
 									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_locations_content\")))).to.be.true;",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7137,7 +9012,6 @@
 							"listen": "test",
 							"script": {
 								"id": "11e0eeda-4264-413f-be22-b6519994a27a",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 204\", function () {",
 									"    pm.response.to.have.status(\"No Content\");",
@@ -7150,17 +9024,18 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "b61e6f94-aa53-48e3-8580-88d3bee438ca",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7178,7 +9053,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{testlocationid}}\",\n  \"name\": \"{{testlocationname}}\",\n  \"code\": \"{{testlocationcode}}\",\n  \"isActive\": false,\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid}}\",\n  \"libraryId\": \"{{testlibraryid}}\"\n \n}"
+							"raw": "{\n  \"id\": \"{{testlocationid}}\",\n  \"name\": \"{{testlocationname}}\",\n  \"code\": \"{{testlocationcode}}\",\n  \"isActive\": false,\n  \"institutionId\": \"{{testinstitutionid}}\",\n  \"campusId\": \"{{testcampusid}}\",\n  \"libraryId\": \"{{testlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations/{{testlocationid}}",
@@ -7202,7 +9077,6 @@
 							"listen": "test",
 							"script": {
 								"id": "b726e9e1-15e0-4fd3-9f3f-503d4dd7278a",
-								"type": "text/javascript",
 								"exec": [
 									"const jsonData = JSON.parse(responseBody);",
 									"",
@@ -7224,23 +9098,26 @@
 									"    pm.response.to.have.jsonBody(\"institutionId\", pm.environment.get(\"testinstitutionid\"));",
 									"    pm.response.to.have.jsonBody(\"campusId\", pm.environment.get(\"testcampusid\"));",
 									"    pm.response.to.have.jsonBody(\"libraryId\", pm.environment.get(\"testlibraryid\"));",
+									"    pm.response.to.have.jsonBody(\"primaryServicePoint\", pm.environment.get(\"testservicepointid\"));",
+									"    pm.response.to.have.jsonBody(\"servicePointIds[0]\", pm.environment.get(\"testservicepointid\"));",
 									"}); ",
 									"",
 									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
 									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "bac8c4f9-1a1f-4c62-8dba-6fd368a5243e",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7279,7 +9156,6 @@
 		},
 		{
 			"name": "Negative tests - locations",
-			"description": null,
 			"item": [
 				{
 					"name": "/locations 403",
@@ -7288,23 +9164,23 @@
 							"listen": "test",
 							"script": {
 								"id": "cd09c669-305a-42a5-8eba-bb5d8617223e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"/locations POST not OK without token\", function () {",
 									"    pm.response.to.have.status(403);",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "1681e8da-8dd5-4e99-884b-02975459a972",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7318,7 +9194,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}\n"
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}\n"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -7341,7 +9217,6 @@
 							"listen": "test",
 							"script": {
 								"id": "12e4592d-fb73-4485-a3d5-8ee636ed582f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"/locations POST not OK without required name field\", function () {",
 									"    pm.response.to.have.status(422);",
@@ -7373,17 +9248,18 @@
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"",
 									"});"
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7401,7 +9277,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}"
+							"raw": "{\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -7424,7 +9300,6 @@
 							"listen": "test",
 							"script": {
 								"id": "2ce774b3-be46-4abc-991f-1374d8db85bc",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"/shelf-locations POST not OK without required name field\", function () {",
 									"    pm.response.to.have.status(422);",
@@ -7456,17 +9331,18 @@
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"",
 									"});"
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7484,7 +9360,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}\n"
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}\n"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -7507,7 +9383,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5a9bc104-f4be-470d-9108-be03002d1448",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"/locations POST not OK without required name field\", function () {",
 									"    pm.response.to.have.status(422);",
@@ -7539,17 +9414,18 @@
 									"",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7567,7 +9443,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}\n"
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}\n"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -7590,7 +9466,6 @@
 							"listen": "test",
 							"script": {
 								"id": "340492d4-9c54-4c87-bf9d-83eb98b89372",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"/shelf-locations POST not OK without required name field\", function () {",
 									"    pm.response.to.have.status(422);",
@@ -7621,17 +9496,18 @@
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"",
 									"});"
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7649,7 +9525,171 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}"
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"locations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/locations 422  - missing required primaryServicePoint field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "340492d4-9c54-4c87-bf9d-83eb98b89372",
+								"exec": [
+									"pm.test(\"/locations POST not OK without required name field\", function () {",
+									"    pm.response.to.have.status(422);",
+									"    pm.response.json;",
+									"});",
+									"",
+									"pm.test(\"Correct error message returned\", function () {",
+									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"may not be null\");",
+									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"primaryServicePoint\");",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    ",
+									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
+									"    if (schema_parameters.id) {",
+									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
+									"    }",
+									"    ",
+									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
+									"    if (schema_error.id) {",
+									"        tv4.addSchema(schema_error.id, schema_error);",
+									"    }",
+									"    ",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"locations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/locations 422  - missing non-required (but secretly required) servicePointIds field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "340492d4-9c54-4c87-bf9d-83eb98b89372",
+								"exec": [
+									"pm.test(\"/locations POST not OK without required name field\", function () {",
+									"    pm.response.to.have.status(422);",
+									"    pm.response.json;",
+									"});",
+									"",
+									"pm.test(\"Correct error message returned\", function () {",
+									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"A location must have at least one Service Point assigned.\");",
+									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"servicePointIds\");",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    ",
+									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
+									"    if (schema_parameters.id) {",
+									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
+									"    }",
+									"    ",
+									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
+									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
+									"    if (schema_error.id) {",
+									"        tv4.addSchema(schema_error.id, schema_error);",
+									"    }",
+									"    ",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\"\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -7790,7 +9830,6 @@
 							"listen": "test",
 							"script": {
 								"id": "27b22b0c-8be9-4186-badc-240feab69d58",
-								"type": "text/javascript",
 								"exec": [
 									"//https://issues.folio.org/browse/MODINVSTOR-99",
 									"",
@@ -7808,17 +9847,18 @@
 									"    ",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "a6e35bb3-9122-4b49-9ec2-1eff9eb633ed",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7836,7 +9876,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{$guid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}"
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"{{$guid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -7859,7 +9899,6 @@
 							"listen": "test",
 							"script": {
 								"id": "bf8010ef-f2e6-4e78-9195-45d24b520fe7",
-								"type": "text/javascript",
 								"exec": [
 									"//https://issues.folio.org/browse/MODINVSTOR-100",
 									"pm.test(\"Status code 500\", function () {",
@@ -7875,17 +9914,18 @@
 									"});    ",
 									"    ",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "a6e35bb3-9122-4b49-9ec2-1eff9eb633ed",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -7903,7 +9943,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"7777\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n}"
+							"raw": "{\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"institutionId\": \"7777\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -8289,24 +10329,24 @@
 							"listen": "test",
 							"script": {
 								"id": "9e0f01eb-1b35-424d-9279-7a04c482b2fa",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"/locations/{id} PUT not OK without token\", function () {",
 									"    pm.response.to.have.status(403);",
 									"});",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "ad106953-c49e-4848-8bb4-114af0cd2ce2",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -8320,7 +10360,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{testlocationid}}\",\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"isActive\": true,\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}"
+							"raw": "{\n  \"id\": \"{{testlocationid}}\",\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"isActive\": true,\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations/{{test_new_val}}",
@@ -8344,24 +10384,24 @@
 							"listen": "test",
 							"script": {
 								"id": "98a01d7f-e81c-4ae1-95c6-e445e9f1bcba",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"/locations/{id} PUT not OK for non-existing id\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "51aa7ff2-5b02-4e88-a346-dc3d99619ba8",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -8379,7 +10419,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"id\": \"foo\",\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"isActive\": true,\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\"\n \n}"
+							"raw": "{\n  \"id\": \"foo\",\n  \"name\": \"{{locationname}}\",\n  \"code\": \"{{locationcode}}\",\n  \"isActive\": true,\n  \"institutionId\": \"{{locationinstitutionid}}\",\n  \"campusId\": \"{{locationcampusid}}\",\n  \"libraryId\": \"{{locationlibraryid}}\",\n  \"primaryServicePoint\": \"{{testservicepointid}}\",\n  \"servicePointIds\": [\n  \t\"{{testservicepointid}}\"\n  ]\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations/foo",
@@ -8519,7 +10559,6 @@
 		},
 		{
 			"name": "Cleanup",
-			"description": null,
 			"item": [
 				{
 					"name": "/locations/{id} 204",
@@ -8834,6 +10873,139 @@
 								{
 									"key": "query",
 									"value": "(id={{testlocationid}} or id={{testlocationid2}} or id={{testlocationid3}} or id={{testlocationid4}})"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 204",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "27d6c230-ca00-4e90-b3f1-c299e1380fbc",
+								"exec": [
+									"pm.test(\"/service-points/{id} DELETE OK\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "3ee155af-5074-4254-91b8-06fb10ae1d18",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points",
+								"{{testservicepointid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/service-points/{id} 200 - verify delete",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "485bd4ef-b3f7-459a-a80e-215a4dc5fb70",
+								"exec": [
+									"pm.test(\"Return status 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Empty array of service points is returned\", function () {",
+									"    pm.expect(pm.response.json().servicepoints.length).to.equal(0);",
+									"});",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?query=(id=={{testservicepointid}})",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "(id=={{testservicepointid}})"
 								}
 							]
 						}
@@ -9547,109 +11719,106 @@
 	],
 	"variable": [
 		{
-			"id": "52dd3aa1-c1bd-4b0b-9caf-fe5263d410e7",
+			"id": "9978b782-3761-43ac-a06b-64ef4e983e8b",
 			"key": "mod_name",
 			"value": "mod-inventory-storage",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "190ff5a9-c47c-4a7c-a4ec-a7820610ead5",
+			"id": "4a2a4741-af6c-47f5-bd1e-6cb016c0b60d",
 			"key": "mod_version",
-			"value": "6bfa76b63f3bfa5d546b51dbe5dfa0c3887be5d2",
-			"type": "string",
-			"description": ""
+			"value": "v13.0.1",
+			"type": "string"
 		},
 		{
-			"id": "19108576-ea7a-4fba-9aae-851193e1fb8c",
+			"id": "910a6eba-219f-4445-9ae6-2c76a9099587",
 			"key": "schema_location",
 			"value": "location.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "24a8a2ee-c184-4a76-a1b9-a82f67a68dac",
+			"id": "744848d8-5f23-408f-a61c-48a988e98f0e",
 			"key": "schema_locations",
 			"value": "locations.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "427fa7c6-d7e2-46bf-a9d7-8cd814a4146f",
+			"id": "49861076-a7fc-449b-a82a-50c743586379",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "551bed83-d52a-4e79-a0eb-01c2d734e1b5",
+			"id": "3558767c-fd7f-4c65-98fb-db2f1ffaae0a",
 			"key": "schema_locinsts",
 			"value": "locinsts.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "9a7c2e43-8736-4651-a079-7533a505523c",
+			"id": "ed417312-a31c-443c-9daa-b2b5b8b06389",
 			"key": "schema_locinst",
 			"value": "locinst.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "8cf40532-8f92-4204-bdba-4d5ded9bd6fd",
+			"id": "f324db10-fcf5-457e-bef2-d1b8a0f40e06",
 			"key": "schema_loccamps",
 			"value": "loccamps.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "fd7e4c4f-4c20-493f-9b3b-5ea7b98dfe7d",
+			"id": "a0e77a74-26b7-4b89-92ca-13df4ca1c264",
 			"key": "schema_loccamp",
 			"value": "loccamp.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "3fcde8cd-8a17-470b-87d5-7ead3d495f92",
+			"id": "f7997f90-9e67-4988-82f6-0ae75db028ab",
 			"key": "schema_loclibs",
 			"value": "loclibs.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "fe9fd98a-6169-4ec0-b980-22a6e36e3aa3",
+			"id": "7fc3f759-7012-4afe-8543-83fc4ee33d09",
 			"key": "schema_loclib",
 			"value": "loclib.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "9cd39860-e3f7-4f74-85f7-2d4451a21c80",
+			"id": "c986301c-29a0-432d-a8d8-0afb27408ddf",
 			"key": "schema_error",
 			"value": "error.schema",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "05e12264-f3fd-4e84-a710-1750ff70f5a4",
+			"id": "5d1714bf-963c-4361-880a-d2d795a2bed4",
 			"key": "schema_errors",
 			"value": "errors.schema",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "ad391f9c-d473-4ab3-a4ea-1ef366f18c59",
+			"id": "d0dd0389-b28a-405c-9c87-18c50265f9e5",
 			"key": "schema_parameters",
 			"value": "parameters.schema",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "2327219f-227c-4f2f-8445-309f3ed634dd",
+			"id": "597a896a-df4d-4027-824d-a27360721934",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
-			"type": "string",
-			"description": ""
+			"type": "string"
+		},
+		{
+			"id": "30b31e97-0caf-4705-8547-1358c8033e12",
+			"key": "schema_service_points",
+			"value": "servicepoints.json",
+			"type": "string"
+		},
+		{
+			"id": "3e120051-cca9-4dbd-b07b-8e6a322353b4",
+			"key": "schema_service_point",
+			"value": "servicepoint.json",
+			"type": "string"
 		}
 	]
 }

--- a/mod-inventory-storage/mod-inventory-storage-location.postman_collection.json
+++ b/mod-inventory-storage/mod-inventory-storage-location.postman_collection.json
@@ -687,6 +687,95 @@
 						"description": "Set okapi-token header to be used by following tests."
 					},
 					"response": []
+				},
+				{
+					"name": "/service-points 201",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "51e56114-b15a-46d4-9f32-bb5f86e2ef3a",
+								"exec": [
+									"const jsonData = JSON.parse(responseBody);",
+									"console.log(\"id\" + jsonData.id);",
+									"",
+									"pm.environment.set(\"testservicepointid\", jsonData.id);",
+									"",
+									"pm.test(\"Status code is OK\", function () {",
+									"    pm.response.to.have.status(201);",
+									"    pm.response.to.have.jsonBody();",
+									"    ",
+									"});   ",
+									"    ",
+									"pm.test(\"Response contains correct data\", function () {    ",
+									"    pm.response.to.have.jsonBody(\"id\", jsonData.id);",
+									"    pm.response.to.have.jsonBody(\"name\", pm.environment.get(\"testservicepointname\"));",
+									"    pm.response.to.have.jsonBody(\"code\", pm.environment.get(\"testservicepointcode\"));",
+									"    pm.response.to.have.jsonBody(\"discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
+									"});  ",
+									"",
+									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+									"});",
+									"",
+									"pm.test(\"'Location' header is present\", function () {",
+									"    pm.response.to.have.header(\"location\");",
+									"    pm.response.to.have.header(\"location\", \"/service-points/\" + jsonData.id)",
+									"});    ",
+									"    ",
+									"pm.test(\"Verify schema\", function () {    ",
+									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
+									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_point_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "c59d7b9c-931f-4316-9a71-b49cde0c4686",
+								"exec": [
+									"pm.environment.set(\"testservicepointname\", \"test service point\");",
+									"pm.environment.set(\"testservicepointcode\", \"TSP\");",
+									"pm.environment.set(\"testdiscoverydisplayname\", \"Test Service Point Discovery Name\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"service-points"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -6394,1795 +6483,6 @@
 			]
 		},
 		{
-			"name": "Happy path - /service-points",
-			"item": [
-				{
-					"name": "/service-points 200",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "0ac312d2-c505-41c6-9493-f047b4107a88",
-								"exec": [
-									"let jsonData = JSON.parse(responseBody);",
-									"",
-									"if(jsonData.servicepoints.length > 0){",
-									"   pm.environment.set(\"originalservicepointscount\", jsonData.totalRecords);",
-									"}",
-									"",
-									"pm.test(\"Returns status 200\", function () {",
-									"    pm.response.to.be.ok;",
-									"    pm.response.to.have.jsonBody();",
-									"});",
-									"",
-									"pm.test(\"Contains data\", function () {",
-									" pm.expect(jsonData.servicepoints.length > 0).to.be.true;",
-									"});",
-									"",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 201",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "51e56114-b15a-46d4-9f32-bb5f86e2ef3a",
-								"exec": [
-									"const jsonData = JSON.parse(responseBody);",
-									"console.log(\"id\" + jsonData.id);",
-									"",
-									"pm.environment.set(\"testservicepointid\", jsonData.id);",
-									"",
-									"pm.test(\"Status code is OK\", function () {",
-									"    pm.response.to.have.status(201);",
-									"    pm.response.to.have.jsonBody();",
-									"    ",
-									"});   ",
-									"    ",
-									"pm.test(\"Response contains correct data\", function () {    ",
-									"    pm.response.to.have.jsonBody(\"id\", jsonData.id);",
-									"    pm.response.to.have.jsonBody(\"name\", pm.environment.get(\"testservicepointname\"));",
-									"    pm.response.to.have.jsonBody(\"code\", pm.environment.get(\"testservicepointcode\"));",
-									"    pm.response.to.have.jsonBody(\"discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
-									"});  ",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									"",
-									"pm.test(\"'Location' header is present\", function () {",
-									"    pm.response.to.have.header(\"location\");",
-									"    pm.response.to.have.header(\"location\", \"/service-points/\" + jsonData.id)",
-									"});    ",
-									"    ",
-									"pm.test(\"Verify schema\", function () {    ",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_point_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "c59d7b9c-931f-4316-9a71-b49cde0c4686",
-								"exec": [
-									"pm.environment.set(\"testservicepointname\", \"test service point\");",
-									"pm.environment.set(\"testservicepointcode\", \"TSP\");",
-									"pm.environment.set(\"testdiscoverydisplayname\", \"Test Service Point Discovery Name\");"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 200",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "fe52b9b2-fc8c-496a-b4ba-d60d47f7581d",
-								"exec": [
-									"const jsonData = JSON.parse(responseBody);",
-									"",
-									"pm.test(\"Returns status 200\", function () {",
-									"    pm.response.to.be.ok;",
-									"    pm.response.to.have.jsonBody();",
-									" });",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_point_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									"",
-									"pm.test(\"Response contains correct data\", function () {    ",
-									"    pm.response.to.have.jsonBody(\"id\", pm.environment.get(\"testservicepointid\"));",
-									"    pm.response.to.have.jsonBody(\"name\", pm.environment.get(\"testservicepointname\"));",
-									"    pm.response.to.have.jsonBody(\"code\", pm.environment.get(\"testservicepointcode\"));",
-									"    pm.response.to.have.jsonBody(\"discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
-									"}); ",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"{{testservicepointid}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 200 -- query by name",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "1935b1ad-26ee-4b0c-8b4a-d39d06163d22",
-								"exec": [
-									"const jsonData = JSON.parse(responseBody);",
-									"",
-									"pm.test(\"Returns status 200\", function () {",
-									"    pm.response.to.be.ok;",
-									"    pm.response.to.have.jsonBody();",
-									" });",
-									"",
-									"",
-									"pm.test(\"Response contains correct data\", function () {    ",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].id\", pm.environment.get(\"testservicepointid\"));",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].name\", pm.environment.get(\"testservicepointname\"));",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].code\", pm.environment.get(\"testservicepointcode\"));",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
-									"}); ",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?query=(name=={{testservicepointname}})",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							],
-							"query": [
-								{
-									"key": "query",
-									"value": "(name=={{testservicepointname}})"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 200 -- query by code",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "5e9d1a17-d422-4c77-8d9a-636beb0dba79",
-								"exec": [
-									"const jsonData = JSON.parse(responseBody);",
-									"",
-									"pm.test(\"Returns status 200\", function () {",
-									"    pm.response.to.be.ok;",
-									"    pm.response.to.have.jsonBody();",
-									" });",
-									"",
-									"",
-									"pm.test(\"Response contains correct data\", function () {    ",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].id\", pm.environment.get(\"testservicepointid\"));",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].name\", pm.environment.get(\"testservicepointname\"));",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].code\", pm.environment.get(\"testservicepointcode\"));",
-									"    pm.response.to.have.jsonBody(\"servicepoints[0].discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
-									"}); ",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?query=(code=={{testservicepointcode}})",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							],
-							"query": [
-								{
-									"key": "query",
-									"value": "(code=={{testservicepointcode}})"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points?limit={{limit}}&offset=1 200",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "250579b6-88d1-4ef5-b10c-55e7b4d78e5e",
-								"exec": [
-									"const jsonData = JSON.parse(responseBody);",
-									"",
-									"pm.test(\"/service-points GET OK\", function () {",
-									"    pm.response.to.be.ok;",
-									"    pm.response.to.have.jsonBody();",
-									"});",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});   ",
-									"",
-									"pm.test(\"Returned correct number of records\", function () {",
-									"       pm.expect(jsonData.servicepoints.length == pm.environment.get(\"originalservicepointscount\")).to.be.true;",
-									"});",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "35c5c253-ec2c-4f52-844e-0e6e62af9292",
-								"exec": [
-									"let limit = pm.environment.get(\"originalservicepointscount\");",
-									"",
-									"if (limit === 0) {",
-									"    limit = 2;",
-									"} ",
-									"",
-									"pm.variables.set(\"limit\", limit);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?limit={{limit}}&offset=1",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": "{{limit}}"
-								},
-								{
-									"key": "offset",
-									"value": "1"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 200 -- query by non-existing code",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "695d4b17-2b97-4e34-9359-99edcb749106",
-								"exec": [
-									"const jsonData = JSON.parse(responseBody);",
-									"",
-									"pm.test(\"Returns status 200\", function () {",
-									"    pm.response.to.be.ok;",
-									"    pm.response.to.have.jsonBody();",
-									" });",
-									"",
-									"pm.test(\"No results found\", function() {",
-									"    pm.expect(jsonData.servicepoints.length).to.equal(0);",
-									"});",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    tv4.addSchema(\"servicepoint.json\", JSON.parse(pm.environment.get(\"schema_service_point_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_points_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?query=(code=foo)",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							],
-							"query": [
-								{
-									"key": "query",
-									"value": "(code=foo)"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 204",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "11e0eeda-4264-413f-be22-b6519994a27a",
-								"exec": [
-									"pm.test(\"Status code is 204\", function () {",
-									"    pm.response.to.have.status(\"No Content\");",
-									"});   ",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "b61e6f94-aa53-48e3-8580-88d3bee438ca",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{testservicepointid}}\",\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\",\n  \"description\": \"test\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"{{testservicepointid}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 200 - verify update",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "b726e9e1-15e0-4fd3-9f3f-503d4dd7278a",
-								"exec": [
-									"const jsonData = JSON.parse(responseBody);",
-									"",
-									"pm.test(\"Returns status 200\", function () {",
-									"    pm.response.to.be.ok;",
-									"    pm.response.to.have.jsonBody();",
-									" });",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(pm.variables.get(\"schema_metadata_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_service_point_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									"",
-									"pm.test(\"Response contains correct data\", function () {",
-									"    pm.response.to.have.jsonBody(\"id\", pm.environment.get(\"testservicepointid\"));",
-									"    pm.response.to.have.jsonBody(\"name\", pm.environment.get(\"testservicepointname\"));",
-									"    pm.response.to.have.jsonBody(\"code\", pm.environment.get(\"testservicepointcode\"));",
-									"    pm.response.to.have.jsonBody(\"discoveryDisplayName\", pm.environment.get(\"testdiscoverydisplayname\"));",
-									"    pm.response.to.have.jsonBody(\"description\", \"test\");",
-									"}); ",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "bac8c4f9-1a1f-4c62-8dba-6fd368a5243e",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"{{testservicepointid}}"
-							]
-						}
-					},
-					"response": []
-				}
-			],
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "6a66f184-ae55-457f-898a-fb849dc0071c",
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"id": "1460d85b-4fa7-4228-9488-69872e103009",
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				}
-			]
-		},
-		{
-			"name": "Negative tests - service-points",
-			"item": [
-				{
-					"name": "/service-points 403",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "cd09c669-305a-42a5-8eba-bb5d8617223e",
-								"exec": [
-									"pm.test(\"/service-points POST not OK without token\", function () {",
-									"    pm.response.to.have.status(403);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "1681e8da-8dd5-4e99-884b-02975459a972",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}\n"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 422  - missing required name field",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "12e4592d-fb73-4485-a3d5-8ee636ed582f",
-								"exec": [
-									"pm.test(\"/service-points POST not OK without required name field\", function () {",
-									"    pm.response.to.have.status(422);",
-									"    pm.response.json;",
-									"});",
-									"",
-									"pm.test(\"Correct error message returned\", function () {",
-									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"may not be null\");",
-									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"name\");",
-									"    ",
-									"});",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    let jsonData = pm.response.json();",
-									"    ",
-									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
-									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
-									"    if (schema_parameters.id) {",
-									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
-									"    }",
-									"    ",
-									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
-									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
-									"    if (schema_error.id) {",
-									"        tv4.addSchema(schema_error.id, schema_error);",
-									"    }",
-									"    ",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 422  - missing required code field",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "2ce774b3-be46-4abc-991f-1374d8db85bc",
-								"exec": [
-									"pm.test(\"/service-points POST not OK without required code field\", function () {",
-									"    pm.response.to.have.status(422);",
-									"    pm.response.json;",
-									"});",
-									"",
-									"pm.test(\"Correct error message returned\", function () {",
-									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"may not be null\");",
-									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"code\");",
-									"    ",
-									"});",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    let jsonData  = pm.response.json();",
-									"    ",
-									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
-									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
-									"    if (schema_parameters.id) {",
-									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
-									"    }",
-									"    ",
-									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
-									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
-									"    if (schema_error.id) {",
-									"        tv4.addSchema(schema_error.id, schema_error);",
-									"    }",
-									"    ",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 422  - missing required discoveryDisplayName field",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "5a9bc104-f4be-470d-9108-be03002d1448",
-								"exec": [
-									"pm.test(\"/service-points POST not OK without required discoveryDisplayName field\", function () {",
-									"    pm.response.to.have.status(422);",
-									"    pm.response.json;",
-									"});",
-									"",
-									"pm.test(\"Correct error message returned\", function () {",
-									"    pm.expect(pm.response.json().errors[0].message).to.equal(\"may not be null\");",
-									"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.equal(\"discoveryDisplayName\");",
-									"    ",
-									"});",
-									"",
-									"pm.test(\"Validate schema\", function () {",
-									"    let jsonData = pm.response.json();",
-									"    let schema_parameters = JSON.parse(pm.variables.get(\"schema_parameters_content\"));",
-									"    tv4.addSchema(pm.variables.get(\"schema_parameters\"), schema_parameters);",
-									"    if (schema_parameters.id) {",
-									"        tv4.addSchema(schema_parameters.id, schema_parameters);",
-									"    }",
-									"    ",
-									"    let schema_error = JSON.parse(pm.variables.get(\"schema_error_content\"));",
-									"    tv4.addSchema(pm.variables.get(\"schema_error\"), schema_error);",
-									"    if (schema_error.id) {",
-									"        tv4.addSchema(schema_error.id, schema_error);",
-									"    }",
-									"    ",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_errors_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eaa85812-a2b4-4073-a699-40c2c19d0a9d",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 400 No payload",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "c2d75f84-abdd-4d1f-ae0d-98959ef42edf",
-								"exec": [
-									"pm.test(\"/service-points POST returns 400 without request payload\", function () {",
-									"    pm.response.to.have.status(400);",
-									"    pm.response.to.be.clientError;",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "ec7e42ca-d200-4851-940e-deb7952d8da4",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 400 Not well formed JSON payload",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "fd0c3f3c-9ca5-4469-b380-0e7c6b436f6a",
-								"exec": [
-									"pm.test(\"/service-points POST returns 400 with not well formed JSON payload\", function () {",
-									"    pm.response.to.have.status(400);",
-									"    pm.response.to.be.clientError;",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "0284f909-befc-4c76-9bb1-7ae350f06365",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "\"name\""
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 400 - limit  -1",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "35539344-e4fe-4b0a-b1a1-9749f94ccbec",
-								"exec": [
-									"pm.test(\"Returns status 400 when limit -1\", function () {",
-									"    // pm.response.to.have.status(\"Bad Request\");",
-									"    pm.response.to.have.status(500); // See https://issues.folio.org/browse/MODINVSTOR-211",
-									"    pm.response.to.have.body;",
-									"});",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "d4e24c44-537a-4f1a-85ef-368898375f74",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?limit=-1",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": "-1"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 400 - limit  exeeds max int value",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "20adaa64-17f8-439e-a183-4df49ab6c44a",
-								"exec": [
-									"pm.test(\"Returns status 400 when limit exeeds max value for integer\", function () {",
-									"    pm.response.to.have.status(\"Bad Request\");",
-									"    pm.response.to.have.body;",
-									"});",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "d4e24c44-537a-4f1a-85ef-368898375f74",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points?limit=2147483648",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": "2147483648"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 403 With tenant but no token",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "0c6a5e63-9c58-43d3-9b45-0f76ee016e44",
-								"exec": [
-									"pm.test(\"/service-points GET returns 403 without token\", function () {",
-									"    pm.response.to.have.status(403);",
-									"});",
-									"",
-									"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
-									"    pm.response.to.have.header(\"X-Okapi-Trace\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "x-okapi-tenant",
-								"value": "{{xokapitenant}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points 403 No tenant and no token",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "390653f0-11e4-45e4-ac6d-d8169dd26470",
-								"exec": [
-									"pm.test(\"/service-points GET returns 403 without token\", function () {",
-									"    pm.response.to.have.status(403);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 403",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "b57d51c3-ed85-4c4c-91c8-d2f3cdadca36",
-								"exec": [
-									"pm.test(\"/service-points GET not OK without token\", function () {",
-									"    pm.response.to.have.status(403);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "0df983f4-f9f0-4a9b-95ea-83eb71b5dc99",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{testservicepointid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"{{testservicepointid}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 404",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "49c93149-94b1-4011-8c9d-8c5d037edc9a",
-								"exec": [
-									"pm.test(\"/service-points GET not OK for non-existing id\", function () {",
-									"    pm.response.to.have.status(404);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "0df983f4-f9f0-4a9b-95ea-83eb71b5dc99",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": \"{{test_id}}\",\n  \"name\": \"{{test_val}}\"\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{$guid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"{{$guid}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 403",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "9e0f01eb-1b35-424d-9279-7a04c482b2fa",
-								"exec": [
-									"pm.test(\"/service-points/{id} PUT not OK without token\", function () {",
-									"    pm.response.to.have.status(403);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "ad106953-c49e-4848-8bb4-114af0cd2ce2",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\",\n  \"pickupLocation\": true\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{$guid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"{{$guid}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/foo 404",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "98a01d7f-e81c-4ae1-95c6-e445e9f1bcba",
-								"exec": [
-									"pm.test(\"/service-points/{id} PUT not OK for non-existing id\", function () {",
-									"    pm.response.to.have.status(404);",
-									"});",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "51aa7ff2-5b02-4e88-a346-dc3d99619ba8",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"{{testservicepointname}}\",\n  \"code\": \"{{testservicepointcode}}\",\n  \"discoveryDisplayName\": \"{{testdiscoverydisplayname}}\",\n  \"pickupLocation\": true\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/foo",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"foo"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 403",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "75deb0cb-a138-43e4-98e9-cd9be1317ff7",
-								"exec": [
-									"pm.test(\"/service-points/{id} DELETE not OK without token\", function () {",
-									"    pm.response.to.have.status(403);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "x-okapi-tenant",
-								"value": "{{xokapitenant}}",
-								"disabled": true
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points/{{$guid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"service-points",
-								"{{$guid}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/service-points/{id} 404",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "82f012e9-9223-4b89-8e58-a9eb734bfac9",
-								"type": "text/javascript",
-								"exec": [
-									"pm.test(\"/locations/{id} DELETE not OK for non-existing id\", function () {",
-									"    // TODO: https://issues.folio.org/browse/MODINVSTOR-81",
-									"    // pm.response.to.have.status(404);",
-									"    pm.response.to.have.status(204);",
-									"});",
-									""
-								]
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "38e74085-008d-495a-bf3b-1ca88cb06290",
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations/{{$guid}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"locations",
-								"{{$guid}}"
-							]
-						}
-					},
-					"response": []
-				}
-			],
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "dafb86aa-c382-41dc-8592-d9e30798ab68",
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"id": "01a30f26-acb9-4982-a304-90fd3715fd73",
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				}
-			]
-		},
-		{
 			"name": "Happy path - locations",
 			"item": [
 				{
@@ -11719,103 +10019,103 @@
 	],
 	"variable": [
 		{
-			"id": "9978b782-3761-43ac-a06b-64ef4e983e8b",
+			"id": "5fd4b6ab-02c2-4279-ae92-6983fdcc1c64",
 			"key": "mod_name",
 			"value": "mod-inventory-storage",
 			"type": "string"
 		},
 		{
-			"id": "4a2a4741-af6c-47f5-bd1e-6cb016c0b60d",
+			"id": "11f68331-5239-436e-8eec-54d4113d154a",
 			"key": "mod_version",
 			"value": "v13.0.1",
 			"type": "string"
 		},
 		{
-			"id": "910a6eba-219f-4445-9ae6-2c76a9099587",
+			"id": "ca0cfd56-7b0a-401e-b9e1-41f2af684b38",
 			"key": "schema_location",
 			"value": "location.json",
 			"type": "string"
 		},
 		{
-			"id": "744848d8-5f23-408f-a61c-48a988e98f0e",
+			"id": "178a3cf3-e0eb-4822-bd31-23d25baa521c",
 			"key": "schema_locations",
 			"value": "locations.json",
 			"type": "string"
 		},
 		{
-			"id": "49861076-a7fc-449b-a82a-50c743586379",
+			"id": "87567f7c-6a6c-4113-ac3b-75527ad1d3ab",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org",
 			"type": "string"
 		},
 		{
-			"id": "3558767c-fd7f-4c65-98fb-db2f1ffaae0a",
+			"id": "d1dd6435-034b-4fb4-8399-21e7cc318562",
 			"key": "schema_locinsts",
 			"value": "locinsts.json",
 			"type": "string"
 		},
 		{
-			"id": "ed417312-a31c-443c-9daa-b2b5b8b06389",
+			"id": "db005476-8b93-40af-8a21-5c42ae8744df",
 			"key": "schema_locinst",
 			"value": "locinst.json",
 			"type": "string"
 		},
 		{
-			"id": "f324db10-fcf5-457e-bef2-d1b8a0f40e06",
+			"id": "9c09d86d-16eb-4d0a-a649-033fc56a6887",
 			"key": "schema_loccamps",
 			"value": "loccamps.json",
 			"type": "string"
 		},
 		{
-			"id": "a0e77a74-26b7-4b89-92ca-13df4ca1c264",
+			"id": "0b2c5113-5a76-43c1-8ed7-a88d6a26b006",
 			"key": "schema_loccamp",
 			"value": "loccamp.json",
 			"type": "string"
 		},
 		{
-			"id": "f7997f90-9e67-4988-82f6-0ae75db028ab",
+			"id": "7eb98e1e-efd6-4a23-aa60-a81e802f22df",
 			"key": "schema_loclibs",
 			"value": "loclibs.json",
 			"type": "string"
 		},
 		{
-			"id": "7fc3f759-7012-4afe-8543-83fc4ee33d09",
+			"id": "8fc09cd3-fe78-4696-a23e-5e4fd96de8d7",
 			"key": "schema_loclib",
 			"value": "loclib.json",
 			"type": "string"
 		},
 		{
-			"id": "c986301c-29a0-432d-a8d8-0afb27408ddf",
+			"id": "1a86113b-b96d-4142-b1b5-dfac7506d8f5",
 			"key": "schema_error",
 			"value": "error.schema",
 			"type": "string"
 		},
 		{
-			"id": "5d1714bf-963c-4361-880a-d2d795a2bed4",
+			"id": "eb865c90-29e1-4121-90f5-b23857ff214c",
 			"key": "schema_errors",
 			"value": "errors.schema",
 			"type": "string"
 		},
 		{
-			"id": "d0dd0389-b28a-405c-9c87-18c50265f9e5",
+			"id": "5af88352-1e64-4eb4-9614-afb2a1ffad25",
 			"key": "schema_parameters",
 			"value": "parameters.schema",
 			"type": "string"
 		},
 		{
-			"id": "597a896a-df4d-4027-824d-a27360721934",
+			"id": "649f8abc-1e64-4fa4-b769-5ca490932ecb",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "30b31e97-0caf-4705-8547-1358c8033e12",
+			"id": "d01d5e19-c924-46b2-ab88-b25845c4c2b6",
 			"key": "schema_service_points",
 			"value": "servicepoints.json",
 			"type": "string"
 		},
 		{
-			"id": "3e120051-cca9-4dbd-b07b-8e6a322353b4",
+			"id": "59d7638f-a6d4-4e92-8286-a06c704107e0",
 			"key": "schema_service_point",
 			"value": "servicepoint.json",
 			"type": "string"

--- a/mod-inventory-storage/mod-inventory-storage-location.postman_collection.json
+++ b/mod-inventory-storage/mod-inventory-storage-location.postman_collection.json
@@ -19,7 +19,6 @@
 									"listen": "test",
 									"script": {
 										"id": "ad455e26-7dc6-4d08-a023-8910e4368b53",
-										"type": "text/javascript",
 										"exec": [
 											"pm.test(\"GET schema_parameters OK\", function () {",
 											"    pm.response.to.be.ok;",
@@ -30,7 +29,8 @@
 											"});",
 											"",
 											"pm.environment.set(\"schema_parameters_content\", responseBody);"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -42,13 +42,13 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/raml/master/schemas/{{schema_parameters}}",
+									"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_parameters}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"raml",
-										"master",
+										"{{raml_version}}",
 										"schemas",
 										"{{schema_parameters}}"
 									]
@@ -63,7 +63,6 @@
 									"listen": "test",
 									"script": {
 										"id": "5e952041-5ba6-4602-8b63-0549e94a6a4f",
-										"type": "text/javascript",
 										"exec": [
 											"pm.test(\"GET schema_error OK\", function () {",
 											"    pm.response.to.be.ok;",
@@ -74,7 +73,8 @@
 											"});",
 											"",
 											"pm.environment.set(\"schema_error_content\", responseBody);"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -86,13 +86,13 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/raml/master/schemas/{{schema_error}}",
+									"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_error}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"raml",
-										"master",
+										"{{raml_version}}",
 										"schemas",
 										"{{schema_error}}"
 									]
@@ -107,7 +107,6 @@
 									"listen": "test",
 									"script": {
 										"id": "f708b061-026b-44d6-92ba-dff26a1b6a94",
-										"type": "text/javascript",
 										"exec": [
 											"pm.test(\"Response OK\", function () {",
 											"    pm.response.to.be.ok;",
@@ -118,7 +117,8 @@
 											"});",
 											"",
 											"pm.environment.set(\"schema_errors_content\", responseBody);"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -130,13 +130,13 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/raml/master/schemas/{{schema_errors}}",
+									"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_errors}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"raml",
-										"master",
+										"{{raml_version}}",
 										"schemas",
 										"{{schema_errors}}"
 									]
@@ -151,7 +151,6 @@
 									"listen": "test",
 									"script": {
 										"id": "105282cc-4e6f-48e8-982e-d7134cac2578",
-										"type": "text/javascript",
 										"exec": [
 											"pm.test(\"GET schema_metadata OK\", function () {",
 											"    pm.response.to.be.ok;",
@@ -162,7 +161,8 @@
 											"});",
 											"",
 											"pm.environment.set(\"schema_metadata_content\", responseBody);"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -174,13 +174,13 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/raml/master/schemas/{{schema_metadata}}",
+									"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_metadata}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"raml",
-										"master",
+										"{{raml_version}}",
 										"schemas",
 										"{{schema_metadata}}"
 									]
@@ -10019,103 +10019,109 @@
 	],
 	"variable": [
 		{
-			"id": "5fd4b6ab-02c2-4279-ae92-6983fdcc1c64",
+			"id": "34888741-85cf-420d-b669-d0edcfd7f90e",
 			"key": "mod_name",
 			"value": "mod-inventory-storage",
 			"type": "string"
 		},
 		{
-			"id": "11f68331-5239-436e-8eec-54d4113d154a",
+			"id": "81c7424c-72c9-4c42-8a75-2e17d3b5b955",
 			"key": "mod_version",
 			"value": "v13.0.1",
 			"type": "string"
 		},
 		{
-			"id": "ca0cfd56-7b0a-401e-b9e1-41f2af684b38",
-			"key": "schema_location",
-			"value": "location.json",
+			"id": "c6c51813-d987-4d54-99ba-c1c6347d46c7",
+			"key": "raml_version",
+			"value": "bf5b23978b71776c59eca1fd6b33c7fb315b0f2a",
 			"type": "string"
 		},
 		{
-			"id": "178a3cf3-e0eb-4822-bd31-23d25baa521c",
-			"key": "schema_locations",
-			"value": "locations.json",
-			"type": "string"
-		},
-		{
-			"id": "87567f7c-6a6c-4113-ac3b-75527ad1d3ab",
+			"id": "b979f3e4-d0af-4064-92a7-89d46a2eaf1f",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org",
 			"type": "string"
 		},
 		{
-			"id": "d1dd6435-034b-4fb4-8399-21e7cc318562",
+			"id": "3a16e5be-55aa-440c-93e1-f3d4343ce9c5",
+			"key": "schema_location",
+			"value": "location.json",
+			"type": "string"
+		},
+		{
+			"id": "7cc22871-9078-4045-8345-7f97255a457b",
+			"key": "schema_locations",
+			"value": "locations.json",
+			"type": "string"
+		},
+		{
+			"id": "98ece27e-df4e-4a25-be80-be8df10a50d5",
 			"key": "schema_locinsts",
 			"value": "locinsts.json",
 			"type": "string"
 		},
 		{
-			"id": "db005476-8b93-40af-8a21-5c42ae8744df",
+			"id": "6f61582c-c0f0-45f6-8fb8-e463609e06c3",
 			"key": "schema_locinst",
 			"value": "locinst.json",
 			"type": "string"
 		},
 		{
-			"id": "9c09d86d-16eb-4d0a-a649-033fc56a6887",
+			"id": "6f9f0ab2-678f-4b45-ad74-8ada660c0487",
 			"key": "schema_loccamps",
 			"value": "loccamps.json",
 			"type": "string"
 		},
 		{
-			"id": "0b2c5113-5a76-43c1-8ed7-a88d6a26b006",
+			"id": "5db802d3-4d50-4d05-bf55-fe84eb941178",
 			"key": "schema_loccamp",
 			"value": "loccamp.json",
 			"type": "string"
 		},
 		{
-			"id": "7eb98e1e-efd6-4a23-aa60-a81e802f22df",
+			"id": "43f9267c-494c-4e08-ba27-995c10502d19",
 			"key": "schema_loclibs",
 			"value": "loclibs.json",
 			"type": "string"
 		},
 		{
-			"id": "8fc09cd3-fe78-4696-a23e-5e4fd96de8d7",
+			"id": "bc4c9df1-30da-4066-b85e-5306d5519c7a",
 			"key": "schema_loclib",
 			"value": "loclib.json",
 			"type": "string"
 		},
 		{
-			"id": "1a86113b-b96d-4142-b1b5-dfac7506d8f5",
+			"id": "bb18ecae-4c2b-4dc5-b454-e2f9cb99c043",
 			"key": "schema_error",
 			"value": "error.schema",
 			"type": "string"
 		},
 		{
-			"id": "eb865c90-29e1-4121-90f5-b23857ff214c",
+			"id": "f49e2fde-b3f5-4e54-97e9-242e5b5bafad",
 			"key": "schema_errors",
 			"value": "errors.schema",
 			"type": "string"
 		},
 		{
-			"id": "5af88352-1e64-4eb4-9614-afb2a1ffad25",
+			"id": "2666668e-3604-418e-94fd-779b85b7f5ae",
 			"key": "schema_parameters",
 			"value": "parameters.schema",
 			"type": "string"
 		},
 		{
-			"id": "649f8abc-1e64-4fa4-b769-5ca490932ecb",
+			"id": "f119b4ca-dcba-4a96-94ab-0adaf99170af",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "d01d5e19-c924-46b2-ab88-b25845c4c2b6",
+			"id": "da41d8e3-fbfb-4686-9dd2-0d1292e38cc1",
 			"key": "schema_service_points",
 			"value": "servicepoints.json",
 			"type": "string"
 		},
 		{
-			"id": "59d7638f-a6d4-4e92-8286-a06c704107e0",
+			"id": "a28ae56e-bde4-4466-aa30-be5c804cd8b6",
 			"key": "schema_service_point",
 			"value": "servicepoint.json",
 			"type": "string"


### PR DESCRIPTION
The locations managed by this API require a new property, `primaryServicePoint`. However, there is a runtime dependency on the new `servicePointIds` array to contain the `primaryServicePoint`, so these needed to be added when using the locations API.

Also added `/service-points` API tests in order to have a service point for the locations API to use.