### PR TITLE
MODKBEKBJ-71 - API Tests DELETE /eholdings/packages/{packageId} endpoint

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "3cde7229-380f-46ba-95f8-08b684d61e9d",
+		"_postman_id": "286f9d3e-cff5-4f5e-9e23-8bad9e1f9e5d",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7331,7 +7331,13 @@
 													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
 													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});"
+													"});",
+													"",
+													"//Ensure that appropriate error message is being returned",
+													"pm.test('Ensure that appropriate error message is returned', function(){",
+													"    pm.expect(response.errors[0].title).to.eq('Package and provider id are required');",
+													"});",
+													""
 												],
 												"type": "text/javascript"
 											}
@@ -7478,8 +7484,8 @@
 													"",
 													"    //Ensure that appropriate error message is being returned",
 													"    pm.test('Ensure that appropriate error message is returned', function() {",
-													"        pm.expect(response.errors[0].title).to.eq('Invalid package');",
-													"        pm.expect(response.errors[0].detail).to.eq('Package cannot be deleted');",
+													"        pm.expect(response.errors[0].title).to.eq('Package cannot be deleted');",
+													"        pm.expect(response.errors[0].detail).to.eq('Invalid package');",
 													"    });",
 													"}",
 													"",

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "286f9d3e-cff5-4f5e-9e23-8bad9e1f9e5d",
+		"_postman_id": "1f4ff03a-541c-40ea-91af-c3464610ed57",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7242,298 +7242,6 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"name": "DELETE package by packageId",
-					"item": [
-						{
-							"name": "Positive",
-							"item": [
-								{
-									"name": "Delete custom package",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "3a82bad3-3794-4e96-a832-9726afc45c8f",
-												"exec": [
-													"//Check that status is 204",
-													"pm.test(\"Status is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.api+json",
-												"disabled": true
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"eholdings",
-												"packages",
-												"{{custom-package-id-created-in-post}}"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
-						{
-							"name": "Negative",
-							"item": [
-								{
-									"name": "invalid providerId in packageId",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "6a500736-5692-48d5-a2b3-be1a3a7abcb8",
-												"exec": [
-													"pm.test(\"success test\", function() {",
-													"    pm.response.to.be.json;",
-													"});",
-													"/* Tests below should be re-visited after https://issues.folio.org/browse/UIEH-427 is fixed.*/",
-													"let response = pm.response.json();",
-													"",
-													"//Check that status is 400",
-													"pm.test(\"Status is 400\", function () {",
-													"    pm.response.to.have.status(400);",
-													"});",
-													"",
-													"//Validate response against json api schema",
-													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});",
-													"",
-													"//Ensure that appropriate error message is being returned",
-													"pm.test('Ensure that appropriate error message is returned', function(){",
-													"    pm.expect(response.errors[0].title).to.eq('Package and provider id are required');",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"eholdings",
-												"packages",
-												"abc"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "invalid packageId",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "b141bf4d-bf91-477f-a103-294bdbaedb39",
-												"exec": [
-													"pm.test(\"success test\", function() {",
-													"    pm.response.to.be.json;",
-													"});",
-													"",
-													"/* Tests below should be re-visited after https://issues.folio.org/browse/UIEH-427 is fixed.*/",
-													"let response = pm.response.json();",
-													"",
-													"//Check that status is 400",
-													"pm.test(\"Status is 400\", function () {",
-													"    pm.response.to.have.status(400);",
-													"});",
-													"",
-													"//Validate response against json api schema",
-													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});",
-													"",
-													"//Ensure that errors array is *not* empty",
-													"if(response.errors) {",
-													"    pm.test('Ensure that errors array is not empty', function() {",
-													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
-													"    });",
-													"",
-													"    //Test that we get expected error message",
-													"    pm.test('Ensure that we get expected error message', function() {",
-													"        pm.expect(response.errors[0].title).to.eq('Package or provider id are invalid');",
-													"    });",
-													"}"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc-abc",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"eholdings",
-												"packages",
-												"abc-abc"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "delete a managed package",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "516aae59-b197-4a2d-90ed-44116368e5f1",
-												"exec": [
-													"pm.test(\"success test\", function() {",
-													"    pm.response.to.be.json;",
-													"});",
-													"",
-													"let response = pm.response.json();",
-													"",
-													"//Check that status is 400",
-													"pm.test(\"Status is 400\", function () {",
-													"    pm.response.to.have.status(400);",
-													"});",
-													"",
-													"//Validate response against json api schema",
-													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});",
-													"",
-													"//Ensure that errors array is not empty",
-													"if(response.errors) {",
-													"    pm.test('Ensure that errors array is not empty', function() {",
-													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
-													"    });",
-													"",
-													"    //Ensure that appropriate error message is being returned",
-													"    pm.test('Ensure that appropriate error message is returned', function() {",
-													"        pm.expect(response.errors[0].title).to.eq('Package cannot be deleted');",
-													"        pm.expect(response.errors[0].detail).to.eq('Invalid package');",
-													"    });",
-													"}",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"eholdings",
-												"packages",
-												"{{packageId}}"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
 					"name": "PUT package by packageId",
 					"item": [
 						{
@@ -8711,6 +8419,298 @@
 										}
 									],
 									"_postman_isSubFolder": true
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "DELETE package by packageId",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "Delete custom package",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "3a82bad3-3794-4e96-a832-9726afc45c8f",
+												"exec": [
+													"//Check that status is 204",
+													"pm.test(\"Status is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"{{custom-package-id-created-in-post}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "invalid providerId in packageId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "6a500736-5692-48d5-a2b3-be1a3a7abcb8",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"/* Tests below should be re-visited after https://issues.folio.org/browse/UIEH-427 is fixed.*/",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that appropriate error message is being returned",
+													"pm.test('Ensure that appropriate error message is returned', function(){",
+													"    pm.expect(response.errors[0].title).to.eq('Package and provider id are required');",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"abc"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "invalid packageId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "b141bf4d-bf91-477f-a103-294bdbaedb39",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"/* Tests below should be re-visited after https://issues.folio.org/browse/UIEH-427 is fixed.*/",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is *not* empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package or provider id are invalid');",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc-abc",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"abc-abc"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "delete a managed package",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "516aae59-b197-4a2d-90ed-44116368e5f1",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Ensure that appropriate error message is being returned",
+													"    pm.test('Ensure that appropriate error message is returned', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package cannot be deleted');",
+													"        pm.expect(response.errors[0].detail).to.eq('Invalid package');",
+													"    });",
+													"}",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"{{packageId}}"
+											]
+										}
+									},
+									"response": []
 								}
 							],
 							"_postman_isSubFolder": true

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "aae099d8-3f08-4254-86cc-7c23ba13bf4c",
+		"_postman_id": "3cde7229-380f-46ba-95f8-08b684d61e9d",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7230,6 +7230,292 @@
 												"eholdings",
 												"packages",
 												"abc-abc"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "DELETE package by packageId",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "Delete custom package",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "3a82bad3-3794-4e96-a832-9726afc45c8f",
+												"exec": [
+													"//Check that status is 204",
+													"pm.test(\"Status is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"{{custom-package-id-created-in-post}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "invalid providerId in packageId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "6a500736-5692-48d5-a2b3-be1a3a7abcb8",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"/* Tests below should be re-visited after https://issues.folio.org/browse/UIEH-427 is fixed.*/",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"abc"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "invalid packageId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "b141bf4d-bf91-477f-a103-294bdbaedb39",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"/* Tests below should be re-visited after https://issues.folio.org/browse/UIEH-427 is fixed.*/",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is *not* empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package or provider id are invalid');",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc-abc",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"abc-abc"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "delete a managed package",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "516aae59-b197-4a2d-90ed-44116368e5f1",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Ensure that appropriate error message is being returned",
+													"    pm.test('Ensure that appropriate error message is returned', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Invalid package');",
+													"        pm.expect(response.errors[0].detail).to.eq('Package cannot be deleted');",
+													"    });",
+													"}",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"{{packageId}}"
 											]
 										}
 									},


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-71 we want to have API Tests for  DELETE `/eholdings/packages/{packageId}` endpoint
## Approach

- checked if tests from https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json pass for the endpoint in Java
-  added api tests to the mod-kb-ebsco-java postman collection