### PR TITLE
Adjust mod-users tests to get schemas from RAML0.8 branch

### DIFF
--- a/mod-users/mod-users.postman_collection.json
+++ b/mod-users/mod-users.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b80f7021-1536-4531-bf85-aceca3d26659",
+		"_postman_id": "bd6976dc-10ee-4be9-a7e6-972fb366baee",
 		"name": "mod-users",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -15,7 +15,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5e952041-5ba6-4602-8b63-0549e94a6a4f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_error OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -26,7 +25,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_error_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -38,14 +38,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_error}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_error}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_error}}"
 							]
 						}
@@ -59,7 +57,6 @@
 							"listen": "test",
 							"script": {
 								"id": "f708b061-026b-44d6-92ba-dff26a1b6a94",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -70,7 +67,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_errors_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -82,14 +80,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_errors}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_errors}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_errors}}"
 							]
 						}
@@ -103,7 +99,6 @@
 							"listen": "test",
 							"script": {
 								"id": "105282cc-4e6f-48e8-982e-d7134cac2578",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_metadata OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -114,7 +109,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_metadata_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -126,14 +122,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_metadata}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_metadata}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_metadata}}"
 							]
 						}
@@ -147,7 +141,6 @@
 							"listen": "test",
 							"script": {
 								"id": "7d1f6195-4630-415d-9eed-56d38033d5aa",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_metadata OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -158,7 +151,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_resultInfo_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -170,14 +164,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_resultInfo}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_resultInfo}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_resultInfo}}"
 							]
 						}
@@ -191,7 +183,6 @@
 							"listen": "test",
 							"script": {
 								"id": "779af7ea-1e68-4a3f-84f2-d26fa3f39b90",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_metadata OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -202,7 +193,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_tags_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -214,14 +206,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_tags}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_tags}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_tags}}"
 							]
 						}
@@ -235,7 +225,6 @@
 							"listen": "test",
 							"script": {
 								"id": "ad455e26-7dc6-4d08-a023-8910e4368b53",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_parameters OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -246,7 +235,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_parameters_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -258,14 +248,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_parameters}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_parameters}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_parameters}}"
 							]
 						}
@@ -279,7 +267,6 @@
 							"listen": "test",
 							"script": {
 								"id": "0403a5ee-5278-4de2-8071-449f0138b3ec",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -290,7 +277,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_addresstype_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -302,14 +290,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_addresstype}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_addresstype}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_addresstype}}"
 							]
@@ -324,7 +310,6 @@
 							"listen": "test",
 							"script": {
 								"id": "956effde-7569-4722-9955-308630b087ff",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -335,7 +320,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_addresstypeCollection_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -347,14 +333,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_addresstypeCollection}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_addresstypeCollection}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_addresstypeCollection}}"
 							]
@@ -369,7 +353,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5135711b-4235-464c-8bbe-d2f4eec7e2b4",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -380,7 +363,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_proxyfor_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -392,14 +376,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_proxyfor}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_proxyfor}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_proxyfor}}"
 							]
@@ -414,7 +396,6 @@
 							"listen": "test",
 							"script": {
 								"id": "0a5e3c62-9ec5-49b7-be97-8906a9cbf9b9",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -425,7 +406,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_proxyforCollection_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -437,14 +419,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_proxyforCollection}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_proxyforCollection}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_proxyforCollection}}"
 							]
@@ -459,7 +439,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5c5dcbea-474a-484f-bcbc-e2e7a02fc5c5",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -470,7 +449,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_userdata_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -482,14 +462,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_userdata}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_userdata}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_userdata}}"
 							]
@@ -504,7 +482,6 @@
 							"listen": "test",
 							"script": {
 								"id": "49a442fd-5ff6-4c8e-9c9c-3ac6891ceac7",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -515,7 +492,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_userdataCollection_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -527,14 +505,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_userdataCollection}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_userdataCollection}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_userdataCollection}}"
 							]
@@ -549,7 +525,6 @@
 							"listen": "test",
 							"script": {
 								"id": "1b213ce4-b91d-44ef-80ed-016ede0d6957",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -560,7 +535,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_usergroups_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -572,14 +548,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_usergroups}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_usergroups}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_usergroups}}"
 							]
@@ -594,7 +568,6 @@
 							"listen": "test",
 							"script": {
 								"id": "d58bf639-34cc-4058-840a-2dbf37c8c1d8",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -605,7 +578,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_usergroup_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -617,14 +591,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_usergroup}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_usergroup}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_usergroup}}"
 							]
