### PR TITLE
MODKBEKBJ-77 - API Tests GET /eholdings/resources/{resourceId} endpoint, MODKBEKBJ-80 - Support ?include=title, MODKBEKBJ-79 - Support ?include=package, MODKBEKBJ-78 - Support ?include=provider

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "bb571132-a362-45ac-8e70-96f8f87b9f93",
+		"_postman_id": "e0f0d512-2259-4265-93b4-36e81ce09f1d",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -8019,6 +8019,1017 @@
 								}
 							],
 							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
+		},
+		{
+			"name": "resources",
+			"item": [
+				{
+					"name": "GET resource by resourceId",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "/resources GET specific resource (managed title)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "3229617c-2009-4392-800a-051cda9ddc4e",
+												"exec": [
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//verify headers",
+													"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+													"    pm.response.to.have.header(\"Content-Type\");",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+													"    pm.response.to.have.header(\"Transfer-Encoding\");",
+													"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+													"});",
+													"",
+													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+													"});",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"});",
+													"",
+													"pm.test(\"data type is as expected\", function () {",
+													"    pm.expect(firstRecord.type).eq(\"resources\");",
+													"});",
+													"",
+													"pm.test('title with requested id is returned', function() {",
+													"    pm.expect(firstRecord.id).to.eql(pm.environment.get(\"managed-resourceid\"));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"{{managed-resourceid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/resources GET specific resource (custom title)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "84bee548-e399-4759-bf34-09229ee1bbef",
+												"exec": [
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//verify headers",
+													"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+													"    pm.response.to.have.header(\"Content-Type\");",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+													"    pm.response.to.have.header(\"Transfer-Encoding\");",
+													"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+													"});",
+													"",
+													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+													"});",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"});",
+													"",
+													"pm.test(\"data type is as expected\", function () {",
+													"    pm.expect(firstRecord.type).eq(\"resources\");",
+													"});",
+													"",
+													"pm.test('title with requested id is returned', function() {",
+													"    pm.expect(firstRecord.id).to.eql(pm.environment.get(\"custom-resourceid\"));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"{{custom-resourceid}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/resources GET specific resource and include provider",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "e3f33bb8-6339-425f-88db-2ff6d42d86a1",
+												"exec": [
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"data type is as expected\", function () {",
+													"    pm.expect(firstRecord.type).eq(\"resources\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"});",
+													"",
+													"//Test that relationships has expected attributes",
+													"pm.test('expected relationships are present', function() {",
+													"    pm.expect(firstRecord.relationships).to.include.all.keys(\"provider\", \"title\", \"package\");",
+													" });",
+													"",
+													"pm.test('relationships meta should not include title', function() {",
+													"    pm.expect(firstRecord.relationships.title.meta.included).to.be.false;",
+													"});",
+													"",
+													"pm.test('relationships meta should not include package', function() {",
+													"    pm.expect(firstRecord.relationships.package.meta.included).to.be.false;",
+													"});",
+													"",
+													"//Get the provider relationship",
+													"let providerRelationship = firstRecord.relationships.provider.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in provider relationship', function() {",
+													"    pm.expect(providerRelationship).to.be.an('object');",
+													"    pm.expect(providerRelationship).to.include.all.keys(\"id\", \"type\");",
+													"    pm.expect(providerRelationship.id).eq(firstAttributes.providerId.toString());",
+													"});",
+													"",
+													" //Get the included",
+													"let includedItems = jsonData.included;",
+													"",
+													"//Test that included is an array of 1 record and has the expected keys",
+													"pm.test('expected keys are present in included array record', function() {",
+													"    pm.expect(includedItems).to.be.an('array');",
+													"    pm.expect(includedItems.length).to.eql(1);",
+													"    pm.expect(includedItems[0]).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"included type is as expected\", function () {",
+													"    pm.expect(includedItems[0].type).eq(\"providers\");",
+													"});",
+													"",
+													"pm.test(\"included id is as expected\", function () {",
+													"    pm.expect(includedItems[0].id).eq(firstAttributes.providerId.toString());",
+													"});",
+													"         ",
+													"        "
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}?include=provider",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"{{managed-resourceid}}"
+											],
+											"query": [
+												{
+													"key": "include",
+													"value": "provider"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/resources GET specific resource and include package",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "f4a87a3e-885e-40de-8e41-c2975fd64d95",
+												"exec": [
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"data type is as expected\", function () {",
+													"    pm.expect(firstRecord.type).eq(\"resources\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"});",
+													"",
+													"//Test that relationships has expected attributes",
+													"pm.test('expected relationships are present', function() {",
+													"    pm.expect(firstRecord.relationships).to.include.all.keys(\"provider\", \"title\", \"package\");",
+													" });",
+													"",
+													"pm.test('relationships meta should not include title', function() {",
+													"    pm.expect(firstRecord.relationships.title.meta.included).to.be.false;",
+													"});",
+													"",
+													"pm.test('relationships meta should not include provider', function() {",
+													"    pm.expect(firstRecord.relationships.provider.meta.included).to.be.false;",
+													"});",
+													"",
+													"//Get the package relationship",
+													"let packageRelationship = firstRecord.relationships.package.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in package relationship', function() {",
+													"    pm.expect(packageRelationship).to.be.an('object');",
+													"    pm.expect(packageRelationship).to.include.all.keys(\"id\", \"type\");",
+													"    pm.expect(packageRelationship.id).eq(firstAttributes.packageId.toString());",
+													"});",
+													"",
+													" //Get the included",
+													"let includedItems = jsonData.included;",
+													"",
+													"//Test that included is an array of 1 record and has the expected keys",
+													"pm.test('expected keys are present in included array record', function() {",
+													"    pm.expect(includedItems).to.be.an('array');",
+													"    pm.expect(includedItems.length).to.eql(1);",
+													"    pm.expect(includedItems[0]).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"included type is as expected\", function () {",
+													"    pm.expect(includedItems[0].type).eq(\"packages\");",
+													"});",
+													"",
+													"pm.test(\"included id is as expected\", function () {",
+													"    pm.expect(includedItems[0].id).eq(firstAttributes.packageId.toString());",
+													"});",
+													"         ",
+													"        "
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}?include=package",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"{{managed-resourceid}}"
+											],
+											"query": [
+												{
+													"key": "include",
+													"value": "package"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/resources GET specific resource and include title",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "514fa72e-d1ea-4aad-904b-896efc98606e",
+												"exec": [
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"data type is as expected\", function () {",
+													"    pm.expect(firstRecord.type).eq(\"resources\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"});",
+													"",
+													"//Test that relationships has expected attributes",
+													"pm.test('expected relationships are present', function() {",
+													"    pm.expect(firstRecord.relationships).to.include.all.keys(\"provider\", \"title\", \"package\");",
+													" });",
+													"",
+													"pm.test('relationships meta should not include package', function() {",
+													"    pm.expect(firstRecord.relationships.package.meta.included).to.be.false;",
+													"});",
+													"",
+													"pm.test('relationships meta should not include provider', function() {",
+													"    pm.expect(firstRecord.relationships.provider.meta.included).to.be.false;",
+													"});",
+													"",
+													"//Get the title relationship",
+													"let titleRelationship = firstRecord.relationships.title.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in title relationship', function() {",
+													"    pm.expect(titleRelationship).to.be.an('object');",
+													"    pm.expect(titleRelationship).to.include.all.keys(\"id\", \"type\");",
+													"    pm.expect(titleRelationship.id).eq(firstAttributes.titleId.toString());",
+													"});",
+													"",
+													" //Get the included",
+													"let includedItems = jsonData.included;",
+													"",
+													"//Test that included is an array of 1 record and has the expected keys",
+													"pm.test('expected keys are present in included array record', function() {",
+													"    pm.expect(includedItems).to.be.an('array');",
+													"    pm.expect(includedItems.length).to.eql(1);",
+													"    pm.expect(includedItems[0]).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"included type is as expected\", function () {",
+													"    pm.expect(includedItems[0].type).eq(\"titles\");",
+													"});",
+													"",
+													"pm.test(\"included id is as expected\", function () {",
+													"    pm.expect(includedItems[0].id).eq(firstAttributes.titleId.toString());",
+													"});",
+													"         ",
+													"        "
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}?include=title",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"{{managed-resourceid}}"
+											],
+											"query": [
+												{
+													"key": "include",
+													"value": "title"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/resources GET specific resource and include provider,package,title",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "4031b837-11a2-422d-b781-baebc5ac6b9c",
+												"exec": [
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"data type is as expected\", function () {",
+													"    pm.expect(firstRecord.type).eq(\"resources\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"});",
+													"",
+													"//Test that relationships has expected attributes",
+													"pm.test('expected relationships are present', function() {",
+													"    pm.expect(firstRecord.relationships).to.include.all.keys(\"provider\", \"title\", \"package\");",
+													" });",
+													"    ",
+													"//Get the provider relationship",
+													"let providerRelationship = firstRecord.relationships.provider.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in provider relationship', function() {",
+													"    pm.expect(providerRelationship).to.be.an('object');",
+													"    pm.expect(providerRelationship).to.include.all.keys(\"id\", \"type\");",
+													"    pm.expect(providerRelationship.id).eq(firstAttributes.providerId.toString());",
+													"});",
+													"",
+													"//Get the package relationship",
+													"let packageRelationship = firstRecord.relationships.package.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in package relationship', function() {",
+													"    pm.expect(packageRelationship).to.be.an('object');",
+													"    pm.expect(packageRelationship).to.include.all.keys(\"id\", \"type\");",
+													"    pm.expect(packageRelationship.id).eq(firstAttributes.packageId.toString());",
+													"});",
+													"",
+													"//Get the title relationship",
+													"let titleRelationship = firstRecord.relationships.title.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in title relationship', function() {",
+													"    pm.expect(titleRelationship).to.be.an('object');",
+													"    pm.expect(titleRelationship).to.include.all.keys(\"id\", \"type\");",
+													"    pm.expect(titleRelationship.id).eq(firstAttributes.titleId.toString());",
+													"});",
+													"",
+													" //Get the included",
+													"let includedItems = jsonData.included;",
+													"",
+													"//Test that included is an array of 3 records and has the expected keys",
+													"pm.test('expected keys are present in included array record', function() {",
+													"    pm.expect(includedItems).to.be.an('array');",
+													"    pm.expect(includedItems.length).to.eql(3);",
+													"    pm.expect(includedItems[0]).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"     ",
+													"var includedTitles = includedItems.filter(",
+													"        function(titles) {",
+													"            if (titles.type.toLowerCase().includes(\"titles\")) {",
+													"               return titles;",
+													"            }",
+													"        }",
+													"    );",
+													"    ",
+													"pm.test('Included title is as expected', function() {",
+													"    pm.expect(includedTitles.length).eq(1);",
+													"    pm.expect(includedTitles[0].id).eq(firstAttributes.titleId.toString());",
+													"});     ",
+													"",
+													"var includedPackages = includedItems.filter(",
+													"        function(packages) {",
+													"            if (packages.type.toLowerCase().includes(\"packages\")) {",
+													"               return packages;",
+													"            }",
+													"        }",
+													"    );",
+													"    ",
+													"pm.test('Included package is as expected', function() {",
+													"    pm.expect(includedPackages.length).eq(1);",
+													"    pm.expect(includedPackages[0].id).eq(firstAttributes.packageId.toString());",
+													"});          ",
+													"",
+													"var includedProvider = includedItems.filter(",
+													"        function(providers) {",
+													"            if (providers.type.toLowerCase().includes(\"providers\")) {",
+													"               return providers;",
+													"            }",
+													"        }",
+													"    );",
+													"    ",
+													"pm.test('Included provider is as expected', function() {",
+													"    pm.expect(includedProvider.length).eq(1);",
+													"    pm.expect(includedProvider[0].id).eq(firstAttributes.providerId.toString());",
+													"});           ",
+													"        "
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}?include=provider,package,title",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"{{managed-resourceid}}"
+											],
+											"query": [
+												{
+													"key": "include",
+													"value": "provider,package,title"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "/resources GET invalid resource",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "131ade68-03b3-42dd-b257-3da5a3cf3a1b",
+												"exec": [
+													"//https://issues.folio.org/browse/UIEH-486",
+													"// status should be 404 but returns a 400",
+													"pm.test(\"Status is 404\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    // to be updated with UIEH-486",
+													"    //pm.response.to.be.notFound;",
+													"    pm.response.to.be.badRequest;",
+													"    pm.response.to.have.jsonBody();",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//verify headers",
+													"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+													"    pm.response.to.have.header(\"Content-Type\");",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+													"    pm.response.to.have.header(\"Transfer-Encoding\");",
+													"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+													"});",
+													"",
+													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+													"});",
+													"",
+													"// https://issues.folio.org/browse/UIEH-464",
+													"// Errors array should return a more relevant response",
+													"pm.test(\"Errors array contains 1 entries\", function () {",
+													"   // pm.expect(jsonData.errors.length).to.eql(1);",
+													"   // pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid\");",
+													"    pm.expect(jsonData.errors.length).to.eql(1);",
+													"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid\");",
+													"});",
+													"",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/1",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"1"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/resources GET specific resource and invalid include",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "d6649ece-5a31-4912-b9f7-fe3a0bec9996",
+												"exec": [
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data;",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"pm.test(\"data type is as expected\", function () {",
+													"    pm.expect(firstRecord.type).eq(\"resources\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"});",
+													"",
+													"//Test that relationships has expected attributes and invalid include is ignored",
+													"pm.test('expected relationships are present', function() {",
+													"    pm.expect(firstRecord.relationships).to.include.all.keys(\"provider\", \"title\", \"package\");",
+													" });",
+													"",
+													"pm.test('relationships meta should not include provider', function() {",
+													"    pm.expect(firstRecord.relationships.provider.meta.included).to.be.false;",
+													"});",
+													"pm.test('relationships meta should not include package', function() {",
+													"    pm.expect(firstRecord.relationships.package.meta.included).to.be.false;",
+													"});",
+													"pm.test('relationships meta should not include title', function() {",
+													"    pm.expect(firstRecord.relationships.title.meta.included).to.be.false;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}?include=invalid",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"resources",
+												"{{managed-resourceid}}"
+											],
+											"query": [
+												{
+													"key": "include",
+													"value": "invalid"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "cebc5686-0ec1-4cf3-ae68-00ae46f638a6",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "8c1acddd-c978-42f0-8887-03978e7dd10b",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						}
 					],
 					"_postman_isSubFolder": true

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "3e19face-0e58-45d8-8cc2-d24b702a924e",
+		"_postman_id": "b42cfb86-3c4f-4f39-8c48-fee2811c3f7f",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -8022,12 +8022,7 @@
 						}
 					],
 					"_postman_isSubFolder": true
