### PR TITLE
MODKBEKBJ-65 - API Tests POST /eholdings/packages endpoint

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "3bf73ba4-aa6c-4df6-aa2e-ff4d05b580ed",
+		"_postman_id": "4b748e9d-0f33-412d-a88d-3a5b6683ac79",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -5636,6 +5636,592 @@
 													"key": "count",
 													"value": "abc"
 												}
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "POST to package collection",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "create custom package for testing deletion",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "807c50e4-0fd3-449b-b76f-26701581409c",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of packages in response",
+													"if(response.data) {",
+													"    if(response.data.id) {",
+													"        pm.environment.set(\"custom-package-id-created-in-post\", response.data.id);",
+													"    }",
+													"    ",
+													"    //Test that type is packages",
+													"    pm.test('type is packages', function(){",
+													"        pm.expect(response.data.type).eq('packages');",
+													"    });",
+													"    ",
+													"    //Test that data.attributes has expected attributes",
+													"    pm.test('expected data.attributes are present', function() {",
+													"        pm.expect(response.data.attributes).to.be.an('object');",
+													"        pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\", \"isSelected\", \"name\", \"packageId\", ",
+													"        \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\");",
+													"    });",
+													"        ",
+													"    //Test that contentType matches what was passed in POST request",
+													"    pm.test('content type matches value passed in', function() {",
+													"        pm.expect(response.data.attributes.contentType).to.eq('E-Journal');",
+													"    });",
+													"    ",
+													"    //Test that customCoverage matches what was passed in POST request",
+													"    pm.test('custom coverage matches value passed in', function() {",
+													"        pm.expect(response.data.attributes.customCoverage.beginCoverage).to.eq('2003-01-01');",
+													"        pm.expect(response.data.attributes.customCoverage.endCoverage).to.eq('2003-12-01');",
+													"    });",
+													"    ",
+													"    //Test that isCustom is true",
+													"    pm.test('isCustom is true', function() {",
+													"        pm.expect(response.data.attributes.isCustom).to.be.true;",
+													"    });",
+													"    ",
+													"    //Test that isSelected is true",
+													"    pm.test('isSelected is true', function() {",
+													"        pm.expect(response.data.attributes.isSelected).to.be.true;",
+													"    });",
+													"    ",
+													"    //Test that name matches value passed in",
+													"    pm.test('name matches value passed in', function() {",
+													"        pm.expect(response.data.attributes.name).to.eq('custom packages api test one');",
+													"    });",
+													"    ",
+													"    //Test that package type is custom",
+													"    pm.test('packageType is custom', function() {",
+													"        pm.expect(response.data.attributes.packageType).to.eq('Custom');",
+													"    });",
+													"    ",
+													"    //Test that allowKbToAddTitles is false",
+													"    pm.test('allowKbToAddTitles is false', function() {",
+													"        pm.expect(response.data.attributes.allowKbToAddTitles).to.be.false;",
+													"    });",
+													"} else {",
+													"    console.log('Custom package not created');",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test one\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "create custom package for testing deletion in PUT",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "c4a4f293-fb41-4b09-8b13-015b296232e9",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of packages in response",
+													"if(response.data) {",
+													"    if(response.data.id) {",
+													"        pm.environment.set(\"custom-package-id-created-in-post-again\", response.data.id);",
+													"    }",
+													"    ",
+													"    //Test that type is packages",
+													"    pm.test('type is packages', function(){",
+													"        pm.expect(response.data.type).eq('packages');",
+													"    });",
+													"",
+													"    //Test that name matches value passed in",
+													"    pm.test('name matches value passed in', function() {",
+													"        pm.expect(response.data.attributes.name).to.eq('custom packages api test two');",
+													"    });",
+													"    ",
+													"    //Test that package type is custom",
+													"    pm.test('packageType is custom', function() {",
+													"        pm.expect(response.data.attributes.packageType).to.eq('Custom');",
+													"    });",
+													"    ",
+													"    //Test that allowKbToAddTitles is false",
+													"    pm.test('allowKbToAddTitles is false', function() {",
+													"        pm.expect(response.data.attributes.allowKbToAddTitles).to.be.false;",
+													"    });",
+													"} else {",
+													"    console.log('Custom package not created');",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test two\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "with package name that already exists",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "50e4af93-4308-4650-b077-2ea16c8d2a27",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Custom Package with the provided name already exists');",
+													"    }); ",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with invalid contentType",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "a79977ad-8b87-4104-b668-40e38a6afe02",
+												"exec": [
+													"//Check that status is 400",
+													"// This test should be re-visited after https://issues.folio.org/browse/UIEH-488 is fixed.",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"Response must have body with error message\", function () {",
+													"    pm.expect(pm.response.text()).to.contains('Json content error');",
+													"});",
+													"",
+													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test\",\n\t\t\t\"contentType\": 123,\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "bad data for customCoverage",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "c3b36baa-ce08-4c77-b71a-65d41a4b8bd0",
+												"exec": [
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"Response must have body with error message\", function () {",
+													"    pm.expect(pm.response.text()).to.contains('Json content error');",
+													"});",
+													"",
+													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"123\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": 2003-01-01,\n\t\t\t\t\"endCoverage\": 2003-12-01\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "package without name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "ca5f984d-f290-418b-b995-16e6b818abf3",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 422",
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"   pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].message).to.eq('may not be null');",
+													"        pm.expect(response.errors[0].type).to.eq('1');",
+													"        pm.expect(response.errors[0].code).to.eq('-1');",
+													"        pm.expect(response.errors[0].parameters[0].key).to.eq('data.attributes.name');",
+													"        pm.expect(response.errors[0].parameters[0].value).to.eq('null');",
+													"    }); ",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "package without content type",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "cd23092d-ad62-4671-9ecc-84adb25a0378",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 422",
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].message).to.eq('may not be null');",
+													"        pm.expect(response.errors[0].type).to.eq('1');",
+													"        pm.expect(response.errors[0].code).to.eq('-1');",
+													"        pm.expect(response.errors[0].parameters[0].key).to.eq('data.attributes.contentType');",
+													"        pm.expect(response.errors[0].parameters[0].value).to.eq('null');",
+													"    }); ",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"xxx\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
 											]
 										}
 									},

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4b748e9d-0f33-412d-a88d-3a5b6683ac79",
+		"_postman_id": "bb2060f6-8df8-4a6c-a378-49a70e44bcc2",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -890,6 +890,229 @@
 							""
 						]
 					}