@@ -5563,7 +5535,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"username\": \"modusertest\",\r\n  \"id\": \"f3007520-7777-4b4f-b0bf-dd56a426b21e\",\r\n  \"active\": true,\r\n  \"type\": \"patron\",\r\n  \"patronGroup\": \"0966d02b-d551-4a4d-93f9-5dc491ededa7\",\r\n  \"meta\": {\r\n    \"creation_date\": \"2017-10-05T0723\",\r\n    \"last_login_date\": \"\"\r\n  },\r\n  \"personal\": {\r\n    \"lastName\": \"Kosciuszko\",\r\n    \"firstName\": \"Tadeusz\",\r\n    \"email\": \"tkosciuszko@bj.org\",\r\n    \"phone\": \"2125551212\"\r\n  }\r\n}"
+							"raw": ""
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/foo",
@@ -5899,105 +5871,111 @@
 	],
 	"variable": [
 		{
-			"id": "839b3479-3263-4fcb-8fe5-da43038e148b",
+			"id": "3c1602c3-e4c1-4be9-80fe-b4a2fb2d7648",
 			"key": "mod_name",
 			"value": "mod-users",
 			"type": "string"
 		},
 		{
-			"id": "3cdb21e9-3c25-4fc3-a393-02df96924ab9",
+			"id": "5088d0ab-61c8-47d1-84ae-351f025381e5",
 			"key": "mod_version",
 			"value": "v14.2.0",
 			"type": "string"
 		},
 		{
-			"id": "83dd0ca9-20de-47ab-9d0a-dd3066a0c5db",
+			"id": "6e78e765-3363-45b9-bb09-20bd01dff835",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org",
 			"type": "string"
 		},
 		{
-			"id": "5ab6d83e-8a67-4bb4-a609-49df91939800",
+			"id": "9a818c62-5c77-452a-a933-817edbc07625",
 			"key": "schema_error",
 			"value": "error.schema",
 			"type": "string"
 		},
 		{
-			"id": "43fd46b0-631f-4019-bca9-7a436eb4bc76",
+			"id": "4b180627-8c53-410f-a4dc-242565431e92",
 			"key": "schema_errors",
 			"value": "errors.schema",
 			"type": "string"
 		},
 		{
-			"id": "075fef3d-65e3-4e8b-a5f3-8c405720342a",
+			"id": "bbad464d-77a0-4b67-9e83-4d70a9a5d68c",
 			"key": "schema_parameters",
 			"value": "parameters.schema",
 			"type": "string"
 		},
 		{
-			"id": "101ff526-b441-4c0a-9826-9475ab525239",
+			"id": "b48acd7b-a959-4117-8663-146a0ad16585",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "99b1b689-e2cc-4019-a92e-c787dadc8a91",
+			"id": "9b1f8764-0cd8-43b0-9fe7-a4b6cef31802",
 			"key": "schema_resultInfo",
 			"value": "resultInfo.schema",
 			"type": "string"
 		},
 		{
-			"id": "f4318c96-5b5f-47cd-b343-80ee7dc14a50",
+			"id": "eebcd4de-fee2-4976-aa9e-7c342eefbb04",
 			"key": "schema_tags",
 			"value": "tags.schema",
 			"type": "string"
 		},
 		{
-			"id": "c134d27e-f0ef-436c-80e4-3fda5333f482",
+			"id": "551dae2b-f616-4361-bfba-8195c4432bec",
 			"key": "schema_addresstype",
 			"value": "addresstype.json",
 			"type": "string"
 		},
 		{
-			"id": "3678e61f-3321-428d-a07d-28d93f69f303",
+			"id": "c43969bd-1ce3-4af3-a2bb-d8744edeffb5",
 			"key": "schema_addresstypeCollection",
 			"value": "addresstypeCollection.json",
 			"type": "string"
 		},
 		{
-			"id": "4e7e7432-4701-4418-8d5b-348dca42edb9",
+			"id": "22e6f094-16af-4009-865e-103870a70b8c",
 			"key": "schema_proxyfor",
 			"value": "proxyfor.json",
 			"type": "string"
 		},
 		{
-			"id": "90dcfa2f-b0e1-4d2c-b162-c8575becdbba",
+			"id": "aa4d1307-8b65-4f55-b33c-7f69b029a40a",
 			"key": "schema_proxyforCollection",
 			"value": "proxyforCollection.json",
 			"type": "string"
 		},
 		{
-			"id": "0dbde1b5-bbec-461a-8b29-bf47e9b51f56",
+			"id": "32c781bd-70ce-4d16-a331-9f3289df6b02",
 			"key": "schema_userdata",
 			"value": "userdata.json",
 			"type": "string"
 		},
 		{
-			"id": "3b1fd3e6-c2c8-4baf-b9d7-da0e52a49f8a",
+			"id": "f868c06f-1642-4d7f-93e2-1431ff4138ad",
 			"key": "schema_userdataCollection",
 			"value": "userdataCollection.json",
 			"type": "string"
 		},
 		{
-			"id": "c814a0ea-bfed-4eda-83a7-f82852e4ad82",
+			"id": "a435674c-5095-4d07-a102-185d4321f3ad",
 			"key": "schema_usergroup",
 			"value": "usergroup.json",
 			"type": "string"
 		},
 		{
-			"id": "2cf56cfd-3e1c-4704-90e5-5baa33b5b2de",
+			"id": "f7da3dc8-a8ab-4950-ab6b-ba09668a4ee1",
 			"key": "schema_usergroups",
 			"value": "usergroups.json",
+			"type": "string"
+		},
+		{
+			"id": "29d3df68-032b-4b77-b5cf-ee91bc688a45",
+			"key": "schema_path",
+			"value": "raml/raml1.0/schemas",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
mod-users build fails in our Jenkins pipeline. Reason is that API tests are trying to get schemas from master branch of https://github.com/folio-org/raml/tree/ which does not exist anymore. We either have to get them from https://github.com/folio-org/raml/tree/raml0.8/schemas or https://github.com/folio-org/raml/tree/raml1.0/schemas for these tests to pass. 
Getting them from https://github.com/folio-org/raml/tree/raml0.8/schemas because https://github.com/folio-org/raml/tree/raml1.0/schemas does not have mod-users related schemas in it yet. This fixes all the API tests.