### PR TITLE
Adjust mod-users tests to get schemas from RAML0.8 branch

### DIFF
--- a/mod-users/mod-users.postman_collection.json
+++ b/mod-users/mod-users.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b80f7021-1536-4531-bf85-aceca3d26659",
+		"_postman_id": "d0e6021e-a4b4-4961-a959-4b46656a69d4",
 		"name": "mod-users",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -15,7 +15,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5e952041-5ba6-4602-8b63-0549e94a6a4f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_error OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -26,7 +25,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_error_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -38,14 +38,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_error}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_error}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_error}}"
 							]
 						}
@@ -59,7 +57,6 @@
 							"listen": "test",
 							"script": {
 								"id": "f708b061-026b-44d6-92ba-dff26a1b6a94",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -70,7 +67,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_errors_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -82,14 +80,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_errors}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_errors}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_errors}}"
 							]
 						}
@@ -103,7 +99,6 @@
 							"listen": "test",
 							"script": {
 								"id": "105282cc-4e6f-48e8-982e-d7134cac2578",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_metadata OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -114,7 +109,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_metadata_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -126,14 +122,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_metadata}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_metadata}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_metadata}}"
 							]
 						}
@@ -147,7 +141,6 @@
 							"listen": "test",
 							"script": {
 								"id": "7d1f6195-4630-415d-9eed-56d38033d5aa",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_metadata OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -158,7 +151,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_resultInfo_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -170,14 +164,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_resultInfo}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_resultInfo}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_resultInfo}}"
 							]
 						}
@@ -191,7 +183,6 @@
 							"listen": "test",
 							"script": {
 								"id": "779af7ea-1e68-4a3f-84f2-d26fa3f39b90",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_metadata OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -202,7 +193,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_tags_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -214,14 +206,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_tags}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_tags}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_tags}}"
 							]
 						}
@@ -235,7 +225,6 @@
 							"listen": "test",
 							"script": {
 								"id": "ad455e26-7dc6-4d08-a023-8910e4368b53",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_parameters OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -246,7 +235,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_parameters_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -258,14 +248,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_parameters}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_parameters}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{schema_parameters}}"
 							]
 						}
@@ -279,7 +267,6 @@
 							"listen": "test",
 							"script": {
 								"id": "0403a5ee-5278-4de2-8071-449f0138b3ec",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -290,7 +277,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_addresstype_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -302,14 +290,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_addresstype}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_addresstype}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_addresstype}}"
 							]
@@ -324,7 +310,6 @@
 							"listen": "test",
 							"script": {
 								"id": "956effde-7569-4722-9955-308630b087ff",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -335,7 +320,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_addresstypeCollection_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -347,14 +333,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_addresstypeCollection}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_addresstypeCollection}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_addresstypeCollection}}"
 							]
@@ -369,7 +353,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5135711b-4235-464c-8bbe-d2f4eec7e2b4",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -380,7 +363,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_proxyfor_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -392,14 +376,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_proxyfor}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_proxyfor}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_proxyfor}}"
 							]
@@ -414,7 +396,6 @@
 							"listen": "test",
 							"script": {
 								"id": "0a5e3c62-9ec5-49b7-be97-8906a9cbf9b9",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -425,7 +406,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_proxyforCollection_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -437,14 +419,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_proxyforCollection}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_proxyforCollection}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_proxyforCollection}}"
 							]
@@ -459,7 +439,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5c5dcbea-474a-484f-bcbc-e2e7a02fc5c5",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -470,7 +449,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_userdata_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -482,14 +462,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_userdata}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_userdata}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_userdata}}"
 							]
@@ -504,7 +482,6 @@
 							"listen": "test",
 							"script": {
 								"id": "49a442fd-5ff6-4c8e-9c9c-3ac6891ceac7",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -515,7 +492,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_userdataCollection_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -527,14 +505,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_userdataCollection}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_userdataCollection}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_userdataCollection}}"
 							]
@@ -549,7 +525,6 @@
 							"listen": "test",
 							"script": {
 								"id": "1b213ce4-b91d-44ef-80ed-016ede0d6957",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -560,7 +535,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_usergroups_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -572,14 +548,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_usergroups}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_usergroups}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_usergroups}}"
 							]
@@ -594,7 +568,6 @@
 							"listen": "test",
 							"script": {
 								"id": "d58bf639-34cc-4058-840a-2dbf37c8c1d8",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -605,7 +578,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_usergroup_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -617,14 +591,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{mod_name}}/{{schema_usergroup}}",
+							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_usergroup}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
-								"raml",
-								"master",
-								"schemas",
+								"{{schema_path}}",
 								"{{mod_name}}",
 								"{{schema_usergroup}}"
 							]
