### PR TITLE
MODKBEKBJ-61 - API Tests GET /eholdings/providers/{providerId}/packages endpoint

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e206d691-f3dd-41f2-a8c2-562dcaa10921",
+		"_postman_id": "85a3b865-c92a-44d9-ac14-d1f98966d481",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -2977,7 +2977,6 @@
 													"    let len = response.data.length;",
 													"    if(len > 0){",
 													"        //Test that number of records returned are less than or equal to count",
-													"        //This should be re-visited after https://issues.folio.org/browse/UIEH-466 is fixed.",
 													"        pm.test('number of records returned are less than or equal to count', function(){",
 													"            pm.expect(len).to.be.at.most(5);",
 													"        });",
@@ -3450,8 +3449,7 @@
 													"",
 													"let response = pm.response.json();",
 													"",
-													"//Check that status is 500",
-													"//This test should be re-visited after https://issues.folio.org/browse/UIEH-425 is fixed.",
+													"//Check that status is 400",
 													"pm.test(\"Status is 400\", function () {",
 													"    pm.response.to.have.status(400);",
 													"});"
@@ -3524,8 +3522,9 @@
 													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
 													"    });",
 													"",
-													"    //We can test whether the appropriate error message is being returned after ",
-													"    //https://issues.folio.org/browse/UIEH-464 is fixed.",
+													"    pm.test('Ensure that response contains expected error message', function(){",
+													"       pm.expect(response.errors[0].title).to.eq('Search parameter cannot be empty'); ",
+													"    });",
 													"}",
 													""
 												],

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7f567dab-6f58-44bf-8590-c81006efb69c",
+		"_postman_id": "e206d691-f3dd-41f2-a8c2-562dcaa10921",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -2737,6 +2737,1277 @@
 								}
 							],
 							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "GET provider by providerId including packages",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "for provider that exists",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "252c3079-2899-4e60-8692-2483d29ad85b",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of providers in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Test that if no count is provided, default should be 25 records",
