### PR TITLE
MODKBEKBJ-88 - MOD-KB-EBSCO-JAVA Configuration GET/PUT tests

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d3d16f03-3699-41aa-a856-e0438e1bc10e",
+		"_postman_id": "4736f777-1164-4564-aae0-4b842230a321",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -6470,7 +6470,65 @@
 						},
 						{
 							"name": "Negative",
-							"item": [],
+							"item": [
+								{
+									"name": "GET Configuration - when configuration is invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Negative tests cannot be written yet pending resolution of ",
+													"// https://issues.folio.org/browse/MODKBEKBJ-103",
+													"// Tests will need to clear configuration and set configuration to invalid settings",
+													"// Then issue a GET request. Caching of configuration prevents these tests"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								}
+							],
 							"_postman_isSubFolder": true
 						}
 					],
@@ -6767,6 +6825,7 @@
 												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
 												"exec": [
 													"//Check that status is 500",
+													"// Re-Check after https://issues.folio.org/browse/UIEH-575 is addressed",
 													"pm.test(\"Status is 500\", function () {",
 													"    pm.response.to.have.status(500);",
 													"});",
@@ -6824,6 +6883,7 @@
 												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
 												"exec": [
 													"//Check that status is 500",
+													"// Re-Check after https://issues.folio.org/browse/UIEH-575 is addressed",
 													"pm.test(\"Status is 500\", function () {",
 													"    pm.response.to.have.status(500);",
 													"});",
@@ -6873,6 +6933,64 @@
 									"response": []
 								},
 								{
+									"name": "PUT Configuration - when all fields are empty",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 500",
+													"// Check after https://issues.folio.org/browse/UIEH-575 is addressed",
+													"pm.test(\"Status is 500\", function () {",
+													"    pm.response.to.have.status(500);",
+													"});",
+													"pm.test(\"Response must have body with error message\", function () {",
+													"    pm.expect(pm.response.text()).to.be.eq(\"Internal server error\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"\",\n            \"apiKey\": \"\",\n            \"rmapiBaseUrl\": \"\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "PUT Configuration - when fields are missing",
 									"event": [
 										{
@@ -6893,6 +7011,7 @@
 													"let response = pm.response.json();",
 													"",
 													"// The schema does not validate for PUT request",
+													"// Check after https://issues.folio.org/browse/UIEH-575 is addressed",
 													"pm.test.skip(\"Validate schema\", function () {",
 													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
 													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
@@ -6936,6 +7055,62 @@
 										"body": {
 											"mode": "raw",
 											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"{{rm-api-custid-value}}\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT Configuration - when json is invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//We can check for appropriate error message after https://issues.folio.org/browse/UIEH-482 is fixed."
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"{{rm-api-custid-value}}\",\n            \"apiKey\": \"{{rm-api-key-value}}\",\n            \"rmapiBaseUrl\": \"{{rm-api-url-value}}\"\n        },\n    }\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a9943d15-5512-4ea5-ad4e-dbeb1453e339",
+		"_postman_id": "d3d16f03-3699-41aa-a856-e0438e1bc10e",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -143,7 +143,6 @@
 							"listen": "test",
 							"script": {
 								"id": "b6a548cd-23a5-4b8c-9bf9-622e404e5f04",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -160,6 +159,7 @@
 									"",
 									"if(jsonData!==null && jsonData.configs.length!==0) {",
 									"    pm.environment.set(\"apiUrlExists\", true);",
+									"    pm.environment.set(\"rm-api-url-value\", jsonData.configs[0].value);",
 									"    //\"rm api url exists -- do not overwrite\");",
 									"    postman.setNextRequest(\"Check if customerId exists\");",
 									"}",
@@ -167,17 +167,18 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "d665ae85-57e5-40c5-a197-48a2b098fc0a",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -226,17 +227,16 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "5c5c18b8-178f-4395-9e60-5313f2d03260",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "1999127b-87cf-45b8-a245-be854e138af4",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"Success test on json response\", function() {",
@@ -253,8 +253,11 @@
 									"",
 									"//Store rm-api-url-id temporarily for clean-up purpose",
 									"let body = JSON.parse(responseBody);",
-									"pm.environment.set(\"rm-api-url-id\", body.id);"
-								]
+									"pm.environment.set(\"rm-api-url-id\", body.id);",
+									"",
+									"pm.environment.set(\"rm-api-url-value\", body.value);"
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -276,7 +279,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": " {\r\n    \"module\": \"EKB\",\r\n    \"configName\": \"api_access\",\r\n    \"code\": \"kb.ebsco.url\",\r\n    \"description\": \"EBSCO RM-API URL\",\r\n    \"enabled\": true,\r\n    \"value\": \"https://sandbox.ebsco.io\"\r\n}"
+							"raw": " {\r\n    \"module\": \"EKB\",\r\n    \"configName\": \"api_access\",\r\n    \"code\": \"kb.ebsco.url\",\r\n    \"description\": \"EBSCO RM-API URL\",\r\n    \"enabled\": true,\r\n    \"value\": \"{{rmapi_url}}\"\r\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries",
@@ -300,7 +303,6 @@
 							"listen": "test",
 							"script": {
 								"id": "6cf60b97-d5e9-4028-86ff-9b20ecc32dba",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -317,6 +319,7 @@
 									"",
 									"if(jsonData!==null && jsonData.configs.length!==0) {",
 									"    pm.environment.set(\"customerIdExists\", true);",
+									"    pm.environment.set(\"rm-api-custid-value\", jsonData.configs[0].value);",
 									"     //\"rm api customer id exists -- do not overwrite\");",
 									"    postman.setNextRequest(\"Check if apiKey exists\");",
 									"}",
@@ -324,17 +327,18 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "d665ae85-57e5-40c5-a197-48a2b098fc0a",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -383,17 +387,16 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "5c5c18b8-178f-4395-9e60-5313f2d03260",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "23f25d7b-cbf3-4053-9fc3-35f06a3fffcc",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"Success test on json response\", function() {",
@@ -410,8 +413,10 @@
 									"",
 									"//Store rm-api-customer-id temporarily for clean-up purpose",
 									"let body = JSON.parse(responseBody);",
-									"pm.environment.set(\"rm-api-customer-id\", body.id);"
-								]
+									"pm.environment.set(\"rm-api-customer-id\", body.id);",
+									"pm.environment.set(\"rm-api-custid-value\", body.value);"
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -458,7 +463,6 @@
 							"listen": "test",
 							"script": {
 								"id": "30b0b57f-a25a-41b2-9390-f1e72c241b4c",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -476,23 +480,27 @@
 									"if(jsonData!==null && jsonData.configs.length!==0) {",
 									"    pm.environment.set(\"apiKeyExists\", true);",
 									"     //\"rm api key exists -- do not overwrite\");",
+									"     ",
+									"    pm.environment.set(\"rm-api-key-value\", jsonData.configs[0].value);",
+									"    ",
 									"    postman.setNextRequest(\"First Test - Placeholder\");",
 									"}",
 									"",
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "d665ae85-57e5-40c5-a197-48a2b098fc0a",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -541,17 +549,16 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "5c5c18b8-178f-4395-9e60-5313f2d03260",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "732d3a7c-3a6f-4f9b-b904-9cc6887ccdc3",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"Success test on json response\", function() {",
@@ -568,8 +575,10 @@
 									"",
 									"//Store rm-api-key-id temporarily for clean-up purpose",
 									"let body = JSON.parse(responseBody);",
-									"pm.environment.set(\"rm-api-key-id\", body.id);"
-								]
+									"pm.environment.set(\"rm-api-key-id\", body.id);",
+									"pm.environment.set(\"rm-api-key-value\", body.value);"
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6337,6 +6346,621 @@
 			]
 		},
 		{
+			"name": "configuration",
+			"item": [
+				{
+					"name": "GET Configuration",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "GET Configuration - when configuration is valid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in response object', function() {",
+													"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\");",
+													"});",
+													"",
+													"//Test that id is configuration",
+													"pm.test('id is configuration', function(){",
+													"    pm.expect(response.data.id).eq('configuration');",
+													"});    ",
+													"",
+													"//Test that type is configurations",
+													"pm.test('type is configurations', function(){",
+													"    pm.expect(response.data.type).eq('configurations');",
+													"});",
+													"    ",
+													"//Test that data.attributes has expected attributes",
+													"pm.test('expected data.attributes are present', function() {",
+													"    pm.expect(response.data.attributes).to.be.an('object');",
+													"    pm.expect(response.data.attributes).to.include.all.keys(\"customerId\", \"apiKey\", \"rmapiBaseUrl\");",
+													"});",
+													"//Test that customerId is as expected",
+													"let custid = pm.environment.get(\"rm-api-custid-value\");",
+													"pm.test('customer id is as configured', function(){",
+													"    pm.expect(response.data.attributes.customerId).eq(custid);",
+													"});",
+													"",
+													"//Test that apiKey is hidden as 40 (*) as expected",
+													"let apiKey = \"****************************************\";",
+													"pm.test('apiKey is as configured', function(){",
+													"    pm.expect(response.data.attributes.apiKey).eq(apiKey);",
+													"});",
+													"",
+													"//Test that rmapiBaseUrl is as expected",
+													"let rmapiBaseUrl = pm.environment.get(\"rm-api-url-value\");",
+													"pm.test('rmapiBaseUrl is as configured', function(){",
+													"    pm.expect(response.data.attributes.rmapiBaseUrl).eq(rmapiBaseUrl);",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "PUT Configuration",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "PUT Configuration - when configuration is valid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in response object', function() {",
+													"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\");",
+													"});",
+													"",
+													"//Test that id is configuration",
+													"pm.test('id is configuration', function(){",
+													"    pm.expect(response.data.id).eq('configuration');",
+													"});    ",
+													"",
+													"//Test that type is configurations",
+													"pm.test('type is configurations', function(){",
+													"    pm.expect(response.data.type).eq('configurations');",
+													"});",
+													"    ",
+													"//Test that data.attributes has expected attributes",
+													"pm.test('expected data.attributes are present', function() {",
+													"    pm.expect(response.data.attributes).to.be.an('object');",
+													"    pm.expect(response.data.attributes).to.include.all.keys(\"customerId\", \"apiKey\", \"rmapiBaseUrl\");",
+													"});",
+													"//Test that customerId is as expected",
+													"let custid = pm.environment.get(\"rm-api-custid-value\");",
+													"pm.test('customer id is as configured', function(){",
+													"    pm.expect(response.data.attributes.customerId).eq(custid);",
+													"});",
+													"",
+													"//Test that apiKey is hidden as 40 (*) as expected",
+													"let apiKey = \"****************************************\";",
+													"pm.test('apiKey is as configured', function(){",
+													"    pm.expect(response.data.attributes.apiKey).eq(apiKey);",
+													"});",
+													"",
+													"//Test that rmapiBaseUrl is as expected",
+													"let rmapiBaseUrl = pm.environment.get(\"rm-api-url-value\");",
+													"pm.test('rmapiBaseUrl is as configured', function(){",
+													"    pm.expect(response.data.attributes.rmapiBaseUrl).eq(rmapiBaseUrl);",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"{{rm-api-custid-value}}\",\n            \"apiKey\": \"{{rm-api-key-value}}\",\n            \"rmapiBaseUrl\": \"{{rm-api-url-value}}\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "PUT Configuration - when customer id is invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 422",
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"        pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Configuration is invalid');",
+													"    });",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"not a customer id\",\n            \"apiKey\": \"{{rm-api-key-value}}\",\n            \"rmapiBaseUrl\": \"{{rm-api-url-value}}\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT Configuration - when api key is invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 422",
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"        pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Configuration is invalid');",
+													"    });",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"{{rm-api-custid-value}}\",\n            \"apiKey\": \"not an apikey\",\n            \"rmapiBaseUrl\": \"{{rm-api-url-value}}\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT Configuration - when url is invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 500",
+													"pm.test(\"Status is 500\", function () {",
+													"    pm.response.to.have.status(500);",
+													"});",
+													"pm.test(\"Response must have body with error message\", function () {",
+													"    pm.expect(pm.response.text()).to.be.eq(\"Internal server error\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"{{rm-api-custid-value}}\",\n            \"apiKey\": \"{{rm-api-key-value}}\",\n            \"rmapiBaseUrl\": \"not a url\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT Configuration - when url is empty",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 500",
+													"pm.test(\"Status is 500\", function () {",
+													"    pm.response.to.have.status(500);",
+													"});",
+													"pm.test(\"Response must have body with error message\", function () {",
+													"    pm.expect(pm.response.text()).to.be.eq(\"Internal server error\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"{{rm-api-custid-value}}\",\n            \"apiKey\": \"{{rm-api-key-value}}\",\n            \"rmapiBaseUrl\": \"\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT Configuration - when fields are missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "47d2cb7d-710c-44f8-9770-0921df8bb19d",
+												"exec": [
+													"//Check that status is 422",
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"// The schema does not validate for PUT request",
+													"pm.test.skip(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"        pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test.skip('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Configuration is invalid');",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"data\": {\n        \"id\": \"configuration\",\n        \"type\": \"configurations\",\n        \"attributes\": {\n            \"customerId\": \"{{rm-api-custid-value}}\"\n        }\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/configuration",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"configuration"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
+		},
+		{
 			"name": "tear-down configuration",
 			"item": [
 				{
@@ -6781,21 +7405,20 @@
 							"listen": "test",
 							"script": {
 								"id": "93ea1def-f5f2-4d98-9571-99589b488730",
-								"type": "text/javascript",
 								"exec": [
 									"//placeholder Reset Variables",
 									"pm.test(\"Status is 200\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "9e4453a6-7061-4d96-90e2-f2eac533c754",
-								"type": "text/javascript",
 								"exec": [
 									"// Reset all environment level variables that may have been setup in the tests",
 									"pm.environment.unset(\"schema_jsonapi_content\");",
@@ -6835,10 +7458,13 @@
 									"pm.variables.unset(\"long-identifier\");",
 									"pm.variables.unset(\"packagename-pageone\");",
 									"",
-									"",
+									"pm.variables.unset(\"rm-api-custid-value\");",
+									"pm.variables.unset(\"rm-api-url-value\");",
+									"pm.variables.unset(\"rm-api-key-value\");",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -6928,21 +7554,33 @@
 	],
 	"variable": [
 		{
-			"id": "57356f66-4efb-40b5-957d-2450f8316abf",
+			"id": "5fa84084-eed6-46d0-aaa7-93654a22f87b",
 			"key": "custid",
 			"value": "apidvgvmt",
 			"type": "string"
 		},
 		{
-			"id": "ba6a58e0-35b1-4963-a125-d6b0bacf17b9",
+			"id": "35cf7fc4-6082-4cdb-b3eb-0a5bc3ebaae4",
 			"key": "packageId",
 			"value": "583-4345",
 			"type": "string"
 		},
 		{
-			"id": "9eee344d-9ec2-415b-b190-f70aba0bd65a",
+			"id": "4424a73a-083c-40b1-8e10-85a598e3fbfd",
 			"key": "rmapi_api_key",
 			"value": "",
+			"type": "string"
+		},
+		{
+			"id": "88088415-18a0-46eb-83de-5877f347b576",
+			"key": "rmapi_url",
+			"value": "https://sandbox.ebsco.io",
+			"type": "string"
+		},
+		{
+			"id": "0726962b-937b-4f18-bc81-d7bbd52126ee",
+			"key": "default_rmapi_url",
+			"value": "https://sandbox.ebsco.io",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
Per https://issues.folio.org/browse/MODKBEKBJ-88 and https://issues.folio.org/browse/MODKBEKBJ-89 -- add test for Configuration GET and PUT Requests

- Added new folder for configuration tests
- Updated setup configuration section to save configuration so that it can be used in tests
- Added Positive Test for GET Configuration
- Added Placeholder for Negative Tests with notes on outstanding cache issue (Reference Jira ticket)
- Added Positive and Negative Tests for PUT configuration with notes on error issues (reference Jira tickets)

Outstanding Issues (to be addressed in separate PRs)

- Unable to test GET Configuration Negative cases due to caching -- added ticket to add a way to invalidate cache from api
https://issues.folio.org/browse/MODKBEKBJ-103 
- Encountered issues with permissions required for endpoint -- added ticket to update tests in general to set up needed permissions for user
https://issues.folio.org/browse/MODKBEKBJ-102
- Issues with error response for PUT Configuration endpoint are documented here https://issues.folio.org/browse/UIEH-575


