### PR TITLE
Update name for case sensitivity in mod-kb-ebsco

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "490bbbea-93b4-47c6-9e92-32b3f212a496",
+		"_postman_id": "59ecfc51-34ef-4404-b4eb-819617fa7b00",
 		"name": "mod-kb-ebsco",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1200,7 +1200,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=abc\n",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=abc",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -5164,7 +5164,6 @@
 											"listen": "test",
 											"script": {
 												"id": "569906b9-8e70-4313-b3f8-7d6cbf10f6d3",
-												"type": "text/javascript",
 												"exec": [
 													"pm.test(\"success test\", function() {",
 													"    pm.response.to.be.json;",
@@ -5198,7 +5197,7 @@
 													"        ",
 													"        //Test that Search is in name",
 													"        pm.test('package name contains search string', function() {",
-													"            pm.expect(firstRecord.attributes.name).to.include('package');",
+													"            pm.expect(firstRecord.attributes.name).to.include('Package');",
 													"            pm.globals.set(\"custom-package-name-that-exists\", firstRecord.attributes.name);",
 													"        });",
 													"        ",
@@ -5209,7 +5208,8 @@
 													"    }",
 													"}",
 													""
-												]
+												],
+												"type": "text/javascript"
 											}
 										}
 									],


### PR DESCRIPTION
API tests of mod-kb-ebsco are failing because in a particular test of getting a custom package, we are checking that the first package's name contains "package" using this snippet of JS code - `pm.expect(firstRecord.attributes.name).to.include('package');` and the results themselves have packages created of the format `Custom Package Postman 1515004981` and JS include does not check for strings ignoring case. Modifying the test to check for "Package" case sensitively fixes it. 
I tried to see if something changed recently with "include" in chai.js but no, it seems more like the way Postman is auto-generating those package names.
