### PR TITLE
Revert change made to api-tests for mod-login

### DIFF
--- a/mod-login/mod-login.postman_collection.json
+++ b/mod-login/mod-login.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "8acbc603-0ad5-4b7c-b1f8-2f2e06bcceb7",
+		"_postman_id": "1b0aa55a-6936-4600-a258-02afc912f9a7",
 		"name": "mod-login",
 		"description": "Tests for mod-login",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -622,15 +622,15 @@
 							"response": []
 						},
 						{
-							"name": "/authn/login - 400 (no tenant header)",
+							"name": "/authn/login - 403 (no tenant header)",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "f89eb7a6-cb3f-400a-9795-b8b38ed9e40d",
 										"exec": [
-											"pm.test(\"400 test - no tenant header\", function() {",
-											"    pm.response.to.have.status(400);",
+											"pm.test(\"403 test - no tenant header\", function() {",
+											"    pm.response.to.have.status(403);",
 											"    pm.response.to.have.body();",
 											"});",
 											""


### PR DESCRIPTION
Earlier, we made this change because mod-login changed due to a checkin but they reverted that change of theirs, so reverting this test change