-				}
-			]
-		},
-		{
-			"name": "resources",
-			"item": [
+				},
 				{
 					"name": "GET resource by resourceId",
 					"item": [
@@ -8190,7 +8185,7 @@
 													"let firstAttributes = firstRecord.attributes;",
 													"pm.test('expected attributes are present in a record', function() {",
 													"    pm.expect(firstAttributes).to.be.an('object');",
-													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
 													"});",
 													"",
 													"pm.test(\"data type is as expected\", function () {",

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e0f0d512-2259-4265-93b4-36e81ce09f1d",
+		"_postman_id": "3e19face-0e58-45d8-8cc2-d24b702a924e",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -8819,15 +8819,12 @@
 											"script": {
 												"id": "131ade68-03b3-42dd-b257-3da5a3cf3a1b",
 												"exec": [
-													"//https://issues.folio.org/browse/UIEH-486",
-													"// status should be 404 but returns a 400",
+													"// status should be 404",
 													"pm.test(\"Status is 404\", function () {",
 													"    pm.response.to.have.status(400);",
 													"});",
 													"",
 													"pm.test(\"Response must have a json body\", function () {",
-													"    // to be updated with UIEH-486",
-													"    //pm.response.to.be.notFound;",
 													"    pm.response.to.be.badRequest;",
 													"    pm.response.to.have.jsonBody();",
 													"});",
@@ -8855,11 +8852,8 @@
 													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
 													"});",
 													"",
-													"// https://issues.folio.org/browse/UIEH-464",
 													"// Errors array should return a more relevant response",
 													"pm.test(\"Errors array contains 1 entries\", function () {",
-													"   // pm.expect(jsonData.errors.length).to.eql(1);",
-													"   // pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid\");",
 													"    pm.expect(jsonData.errors.length).to.eql(1);",
 													"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid\");",
 													"});",


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-77 we want to have API Tests for GET `/eholdings/resources/{resourceId}` endpoint
## Approach

- checked if tests from https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json pass for the endpoint in Java
-  added api tests to the mod-kb-ebsco-java postman collection