### PR TITLE
Adjust mod-login tests per schema changes

### DIFF
--- a/mod-login/mod-login.postman_collection.json
+++ b/mod-login/mod-login.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a2da29b2-814b-431f-b6c4-5eb2c4553d3e",
+		"_postman_id": "8acbc603-0ad5-4b7c-b1f8-2f2e06bcceb7",
 		"name": "mod-login",
 		"description": "Tests for mod-login",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -8,11 +8,9 @@
 	"item": [
 		{
 			"name": "authn",
-			"description": null,
 			"item": [
 				{
 					"name": "login",
-					"description": null,
 					"item": [
 						{
 							"name": "/authn/login - 201",
@@ -624,20 +622,20 @@
 							"response": []
 						},
 						{
-							"name": "/authn/login - 403 (no tenant header)",
+							"name": "/authn/login - 400 (no tenant header)",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "f89eb7a6-cb3f-400a-9795-b8b38ed9e40d",
-										"type": "text/javascript",
 										"exec": [
-											"pm.test(\"403 test - no tenant header\", function() {",
-											"    pm.response.to.have.status(403);",
+											"pm.test(\"400 test - no tenant header\", function() {",
+											"    pm.response.to.have.status(400);",
 											"    pm.response.to.have.body();",
 											"});",
 											""
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -674,7 +672,6 @@
 				},
 				{
 					"name": "credentials",
-					"description": "Tests for the /authn/credentials endpoint.",
 					"item": [
 						{
 							"name": "/authn/credentials - 200",
@@ -2865,7 +2862,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"id\": \"{{authnCredentialsUUID}}\",\n\t\"name\": \"Test credentials - modified: {{authnCredentialsUUID}}\"\n}"
+									"raw": ""
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials/{{authnCredentialsUUID}}",
@@ -2930,7 +2927,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"id\": \"{{authnCredentialsUUID}}\",\n\t\"name\": \"Test credentials - modified: {{authnCredentialsUUID}}\"\n}"
+									"raw": ""
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials/{{authnCredentialsUUID}}",
@@ -3162,7 +3159,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"id\": \"{{authnCredentialsUUID}}\",\n\t\"name\": \"Test credentials - modified: {{authnCredentialsUUID}}\"\n}"
+									"raw": ""
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials/{{authnCredentialsUUID}}",
@@ -3226,7 +3223,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"id\": \"{{authnCredentialsUUID}}\",\n\t\"name\": \"Test credentials - modified: {{authnCredentialsUUID}}\"\n}"
+									"raw": ""
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials/12345",
@@ -3892,7 +3889,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"id\": \"{{authnCredentialsUUID}}\",\n\t\"name\": \"Test credentials - modified: {{authnCredentialsUUID}}\"\n}"
+									"raw": ""
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials/{{authnCredentialsUUID}}",
@@ -4536,7 +4533,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"id\": \"{{authnCredentialsUUID}}\",\n\t\"name\": \"Test credentials - modified: {{authnCredentialsUUID}}\"\n}"
+									"raw": ""
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials/{{authnCredentialsUUID}}",
@@ -4708,6 +4705,7 @@
 							"response": []
 						}
 					],
+					"description": "Tests for the /authn/credentials endpoint.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -4835,22 +4833,19 @@
 			"id": "da0c59f7-a611-41f2-977b-1b410a8ebebf",
 			"key": "mod-login_version",
 			"value": "master",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
 			"id": "33cc0337-a7dc-43db-9236-4e4c91b26ab1",
 			"key": "raml-utils_version",
 			"value": "37a7aa3776f17dfcc636b3ef6bbc9fbaf49cfdca",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
 			"id": "20e7f417-2910-4365-903b-f06d45ea1d73",
 			"key": "retrieveSchemaFunction",
 			"value": "var retrieveSchema = function(schemaName, cb) {\n    pm.sendRequest({\n        url: \"https://raw.githubusercontent.com/folio-org/mod-login/\" + pm.variables.get(\"mod-login_version\") + \"/ramls/\" + schemaName,\n        method: 'GET',\n    }, function(err, res) {\n        if (err !== null) {\n            console.log(\"Schema retrieval error: \" + err);\n            cb(\"failed\", null);\n        } else {\n            if (res.code === 200) {\n                cb(null, res.json());\n            } else {\n                console.log(\"Schema retrieval falied: \" + res.reason());\n            cb(\"failed\", null);\n            }\n        }\n    });\n};\n\nvar retrieveRAMLUtilsSchema = function(schemaName, cb) {\n    pm.sendRequest({\n        url: \"https://raw.githubusercontent.com/folio-org/raml/\" + pm.variables.get(\"raml-utils_version\") + \"/schemas/\" + schemaName,\n        method: 'GET',\n    }, function(err, res) {\n        if (err !== null) {\n            console.log(\"Schema retrieval error: \" + err);\n            cb(\"failed\", null);\n        } else {\n            if (res.code === 200) {\n                cb(null, res.json());\n            } else {\n                console.log(\"Schema retrieval falied: \" + res.reason());\n            cb(\"failed\", null);\n            }\n        }\n    });\n};",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		}
 	]
 }


### PR DESCRIPTION
mod-login module build is failing in our devQA Jenkins due to a failing test. Test is for a POST request to /authn/login without a tenant header which probably was returning 403 status at some point which has now been changed to return a 400 status code. 
Per https://s3.amazonaws.com/foliodocs/api/mod-login/login.html#authn_login_post, we do not see a 403 mentioned and if we tweak the tests to expect a 400 response, all tests pass. This PR addresses that change.