+				}
+			]
+		},
+		{
+			"name": "setup for packages test",
+			"item": [
+				{
+					"name": "create custom package for testing deletion",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "807c50e4-0fd3-449b-b76f-26701581409c",
+								"exec": [
+									"pm.test(\"success test\", function() {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.json;",
+									"});",
+									"",
+									"let response = pm.response.json();",
+									"",
+									"//Check that status is 200",
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+									"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									"",
+									"//Check if we get a collection of packages in response",
+									"if(response.data) {",
+									"    if(response.data.id) {",
+									"        pm.environment.set(\"custom-package-id-created-in-post\", response.data.id);",
+									"    }",
+									"    ",
+									"    //Test that type is packages",
+									"    pm.test('type is packages', function(){",
+									"        pm.expect(response.data.type).eq('packages');",
+									"    });",
+									"    ",
+									"    //Test that data.attributes has expected attributes",
+									"    pm.test('expected data.attributes are present', function() {",
+									"        pm.expect(response.data.attributes).to.be.an('object');",
+									"        pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\", \"isSelected\", \"name\", \"packageId\", ",
+									"        \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\");",
+									"    });",
+									"        ",
+									"    //Test that contentType matches what was passed in POST request",
+									"    pm.test('content type matches value passed in', function() {",
+									"        pm.expect(response.data.attributes.contentType).to.eq('E-Journal');",
+									"    });",
+									"    ",
+									"    //Test that customCoverage matches what was passed in POST request",
+									"    pm.test('custom coverage matches value passed in', function() {",
+									"        pm.expect(response.data.attributes.customCoverage.beginCoverage).to.eq('2003-01-01');",
+									"        pm.expect(response.data.attributes.customCoverage.endCoverage).to.eq('2003-12-01');",
+									"    });",
+									"    ",
+									"    //Test that isCustom is true",
+									"    pm.test('isCustom is true', function() {",
+									"        pm.expect(response.data.attributes.isCustom).to.be.true;",
+									"    });",
+									"    ",
+									"    //Test that isSelected is true",
+									"    pm.test('isSelected is true', function() {",
+									"        pm.expect(response.data.attributes.isSelected).to.be.true;",
+									"    });",
+									"    ",
+									"    //Test that name matches value passed in",
+									"    pm.test('name matches value passed in', function() {",
+									"        pm.expect(response.data.attributes.name).to.eq('custom packages api test one');",
+									"    });",
+									"    ",
+									"    //Test that package type is custom",
+									"    pm.test('packageType is custom', function() {",
+									"        pm.expect(response.data.attributes.packageType).to.eq('Custom');",
+									"    });",
+									"    ",
+									"    //Test that allowKbToAddTitles is false",
+									"    pm.test('allowKbToAddTitles is false', function() {",
+									"        pm.expect(response.data.attributes.allowKbToAddTitles).to.be.false;",
+									"    });",
+									"} else {",
+									"    console.log('Custom package not created');",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.api+json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test one\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"eholdings",
+								"packages"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create custom package for testing deletion in PUT",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c4a4f293-fb41-4b09-8b13-015b296232e9",
+								"exec": [
+									"pm.test(\"success test\", function() {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.json;",
+									"});",
+									"",
+									"let response = pm.response.json();",
+									"",
+									"//Check that status is 200",
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Validate schema\", function () {",
+									"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+									"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"});",
+									"",
+									"//Check if we get a collection of packages in response",
+									"if(response.data) {",
+									"    if(response.data.id) {",
+									"        pm.environment.set(\"custom-package-id-created-in-post-again\", response.data.id);",
+									"    }",
+									"    ",
+									"    //Test that type is packages",
+									"    pm.test('type is packages', function(){",
+									"        pm.expect(response.data.type).eq('packages');",
+									"    });",
+									"",
+									"    //Test that name matches value passed in",
+									"    pm.test('name matches value passed in', function() {",
+									"        pm.expect(response.data.attributes.name).to.eq('custom packages api test two');",
+									"    });",
+									"    ",
+									"    //Test that package type is custom",
+									"    pm.test('packageType is custom', function() {",
+									"        pm.expect(response.data.attributes.packageType).to.eq('Custom');",
+									"    });",
+									"    ",
+									"    //Test that allowKbToAddTitles is false",
+									"    pm.test('allowKbToAddTitles is false', function() {",
+									"        pm.expect(response.data.attributes.allowKbToAddTitles).to.be.false;",
+									"    });",
+									"} else {",
+									"    console.log('Custom package not created');",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.api+json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test two\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"eholdings",
+								"packages"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -5650,230 +5873,6 @@
 				{
 					"name": "POST to package collection",
 					"item": [
-						{
-							"name": "Positive",
-							"item": [
-								{
-									"name": "create custom package for testing deletion",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "807c50e4-0fd3-449b-b76f-26701581409c",
-												"exec": [
-													"pm.test(\"success test\", function() {",
-													"    pm.response.to.be.ok;",
-													"    pm.response.to.be.json;",
-													"});",
-													"",
-													"let response = pm.response.json();",
-													"",
-													"//Check that status is 200",
-													"pm.test(\"Status is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"pm.test(\"Validate schema\", function () {",
-													"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});",
-													"",
-													"//Check if we get a collection of packages in response",
-													"if(response.data) {",
-													"    if(response.data.id) {",
-													"        pm.environment.set(\"custom-package-id-created-in-post\", response.data.id);",
-													"    }",
-													"    ",
-													"    //Test that type is packages",
-													"    pm.test('type is packages', function(){",
-													"        pm.expect(response.data.type).eq('packages');",
-													"    });",
-													"    ",
-													"    //Test that data.attributes has expected attributes",
-													"    pm.test('expected data.attributes are present', function() {",
-													"        pm.expect(response.data.attributes).to.be.an('object');",
-													"        pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\", \"isSelected\", \"name\", \"packageId\", ",
-													"        \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\");",
-													"    });",
-													"        ",
-													"    //Test that contentType matches what was passed in POST request",
-													"    pm.test('content type matches value passed in', function() {",
-													"        pm.expect(response.data.attributes.contentType).to.eq('E-Journal');",
-													"    });",
-													"    ",
-													"    //Test that customCoverage matches what was passed in POST request",
-													"    pm.test('custom coverage matches value passed in', function() {",
-													"        pm.expect(response.data.attributes.customCoverage.beginCoverage).to.eq('2003-01-01');",
-													"        pm.expect(response.data.attributes.customCoverage.endCoverage).to.eq('2003-12-01');",
-													"    });",
-													"    ",
-													"    //Test that isCustom is true",
-													"    pm.test('isCustom is true', function() {",
-													"        pm.expect(response.data.attributes.isCustom).to.be.true;",
-													"    });",
-													"    ",
-													"    //Test that isSelected is true",
-													"    pm.test('isSelected is true', function() {",
-													"        pm.expect(response.data.attributes.isSelected).to.be.true;",
-													"    });",
-													"    ",
-													"    //Test that name matches value passed in",
-													"    pm.test('name matches value passed in', function() {",
-													"        pm.expect(response.data.attributes.name).to.eq('custom packages api test one');",
-													"    });",
-													"    ",
-													"    //Test that package type is custom",
-													"    pm.test('packageType is custom', function() {",
-													"        pm.expect(response.data.attributes.packageType).to.eq('Custom');",
-													"    });",
-													"    ",
-													"    //Test that allowKbToAddTitles is false",
-													"    pm.test('allowKbToAddTitles is false', function() {",
-													"        pm.expect(response.data.attributes.allowKbToAddTitles).to.be.false;",
-													"    });",
-													"} else {",
-													"    console.log('Custom package not created');",
-													"}",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.api+json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test one\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"eholdings",
-												"packages"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "create custom package for testing deletion in PUT",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "c4a4f293-fb41-4b09-8b13-015b296232e9",
-												"exec": [
-													"pm.test(\"success test\", function() {",
-													"    pm.response.to.be.ok;",
-													"    pm.response.to.be.json;",
-													"});",
-													"",
-													"let response = pm.response.json();",
-													"",
-													"//Check that status is 200",
-													"pm.test(\"Status is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"pm.test(\"Validate schema\", function () {",
-													"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-													"});",
-													"",
-													"//Check if we get a collection of packages in response",
-													"if(response.data) {",
-													"    if(response.data.id) {",
-													"        pm.environment.set(\"custom-package-id-created-in-post-again\", response.data.id);",
-													"    }",
-													"    ",
-													"    //Test that type is packages",
-													"    pm.test('type is packages', function(){",
-													"        pm.expect(response.data.type).eq('packages');",
-													"    });",
-													"",
-													"    //Test that name matches value passed in",
-													"    pm.test('name matches value passed in', function() {",
-													"        pm.expect(response.data.attributes.name).to.eq('custom packages api test two');",
-													"    });",
-													"    ",
-													"    //Test that package type is custom",
-													"    pm.test('packageType is custom', function() {",
-													"        pm.expect(response.data.attributes.packageType).to.eq('Custom');",
-													"    });",
-													"    ",
-													"    //Test that allowKbToAddTitles is false",
-													"    pm.test('allowKbToAddTitles is false', function() {",
-													"        pm.expect(response.data.attributes.allowKbToAddTitles).to.be.false;",
-													"    });",
-													"} else {",
-													"    console.log('Custom package not created');",
-													"}",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/vnd.api+json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test two\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"eholdings",
-												"packages"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
 						{
 							"name": "Negative",
 							"item": [

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "bb2060f6-8df8-4a6c-a378-49a70e44bcc2",
+		"_postman_id": "bb571132-a362-45ac-8e70-96f8f87b9f93",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -897,7 +897,7 @@
 			"name": "setup for packages test",
 			"item": [
 				{
-					"name": "create custom package for testing deletion",
+					"name": "Create custom package for testing deletion",
 					"event": [
 						{
 							"listen": "test",
@@ -1020,7 +1020,7 @@
 					"response": []
 				},
 				{
-					"name": "create custom package for testing deletion in PUT",
+					"name": "Create custom package for testing deletion in PUT",
 					"event": [
 						{
 							"listen": "test",
@@ -5873,6 +5873,135 @@
 				{
 					"name": "POST to package collection",
 					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "Create custom package valid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "807c50e4-0fd3-449b-b76f-26701581409c",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of packages in response",
+													"if(response.data) {",
+													"    if(response.data.id) {",
+													"        pm.environment.set(\"custom-package-id-created-in-post-valid\", response.data.id);",
+													"    }",
+													"    ",
+													"    //Test that type is packages",
+													"    pm.test('type is packages', function(){",
+													"        pm.expect(response.data.type).eq('packages');",
+													"    });",
+													"    ",
+													"    //Test that data.attributes has expected attributes",
+													"    pm.test('expected data.attributes are present', function() {",
+													"        pm.expect(response.data.attributes).to.be.an('object');",
+													"        pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\", \"isSelected\", \"name\", \"packageId\", ",
+													"        \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\");",
+													"    });",
+													"        ",
+													"    //Test that contentType matches what was passed in POST request",
+													"    pm.test('content type matches value passed in', function() {",
+													"        pm.expect(response.data.attributes.contentType).to.eq('E-Journal');",
+													"    });",
+													"    ",
+													"    //Test that customCoverage matches what was passed in POST request",
+													"    pm.test('custom coverage matches value passed in', function() {",
+													"        pm.expect(response.data.attributes.customCoverage.beginCoverage).to.eq('2003-01-01');",
+													"        pm.expect(response.data.attributes.customCoverage.endCoverage).to.eq('2003-12-01');",
+													"    });",
+													"    ",
+													"    //Test that isCustom is true",
+													"    pm.test('isCustom is true', function() {",
+													"        pm.expect(response.data.attributes.isCustom).to.be.true;",
+													"    });",
+													"    ",
+													"    //Test that isSelected is true",
+													"    pm.test('isSelected is true', function() {",
+													"        pm.expect(response.data.attributes.isSelected).to.be.true;",
+													"    });",
+													"    ",
+													"    //Test that name matches value passed in",
+													"    pm.test('name matches value passed in', function() {",
+													"        pm.expect(response.data.attributes.name).to.eq('custom packages api test valid');",
+													"    });",
+													"    ",
+													"    //Test that package type is custom",
+													"    pm.test('packageType is custom', function() {",
+													"        pm.expect(response.data.attributes.packageType).to.eq('Custom');",
+													"    });",
+													"    ",
+													"    //Test that allowKbToAddTitles is false",
+													"    pm.test('allowKbToAddTitles is false', function() {",
+													"        pm.expect(response.data.attributes.allowKbToAddTitles).to.be.false;",
+													"    });",
+													"} else {",
+													"    console.log('Custom package not created');",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test valid\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t}\n\t\t}\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
 						{
 							"name": "Negative",
 							"item": [
@@ -14254,6 +14383,96 @@
 						}
 					},
 					"response": []
+				}
+			]
+		},
+		{
+			"name": "tear-down packages",
+			"item": [
+				{
+					"name": "Delete custom package created in post",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "967dd204-5352-4475-940d-0d16f2b81eee",
+								"exec": [
+									"pm.test(\"Status is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "67c6fa5e-953a-4222-bc89-1e86fb2900f4",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.api+json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post-valid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"eholdings",
+								"packages",
+								"{{custom-package-id-created-in-post-valid}}"
+							]
+						},
+						"description": "Delete custom package created in post."
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "b47a327f-3526-4755-976f-483cadd0aeed",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "69ec6322-e5c9-41a7-9a75-b38840d01fac",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
 				}
 			]
 		}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-65 we want to have API tests for POST `/eholdings/packages `endpoint
## Approach

- checked if tests from https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json pass for the endpoint in Java
-  added api tests to the mod-kb-ebsco-java postman collection