@@ -5563,7 +5535,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"username\": \"modusertest\",\r\n  \"id\": \"f3007520-7777-4b4f-b0bf-dd56a426b21e\",\r\n  \"active\": true,\r\n  \"type\": \"patron\",\r\n  \"patronGroup\": \"0966d02b-d551-4a4d-93f9-5dc491ededa7\",\r\n  \"meta\": {\r\n    \"creation_date\": \"2017-10-05T0723\",\r\n    \"last_login_date\": \"\"\r\n  },\r\n  \"personal\": {\r\n    \"lastName\": \"Kosciuszko\",\r\n    \"firstName\": \"Tadeusz\",\r\n    \"email\": \"tkosciuszko@bj.org\",\r\n    \"phone\": \"2125551212\"\r\n  }\r\n}"
+							"raw": ""
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/foo",
@@ -5899,105 +5871,111 @@
 	],
 	"variable": [
 		{
-			"id": "839b3479-3263-4fcb-8fe5-da43038e148b",
+			"id": "b90b1d9c-0141-44f7-b1a4-e26989278e35",
 			"key": "mod_name",
 			"value": "mod-users",
 			"type": "string"
 		},
 		{
-			"id": "3cdb21e9-3c25-4fc3-a393-02df96924ab9",
+			"id": "e2992000-8e39-4f73-a814-e655a674e63e",
 			"key": "mod_version",
 			"value": "v14.2.0",
 			"type": "string"
 		},
 		{
-			"id": "83dd0ca9-20de-47ab-9d0a-dd3066a0c5db",
+			"id": "9862b394-b4b0-4552-802d-bfa13ce0fcf6",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org",
 			"type": "string"
 		},
 		{
-			"id": "5ab6d83e-8a67-4bb4-a609-49df91939800",
+			"id": "c9fdd051-00f2-4f62-8437-11ecfef5ea70",
 			"key": "schema_error",
 			"value": "error.schema",
 			"type": "string"
 		},
 		{
-			"id": "43fd46b0-631f-4019-bca9-7a436eb4bc76",
+			"id": "7b12dac3-a1b0-4844-bcf0-f9f4da522b43",
 			"key": "schema_errors",
 			"value": "errors.schema",
 			"type": "string"
 		},
 		{
-			"id": "075fef3d-65e3-4e8b-a5f3-8c405720342a",
+			"id": "8b6763fe-07fa-4808-8a32-f0c18d942d39",
 			"key": "schema_parameters",
 			"value": "parameters.schema",
 			"type": "string"
 		},
 		{
-			"id": "101ff526-b441-4c0a-9826-9475ab525239",
+			"id": "33a7dee5-930b-477b-a6bd-98aaae341c8a",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "99b1b689-e2cc-4019-a92e-c787dadc8a91",
+			"id": "9acb0baf-37d0-4a65-8b63-7cf0599972a2",
 			"key": "schema_resultInfo",
 			"value": "resultInfo.schema",
 			"type": "string"
 		},
 		{
-			"id": "f4318c96-5b5f-47cd-b343-80ee7dc14a50",
+			"id": "f52c8ca8-a384-4514-a73f-0b556dbb6cb0",
 			"key": "schema_tags",
 			"value": "tags.schema",
 			"type": "string"
 		},
 		{
-			"id": "c134d27e-f0ef-436c-80e4-3fda5333f482",
+			"id": "02c186a5-f7b6-48d6-8190-57cd9fe29e26",
 			"key": "schema_addresstype",
 			"value": "addresstype.json",
 			"type": "string"
 		},
 		{
-			"id": "3678e61f-3321-428d-a07d-28d93f69f303",
+			"id": "1e1981e7-811c-4ac7-b7e6-00cb9604458b",
 			"key": "schema_addresstypeCollection",
 			"value": "addresstypeCollection.json",
 			"type": "string"
 		},
 		{
-			"id": "4e7e7432-4701-4418-8d5b-348dca42edb9",
+			"id": "34aebbf2-cabf-4aa0-8ba2-e315bc63aaad",
 			"key": "schema_proxyfor",
 			"value": "proxyfor.json",
 			"type": "string"
 		},
 		{
-			"id": "90dcfa2f-b0e1-4d2c-b162-c8575becdbba",
+			"id": "ea38c3cf-5c49-4957-ac0a-5e96070e4a78",
 			"key": "schema_proxyforCollection",
 			"value": "proxyforCollection.json",
 			"type": "string"
 		},
 		{
-			"id": "0dbde1b5-bbec-461a-8b29-bf47e9b51f56",
+			"id": "cc2049b9-07ce-48e6-b2d4-0072947ed098",
 			"key": "schema_userdata",
 			"value": "userdata.json",
 			"type": "string"
 		},
 		{
-			"id": "3b1fd3e6-c2c8-4baf-b9d7-da0e52a49f8a",
+			"id": "4a9f706c-2875-4178-ae73-6d9ba5ec7a98",
 			"key": "schema_userdataCollection",
 			"value": "userdataCollection.json",
 			"type": "string"
 		},
 		{
-			"id": "c814a0ea-bfed-4eda-83a7-f82852e4ad82",
+			"id": "d321179d-d873-4e02-a149-5f9474797cee",
 			"key": "schema_usergroup",
 			"value": "usergroup.json",
 			"type": "string"
 		},
 		{
-			"id": "2cf56cfd-3e1c-4704-90e5-5baa33b5b2de",
+			"id": "b6a667bb-a838-4ae5-ac7b-2b681ed8c1cc",
 			"key": "schema_usergroups",
 			"value": "usergroups.json",
+			"type": "string"
+		},
+		{
+			"id": "9bfce8de-c6a1-47ec-bd51-3e7874999cb4",
+			"key": "schema_path",
+			"value": "raml/raml0.8/schemas",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
In my earlier PR to fix mod-users tests, although I figured that we have to use raml0.8 branch, I somehow messed up the collection variable to use 1.0. Fix that in this commit.