+													"        pm.test('no count provided', function(){",
+													"            pm.expect(len).eq(25);",
+													"        });",
+													"        ",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is packages",
+													"        pm.test('type is packages', function() {",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that data.attributes has expected attributes",
+													"        pm.test('expected data.attributes are present', function() {",
+													"            pm.expect(firstRecord.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\",\"isSelected\",\"name\", \"packageId\", \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\")",
+													"        });",
+													"        ",
+													"        //Test that providerId matches what we passed in ",
+													"        pm.test('providerId matches value passed in', function() {",
+													"            pm.expect(firstRecord.attributes.providerId).to.eq(19);",
+													"        });",
+													"        ",
+													"        //Test that relationships has expected attributes",
+													"        pm.test('expected relationships are present', function() {",
+													"            pm.expect(firstRecord.relationships).to.include.all.keys(\"resources\", \"provider\")",
+													"        });",
+													"    ",
+													"        //Test that resources are not included in relationships",
+													"        pm.test('relationships meta should not include resources', function() {",
+													"            pm.expect(firstRecord.relationships.resources.meta.included).to.be.false;",
+													"        });",
+													"        ",
+													"        //Test that provider are not included in relationships",
+													"        pm.test('relationships meta should not include provider', function() {",
+													"            pm.expect(firstRecord.relationships.provider.meta.included).to.be.false;",
+													"        })",
+													"    } else {",
+													"        console.log('No packages found for this provider');",
+													"    }",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with valid q param",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "7561c308-dd9d-4ce7-a6d4-b7ea4437d9ed",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check data array is of type providers if not null",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Get first record",
+													"        let firstRecord = response.data[0];",
+													"        //Test that type is packages",
+													"        pm.test('type is packages', function() {",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        })",
+													"        //Test that name contains either basket or weaving in it",
+													"        pm.test('name contains query string', function() {",
+													"            pm.expect(firstRecord.attributes.name).to.have.string('Search');",
+													"        })",
+													"    } else {",
+													"        console.log(\"No packages returned for this provider with this search query\");",
+													"    }",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with q and count",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "48432b4d-f7c2-4f08-b9e9-8f1eac8b921c",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of providers in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Test that number of records returned are less than or equal to count",
+													"        //This should be re-visited after https://issues.folio.org/browse/UIEH-466 is fixed.",
+													"        pm.test('number of records returned are less than or equal to count', function(){",
+													"            pm.expect(len).to.be.at.most(5);",
+													"        });",
+													"        ",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is providers",
+													"        pm.test('type is packages', function(){",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that Journal is in name",
+													"        pm.test('provider name contains search string', function() {",
+													"            pm.expect(firstRecord.attributes.name).to.include('Search');",
+													"        });",
+													"    }",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&count=5",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "count",
+													"value": "5"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "q and count and sort by name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "3c2a12ad-af4a-4a02-ad01-a5c1572ac6f9",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"//Check if we get a collection of packages in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 1){",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        let secondRecord = response.data[1];",
+													"        //Test that type is packages",
+													"        pm.test('type is providers', function() {",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"            pm.expect(secondRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that first and second records are sorted",
+													"        pm.test('first and second records are sorted', function(){",
+													"            pm.expect(firstRecord.attributes.name < secondRecord.attributes.name).to.be.true;",
+													"        })",
+													"        ",
+													"        //Test that Search is in name",
+													"        pm.test('package name contains search string', function() {",
+													"            pm.expect(firstRecord.attributes.name).to.include('Search');",
+													"            pm.expect(secondRecord.attributes.name).to.include('Search');",
+													"        });",
+													"    }",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&count=5&sort=name",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "count",
+													"value": "5"
+												},
+												{
+													"key": "sort",
+													"value": "name"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "valid filter[selected]",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "9c0b1aa3-a4a5-479c-a06e-9b41cf027bee",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of providers in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        ",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is packages",
+													"        pm.test('type is packages', function(){",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that Search is in name",
+													"        pm.test('provider name contains search string', function() {",
+													"            pm.expect(firstRecord.attributes.name).to.include('Search');",
+													"        });",
+													"        ",
+													"        //Test that isSelected is true",
+													"        pm.test('check isSelected', function() {",
+													"            pm.expect(firstRecord.attributes.isSelected).to.be.true;",
+													"        });",
+													"    }",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&filter[selected]=true",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "filter[selected]",
+													"value": "true"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "valid filter[selected] and filter[type]",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "42f3fba6-12ea-4671-b900-3eae020e17d9",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of providers in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        ",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is packages",
+													"        pm.test('type is packages', function(){",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that Search is in name",
+													"        pm.test('provider name contains search string', function() {",
+													"            pm.expect(firstRecord.attributes.name).to.include('Search');",
+													"        });",
+													"        ",
+													"        //Test that isSelected is true",
+													"        pm.test('check isSelected', function() {",
+													"            pm.expect(firstRecord.attributes.isSelected).to.be.true;",
+													"        });",
+													"        ",
+													"        //Test that contentType matches whats passed in query",
+													"        pm.test('check contentType', function() {",
+													"            pm.expect(firstRecord.attributes.contentType).to.eq('Aggregated Full Text');",
+													"        });",
+													"    }",
+													"}",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&filter[selected]=true&filter[type]=aggregatedfulltext",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "filter[selected]",
+													"value": "true"
+												},
+												{
+													"key": "filter[type]",
+													"value": "aggregatedfulltext"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "for non-existing provider",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "c8f0d0d1-f485-47c3-b783-65d618388eec",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 404",
+													"pm.test(\"Status is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Provider not found');",
+													"    }); ",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/1/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"1",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with invalid providerId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "f36aabf0-e2e9-4bbe-a28f-ccd9476ba8a0",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 500",
+													"//This test should be re-visited after https://issues.folio.org/browse/UIEH-425 is fixed.",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/abc/packages",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"abc",
+												"packages"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with invalid query param",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "cc001c28-3517-4831-8405-532b1dce3130",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //We can test whether the appropriate error message is being returned after ",
+													"    //https://issues.folio.org/browse/UIEH-464 is fixed.",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": ""
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "invalid page offset",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "4107bfa1-7d75-4212-a1c6-7f084d0d31de",
+												"exec": [
+													"//Ensure that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Ensure that response contains expected error message",
+													"pm.test(\"Response must have body with error message\", function () {",
+													"    pm.expect(pm.response.text()).to.be.eq('For input string: \"abc\"');",
+													"});",
+													"",
+													"//Check that X-Okapi-Trace header is present",
+													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&count=5&page=abc",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "count",
+													"value": "5"
+												},
+												{
+													"key": "page",
+													"value": "abc"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "q and sort param invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1681ef9a-06f2-4a09-8dd1-6dca2e1a00a8",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Ensure that appropriate error message is given",
+													"    pm.test('Ensure that expected error messages are seen', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Invalid Query Parameter for sort');",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&sort=invalid",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "sort",
+													"value": "invalid"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "filter[selected] invalid value",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "f1a0ae87-540c-47b8-a003-2975d04ce8cc",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//This should actually be a 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Ensure that appropriate error message is given",
+													"    pm.test('Ensure that expected error messages are seen', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Invalid Query Parameter for filter[selected]');",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&filter[selected]=invalid",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "filter[selected]",
+													"value": "invalid"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "invalid filter[type]",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "87060553-7e9d-49b6-ae25-d615196b7643",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Ensure that appropriate error message is being returned",
+													"    pm.test('Ensure that appropriate error message is returned', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Invalid Query Parameter for filter[type]');",
+													"    });",
+													"}",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?q=Search&filter[selected]=true&filter[type]=unsupported",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "q",
+													"value": "Search"
+												},
+												{
+													"key": "filter[selected]",
+													"value": "true"
+												},
+												{
+													"key": "filter[type]",
+													"value": "unsupported"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with count out of range",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "461f1d29-f4ec-417d-ad4e-e02eb5ccfe2b",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is not empty",
+													"pm.test('Ensure that errors array is not empty', function() {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"});",
+													"",
+													"//Ensure that we get the expected error message",
+													"pm.test('Ensure that errors title is as expected', function() {",
+													"    pm.expect(response.errors[0].title).eq('\\n \\'count\\' parameter is incorrect. parameter value {120} is not valid: must be less than or equal to 100');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/19/packages?count=120",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"19",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "count",
+													"value": "120"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "24b15e82-d116-4bf0-8a08-a8be15ed97ce",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "77861d0b-465c-4a78-b026-a9fa13fe4ed0",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						}
 					],
 					"_postman_isSubFolder": true


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-61 we want to have API Tests for GET /eholdings/providers/{providerId}/packages endpoint
## Approach

- checked if tests from https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json pass for the endpoint in Java
-  added api tests to the mod-kb-ebsco-java postman collection