### PR TITLE
Updated the mod-rtac schema locations to be version based

### DIFF
--- a/mod-rtac/mod-rtac.postman_collection.json
+++ b/mod-rtac/mod-rtac.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "2038b00c-981c-b33f-0cbb-a4c2257e47e6",
+		"_postman_id": "020727e7-d9c3-4614-a8cb-0a32eb916b99",
 		"name": "mod-rtac",
 		"description": "Tests for mod-rtac",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -8,7 +8,6 @@
 	"item": [
 		{
 			"name": "Schemas",
-			"description": "",
 			"item": [
 				{
 					"name": "schema_holding",
@@ -17,17 +16,16 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "ffa902b8-5ba8-4035-8270-a735f424ff82",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_parameters OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -38,7 +36,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_holding_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -58,15 +57,18 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
-							"raw": "{{schema_loc}}/mod-rtac/master/ramls/{{schema_holding}}",
+							"raw": "{{schema_loc}}/mod-rtac/{{mod_version}}/ramls/{{schema_holding}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"mod-rtac",
-								"master",
+								"{{mod_version}}",
 								"ramls",
 								"{{schema_holding}}"
 							]
@@ -82,17 +84,16 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "85917db7-7320-4a02-9489-64a8351404c7",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_parameters OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -104,7 +105,8 @@
 									"",
 									"pm.environment.set(\"schema_holdings_content\", responseBody);",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -124,15 +126,18 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
-							"raw": "{{schema_loc}}/mod-rtac/master/ramls/{{schema_holdings}}",
+							"raw": "{{schema_loc}}/mod-rtac/{{mod_version}}/ramls/{{schema_holdings}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"mod-rtac",
-								"master",
+								"{{mod_version}}",
 								"ramls",
 								"{{schema_holdings}}"
 							]
@@ -148,7 +153,6 @@
 							"listen": "test",
 							"script": {
 								"id": "5e952041-5ba6-4602-8b63-0549e94a6a4f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_error OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -159,7 +163,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_error_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -171,13 +176,13 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_error}}",
+							"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_error}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"raml",
-								"master",
+								"{{raml_version}}",
 								"schemas",
 								"{{schema_error}}"
 							]
@@ -192,7 +197,6 @@
 							"listen": "test",
 							"script": {
 								"id": "f708b061-026b-44d6-92ba-dff26a1b6a94",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Response OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -203,7 +207,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_errors_content\", responseBody);"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -215,13 +220,13 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/master/schemas/{{schema_errors}}",
+							"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_errors}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"raml",
-								"master",
+								"{{raml_version}}",
 								"schemas",
 								"{{schema_errors}}"
 							]
@@ -233,7 +238,6 @@
 		},
 		{
 			"name": "Auth",
-			"description": "",
 			"item": [
 				{
 					"name": "/authn/login",
@@ -288,7 +292,6 @@
 		},
 		{
 			"name": "Positive Tests",
-			"description": "",
 			"item": [
 				{
 					"name": "/rtac/ - single holding with status Checked out",
@@ -352,7 +355,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/163d51fd-633f-40d3-aa5d-d5e39951409b",
 							"protocol": "{{protocol}}",
@@ -453,7 +459,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdMultipleHoldings}}",
 							"protocol": "{{protocol}}",
@@ -496,7 +505,6 @@
 		},
 		{
 			"name": "Negative Tests",
-			"description": "",
 			"item": [
 				{
 					"name": "/rtac/ - bad ID - 400",
@@ -553,7 +561,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/123456",
 							"protocol": "{{protocol}}",
@@ -625,7 +636,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
 							"protocol": "{{protocol}}",
@@ -696,7 +710,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
 							"protocol": "{{protocol}}",
@@ -768,7 +785,10 @@
 								"value": "eyJhbGciOiJIUzUxMiJ999999.eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiJlZjY3NmRiOS1kMjMxLTQ3OWEtYWE5MS1mNjVlYjRiMTc4NzIiLCJ0ZW5hbnQiOiJmczAwMDAwMDAwIn2.KC0RbgafcMmR5Mc3-I7a6SQPKeDSr0SkJlLMcqQz3nwI0lwPTlxw0wJgidxDq-qjCR0wurFRn5ugd9_SVadSxg"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
 							"protocol": "{{protocol}}",
@@ -842,7 +862,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{$guid}}",
 							"protocol": "{{protocol}}",
@@ -914,7 +937,10 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/",
 							"protocol": "{{protocol}}",
@@ -935,7 +961,6 @@
 		},
 		{
 			"name": "Cleanup",
-			"description": "",
 			"item": [
 				{
 					"name": "/rtac- 200 - cleanup",
@@ -1035,46 +1060,52 @@
 	],
 	"variable": [
 		{
-			"id": "c5fb7b5c-7672-4ac1-9e38-623cba90d999",
+			"id": "053d2cc9-6f93-4f6e-b10d-2e1582da2546",
 			"key": "mod_name",
 			"value": "mod-rtac",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "fb3452b5-a4c8-468a-bd05-ff5a1e910852",
+			"id": "22fa8416-a674-4ade-9973-bafac56053d9",
 			"key": "schema_holding",
 			"value": "holding.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "c68aa57b-410d-4aea-a9d2-290e4281f4ff",
+			"id": "f39cc60c-58dd-4c31-a41a-ba834886df18",
 			"key": "schema_holdings",
 			"value": "holdings.json",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "59896a55-7b6f-4be3-b2f3-a2e07992ff99",
+			"id": "06aa2a80-6f75-4902-96ef-f390b361b2e8",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "859f07aa-eb9c-4c7d-96db-296ad8f215f8",
+			"id": "7158abc7-e832-4ee6-8a4e-39b4327e7523",
 			"key": "schema_error",
 			"value": "error.schema",
-			"type": "string",
-			"description": ""
+			"type": "string"
 		},
 		{
-			"id": "69e76006-8617-437b-afff-95a5edec5bf0",
+			"id": "bb102c50-7166-4341-95d9-f52ccde8f471",
 			"key": "schema_errors",
 			"value": "errors.schema",
-			"type": "string",
-			"description": ""
+			"type": "string"
+		},
+		{
+			"id": "9a277168-e367-4465-a121-db8aa1129646",
+			"key": "mod_version",
+			"value": "v1.2.0",
+			"type": "string"
+		},
+		{
+			"id": "bdeebdc4-0cc6-42cc-82c3-48bec6fd5f50",
+			"key": "raml_version",
+			"value": "20d6bc5c61c8509e203ea4fe0ce94ddb067200ba",
+			"type": "string"
 		}
 	]
 }


### PR DESCRIPTION
Instead of pulling schemas from mod-rtac master, we use the latest version and the version of the raml repo that the version uses.