### PR TITLE
API tests for POST /orders/id/lines and GET, DELETE /orders/id/lines/id endpoints

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -891,6 +891,76 @@
 						"description": "GET /orders/id requests that return 200"
 					},
 					"response": []
+				},
+				{
+					"name": "GET /orders/id/lines/polineId - get POLine by order Id and poline Id",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									" ",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Multiple notes exist\", function () {",
+									"    pm.expect(jsonData.id).to.have.length >= 0;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/{{polineId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines",
+								"{{polineId}}"
+							]
+						},
+						"description": "GET /orders/id/lines/id requests that return 200"
+					},
+					"response": []
 				}
 			],
 			"event": [
@@ -1304,6 +1374,207 @@
 							]
 						},
 						"description": "GET /orders/ requests that return 404"
+					},
+					"response": []
+				},
+				{
+					"name": "/orders/{{orderId}}/lines/{{polineId}} - empty polineId - 404",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});",
+									"",
+									"pm.test(\"empty instance ID returns error message\", function () {",
+									"     pm.expect(pm.response.text()).to.include(\"No suitable module found for path /orders/\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines",
+								""
+							]
+						},
+						"description": "GET /orders/id/lines/ requests that return 404"
+					},
+					"response": []
+				},
+				{
+					"name": "/orders/{{orderId}}/lines/{{polineId}} - invalid orderId - 422",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
+								"exec": [
+									"pm.test(\"Status code is 422\", function () {",
+									"    pm.response.to.have.status(422);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/invalido-rder-idit-note-xists0000000/lines/{{polineId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"invalido-rder-idit-note-xists0000000",
+								"lines",
+								"{{polineId}}"
+							]
+						},
+						"description": "GET /orders/id/lines/id requests that return 422"
+					},
+					"response": []
+				},
+				{
+					"name": "/orders/{{orderId}}/lines/{{polineId}} - invalid polineId - 404",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});",
+									"",
+									"pm.test(\"empty instance ID returns error message\", function () {",
+									"     pm.expect(pm.response.text()).to.include(\"po1ineid-with-eror-r404-000000000000\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/po1ineid-with-eror-r404-000000000000",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines",
+								"po1ineid-with-eror-r404-000000000000"
+							]
+						},
+						"description": "GET /orders/ requests that return 422"
 					},
 					"response": []
 				}

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1172,7 +1172,7 @@
 					"response": []
 				},
 				{
-					"name": "GET /orders/id - get orders by order id",
+					"name": "GET /orders/id - get order by id - 1 line",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -1263,13 +1263,8 @@
 							"script": {
 								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 								"exec": [
-									"let complete_poline_ids = globals.complete_poline_ids ? JSON.parse(globals.complete_poline_ids) : [];",
-									"if (complete_poline_ids.length > 0) {",
-									"    // Add the last po line id",
-									"    let lineId = complete_poline_ids[complete_poline_ids.length - 1];",
-									"    console.log(\"The PO Line id=\" + lineId);",
-									"    pm.variables.set(\"poline_id\", lineId);",
-									"}"
+									"let utils = eval(globals.loadUtils);",
+									"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
 								],
 								"type": "text/javascript"
 							}
@@ -1427,10 +1422,7 @@
 								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 								"exec": [
 									"let utils = eval(globals.loadUtils);",
-									"let lineId = utils.getLastPoLineId();",
-									"if (lineId) {",
-									"    pm.variables.set(\"poline_id\", lineId);",
-									"}"
+									"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
 								],
 								"type": "text/javascript"
 							}
@@ -1594,10 +1586,7 @@
 								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 								"exec": [
 									"let utils = eval(globals.loadUtils);",
-									"let lineId = utils.getLastPoLineId();",
-									"if (lineId) {",
-									"    pm.variables.set(\"poline_id\", lineId);",
-									"}"
+									"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
 								],
 								"type": "text/javascript"
 							}
@@ -1655,7 +1644,7 @@
 					"response": []
 				},
 				{
-					"name": "GET /orders/id - get orders by order id - 1 line",
+					"name": "GET /orders/id - get order with 1 line",
 					"event": [
 						{
 							"listen": "prerequest",

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -164,6 +164,57 @@
 					"response": []
 				},
 				{
+					"name": "alert.json",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+								"exec": [
+									"pm.test(pm.variables.get(\"schema_alert\") + \" GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									"pm.environment.set(\"schema_alert_content\", responseBody);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{schema_loc}}/{{module}}/schemas/{{schema_alert}}",
+							"host": [
+								"{{schema_loc}}"
+							],
+							"path": [
+								"{{module}}",
+								"schemas",
+								"{{schema_alert}}"
+							]
+						},
+						"description": "GET schema validation"
+					},
+					"response": []
+				},
+				{
 					"name": "composite_po_line.json",
 					"event": [
 						{
@@ -264,6 +315,57 @@
 					"response": []
 				},
 				{
+					"name": "claim.json",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+								"exec": [
+									"pm.test(pm.variables.get(\"schema_claim\") + \" GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									"pm.environment.set(\"schema_claim_content\", responseBody);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{schema_loc}}/{{module}}/schemas/{{schema_claim}}",
+							"host": [
+								"{{schema_loc}}"
+							],
+							"path": [
+								"{{module}}",
+								"schemas",
+								"{{schema_claim}}"
+							]
+						},
+						"description": "GET schema validation"
+					},
+					"response": []
+				},
+				{
 					"name": "details.json",
 					"event": [
 						{
@@ -308,6 +410,108 @@
 								"{{module}}",
 								"schemas",
 								"{{schema_details}}"
+							]
+						},
+						"description": "GET schema validation"
+					},
+					"response": []
+				},
+				{
+					"name": "eresource.json",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+								"exec": [
+									"pm.test(pm.variables.get(\"schema_eresource\") + \" GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									"pm.environment.set(\"schema_eresource_content\", responseBody);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{schema_loc}}/{{module}}/schemas/{{schema_eresource}}",
+							"host": [
+								"{{schema_loc}}"
+							],
+							"path": [
+								"{{module}}",
+								"schemas",
+								"{{schema_eresource}}"
+							]
+						},
+						"description": "GET schema validation"
+					},
+					"response": []
+				},
+				{
+					"name": "fund_distribution.json",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+								"exec": [
+									"pm.test(pm.variables.get(\"schema_fund_distribution\") + \" GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									"pm.environment.set(\"schema_fund_distribution_content\", responseBody);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{schema_loc}}/{{module}}/schemas/{{schema_fund_distribution}}",
+							"host": [
+								"{{schema_loc}}"
+							],
+							"path": [
+								"{{module}}",
+								"schemas",
+								"{{schema_fund_distribution}}"
 							]
 						},
 						"description": "GET schema validation"
@@ -417,6 +621,159 @@
 					"response": []
 				},
 				{
+					"name": "renewal.json",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+								"exec": [
+									"pm.test(pm.variables.get(\"schema_renewal\") + \" GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									"pm.environment.set(\"schema_renewal_content\", responseBody);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{schema_loc}}/{{module}}/schemas/{{schema_renewal}}",
+							"host": [
+								"{{schema_loc}}"
+							],
+							"path": [
+								"{{module}}",
+								"schemas",
+								"{{schema_renewal}}"
+							]
+						},
+						"description": "GET schema validation"
+					},
+					"response": []
+				},
+				{
+					"name": "reporting_code.json",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+								"exec": [
+									"pm.test(pm.variables.get(\"schema_reporting_code\") + \" GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									"pm.environment.set(\"schema_reporting_code_content\", responseBody);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{schema_loc}}/{{module}}/schemas/{{schema_reporting_code}}",
+							"host": [
+								"{{schema_loc}}"
+							],
+							"path": [
+								"{{module}}",
+								"schemas",
+								"{{schema_reporting_code}}"
+							]
+						},
+						"description": "GET schema validation"
+					},
+					"response": []
+				},
+				{
+					"name": "source.json",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+								"exec": [
+									"pm.test(pm.variables.get(\"schema_source\") + \" GET OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									"pm.environment.set(\"schema_source_content\", responseBody);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{schema_loc}}/{{module}}/schemas/{{schema_source}}",
+							"host": [
+								"{{schema_loc}}"
+							],
+							"path": [
+								"{{module}}",
+								"schemas",
+								"{{schema_source}}"
+							]
+						},
+						"description": "GET schema validation"
+					},
+					"response": []
+				},
+				{
 					"name": "vendor_detail.json",
 					"event": [
 						{
@@ -519,7 +876,7 @@
 									"});",
 									"",
 									"pm.test(\"modules exist\", function () {",
-									"    pm.expect(jsonData).to.have.length > 1;",
+									"    pm.expect(jsonData).to.have.lengthOf(1);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -547,7 +904,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/modules",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/modules?filter=mod-orders",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -557,6 +914,12 @@
 								"_",
 								"proxy",
 								"modules"
+							],
+							"query": [
+								{
+									"key": "filter",
+									"value": "mod-orders"
+								}
 							]
 						},
 						"description": "GET /_/proxy/modules requests that returns 200"
@@ -592,10 +955,10 @@
 									"});",
 									"",
 									"pm.test(\"Each order has required fields\", function(){",
-									"    pm.expect(jsonData.composite_purchase_orders[0].id).to.exist;",
-									"    pm.expect(jsonData.composite_purchase_orders[0].notes).to.exist;",
-									"    pm.expect(jsonData.composite_purchase_orders[0].po_number).to.exist;",
-									"    pm.expect(jsonData.composite_purchase_orders[0].po_lines).to.exist;",
+									"    pm.expect(jsonData.purchase_orders[0].id).to.exist;",
+									"    pm.expect(jsonData.purchase_orders[0].notes).to.exist;",
+									"    pm.expect(jsonData.purchase_orders[0].po_number).to.exist;",
+									"    //pm.expect(jsonData.purchase_orders[0].po_lines).to.exist;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -726,14 +1089,9 @@
 									"        method: \"GET\"",
 									"    },",
 									"    function (err, res) {",
-									"        pm.globals.set(\"po_listed_print_monograph\", res.text());     ",
+									"        pm.globals.set(\"po_listed_print_monograph\", res.text());",
 									"    }",
-									");",
-									"",
-									"",
-									"",
-									"",
-									""
+									");"
 								],
 								"type": "text/javascript"
 							}
@@ -743,6 +1101,7 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
+									"let utils = eval(globals.loadUtils);",
 									"var jsonData = pm.response.json();",
 									" ",
 									"pm.environment.set(\"order_id\", jsonData.id);",
@@ -753,9 +1112,15 @@
 									"",
 									"pm.test(\"po_lines exist\", function () {",
 									"    pm.expect(jsonData.po_lines).to.have.lengthOf(1);",
+									"",
+									"    let poLine = jsonData.po_lines[0];",
+									"    utils.rememberPoLineId(poLine);",
+									"    pm.expect(poLine.id).to.exist;",
+									"    pm.expect(poLine.purchase_order_id).to.equal(jsonData.id);",
+									"    utils.validatePoLineSubObjetcsPresence(poLine);",
 									"});",
 									"",
-									"pm.test(\"Each order has these optional fields\", function(){",
+									"pm.test(\"Each order has these optional fields\", function() {",
 									"    pm.expect(jsonData.id).to.exist;",
 									"    pm.globals.set(\"complete_order_id\", jsonData.id); ",
 									"    pm.expect(jsonData.approved).to.exist;",
@@ -763,8 +1128,6 @@
 									"    pm.expect(jsonData.notes).to.exist;",
 									"    pm.expect(jsonData.total_items).to.exist;",
 									"    pm.expect(jsonData.vendor).to.exist;",
-									"    pm.expect(jsonData.po_lines).to.exist;",
-									"    pm.globals.set(\"complete_poline_id\", jsonData.po_lines[0].id);",
 									"});",
 									""
 								],
@@ -826,6 +1189,7 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
+									"let utils = eval(globals.loadUtils);",
 									"var jsonData = pm.response.json();",
 									" ",
 									"pm.test(\"Status code is 200\", function () {",
@@ -837,19 +1201,18 @@
 									"});",
 									"",
 									"pm.test(\"Validate schema for composite_purchase_order.json\", function () {",
-									"     //Create and add schemas for validation",
-									"     //https://github.com/folio-org/acq-models/blob/master/composite_purchase_order.json",
-									"    tv4.addSchema(\"mod-orders-storage/schemas/adjustment.json\", JSON.parse(pm.environment.get(\"schema_adjustment_content\")));",
-									"    tv4.addSchema(\"composite_purchase_order.json\", JSON.parse(pm.environment.get(\"schema_composite_purchase_order_content\")));",
-									"    tv4.addSchema(\"composite_po_line.json\", JSON.parse(pm.environment.get(\"schema_composite_po_line_content\")));",
-									"    tv4.addSchema(\"mod-orders-storage/schemas/cost.json\", JSON.parse(pm.environment.get(\"schema_cost_content\")));",
-									"    tv4.addSchema(\"mod-orders-storage/schemas/details.json\", JSON.parse(pm.environment.get(\"schema_details_content\")));",
-									"    tv4.addSchema(\"mod-orders-storage/schemas/location.json\", JSON.parse(pm.environment.get(\"schema_location_content\")));",
-									"    tv4.addSchema(\"mod-orders-storage/schemas/physical.json\", JSON.parse(pm.environment.get(\"schema_physical_content\")));",
-									"    tv4.addSchema(\"mod-orders-storage/schemas/vendor_detail.json\", JSON.parse(pm.environment.get(\"schema_vendor_detail_content\")));",
-									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_composite_purchase_order_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    //make sure no schemas are missing",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+									"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"order_id\"));",
+									"    utils.validateOrderAgainstSchema(jsonData);",
+									"});",
+									"",
+									"pm.test(\"po_lines exist\", function () {",
+									"    pm.expect(jsonData.po_lines).to.have.lengthOf(1);",
+									"",
+									"    let poLine = jsonData.po_lines[0];",
+									"    pm.expect(poLine.id).to.exist;",
+									"    pm.expect(poLine.purchase_order_id).to.equal(jsonData.id);",
+									"    utils.validatePoLineSubObjetcsPresence(poLine);",
+									"    utils.validatePoLineAgainstSchema(poLine);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -900,7 +1263,13 @@
 							"script": {
 								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 								"exec": [
-									""
+									"let complete_poline_ids = globals.complete_poline_ids ? JSON.parse(globals.complete_poline_ids) : [];",
+									"if (complete_poline_ids.length > 0) {",
+									"    // Add the last po line id",
+									"    let lineId = complete_poline_ids[complete_poline_ids.length - 1];",
+									"    console.log(\"The PO Line id=\" + lineId);",
+									"    pm.variables.set(\"poline_id\", lineId);",
+									"}"
 								],
 								"type": "text/javascript"
 							}
@@ -910,14 +1279,21 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
+									"let utils = eval(globals.loadUtils);",
 									"var jsonData = pm.response.json();",
 									" ",
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"Multiple notes exist\", function () {",
-									"    pm.expect(jsonData.id).to.have.length >= 0;",
+									"pm.test(\"po_line has content\", function () {",
+									"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poline_id\"));",
+									"    pm.expect(jsonData.purchase_order_id).to.equal(pm.variables.get(\"order_id\"));",
+									"    utils.validatePoLineSubObjetcsPresence(jsonData);",
+									"});",
+									"",
+									"pm.test(\"Validate schema for composite_po_line.json\", function () {",
+									"    utils.validatePoLineAgainstSchema(jsonData);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -936,7 +1312,7 @@
 								"value": "application/json"
 							},
 							{
-								"key": "X-Okapi-Token",
+								"key": "x-okapi-token",
 								"value": "{{xokapitoken}}"
 							}
 						],
@@ -945,7 +1321,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/{{polineId}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/{{poline_id}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -955,10 +1331,400 @@
 								"orders",
 								"{{order_id}}",
 								"lines",
-								"{{polineId}}"
+								"{{poline_id}}"
+							]
+						},
+						"description": "GET /orders/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "POST /orders/id/lines - add POLine to existing order",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let line = JSON.parse(pm.globals.get(\"po_listed_print_monograph\")).po_lines[0];",
+									"// make sure there is no id provided",
+									"delete line.id;",
+									"line.po_line_number += \"1\";",
+									"line.po_line_description += \" another PO Line\";",
+									"pm.variables.set(\"po_line_listed_print_monograph\", JSON.stringify(line));"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"var jsonData = pm.response.json();",
+									"",
+									"utils.rememberPoLineId(jsonData);",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Order line has required and optional fields\", function(){",
+									"    pm.expect(jsonData.id).to.exist;",
+									"    pm.expect(jsonData.purchase_order_id).to.equal(pm.variables.get(\"order_id\"));",
+									"    utils.validatePoLineSubObjetcsPresence(jsonData);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{po_line_listed_print_monograph}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines"
 							]
 						},
 						"description": "GET /orders/id/lines/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "GET /orders/id/lines/polineId - get POLine by order Id and poline",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"let lineId = utils.getLastPoLineId();",
+									"if (lineId) {",
+									"    pm.variables.set(\"poline_id\", lineId);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"var jsonData = pm.response.json();",
+									" ",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"po_line has content\", function () {",
+									"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poline_id\"));",
+									"    pm.expect(jsonData.purchase_order_id).to.equal(pm.variables.get(\"order_id\"));",
+									"    utils.validatePoLineSubObjetcsPresence(jsonData);",
+									"});",
+									"",
+									"pm.test(\"Validate schema for composite_po_line.json\", function () {",
+									"    utils.validatePoLineAgainstSchema(jsonData);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/{{poline_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines",
+								"{{poline_id}}"
+							]
+						},
+						"description": "GET /orders/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "GET /orders/id - get order with 2 order lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"var jsonData = pm.response.json();",
+									" ",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Multiple notes exist\", function () {",
+									"    pm.expect(jsonData.notes).to.have.length >= 1;",
+									"});",
+									"",
+									"pm.test(\"Validate schema for composite_purchase_order.json\", function () {",
+									"    utils.validateOrderAgainstSchema(jsonData);",
+									"});",
+									"",
+									"pm.test(\"2 po_lines exist\", function () {",
+									"    let lines = jsonData.po_lines;",
+									"    pm.expect(lines).to.have.lengthOf(2);",
+									"",
+									"    for (let i = 0; i < lines.length; i++) {",
+									"        let poLine = lines[i];",
+									"        pm.expect(poLine.id).to.exist;",
+									"        pm.expect(poLine.purchase_order_id).to.equal(jsonData.id);",
+									"        utils.validatePoLineSubObjetcsPresence(poLine);",
+									"        utils.validatePoLineAgainstSchema(poLine);",
+									"    }",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}"
+							]
+						},
+						"description": "GET /orders/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE /orders/id/lines/polineId - delete second line",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"let lineId = utils.getLastPoLineId();",
+									"if (lineId) {",
+									"    pm.variables.set(\"poline_id\", lineId);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/{{poline_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines",
+								"{{poline_id}}"
+							]
+						},
+						"description": "GET /orders/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "GET /orders/id - get orders by order id - 1 line",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"var jsonData = pm.response.json();",
+									" ",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"1 po_line exist\", function () {",
+									"    pm.expect(jsonData.po_lines).to.have.lengthOf(1);",
+									"",
+									"    let poLine = jsonData.po_lines[0];",
+									"    pm.expect(poLine.id).to.exist;",
+									"    pm.expect(poLine.purchase_order_id).to.equal(jsonData.id);",
+									"    utils.validatePoLineSubObjetcsPresence(poLine);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}"
+							]
+						},
+						"description": "GET /orders/id requests that return 200"
 					},
 					"response": []
 				}
@@ -1378,7 +2144,151 @@
 					"response": []
 				},
 				{
-					"name": "/orders/{{orderId}}/lines/{{polineId}} - empty polineId - 404",
+					"name": "/orders/poId/lines/lineId - deleted line - 404",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"let lineId = utils.getLastPoLineId();",
+									"if (lineId) {",
+									"    pm.variables.set(\"poline_id\", lineId);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});",
+									"",
+									"pm.test(\"empty instance ID returns error message\", function () {",
+									"     pm.expect(pm.response.text()).to.exist;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/{{poline_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines",
+								"{{poline_id}}"
+							]
+						},
+						"description": "GET /orders/id/lines/ requests that return 404"
+					},
+					"response": []
+				},
+				{
+					"name": "/orders/poId/lines/lineId - deleted line - 404",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"let lineId = utils.getLastPoLineId(true);",
+									"if (lineId) {",
+									"    pm.variables.set(\"poline_id\", lineId);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});",
+									"",
+									"pm.test(\"empty instance ID returns error message\", function () {",
+									"     pm.expect(pm.response.text()).to.exist;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines/{{poline_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines",
+								"{{poline_id}}"
+							]
+						},
+						"description": "GET /orders/id/lines/ requests that return 404"
+					},
+					"response": []
+				},
+				{
+					"name": "/orders/poId/lines/lineId - empty polineId - 404",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -1446,14 +2356,18 @@
 					"response": []
 				},
 				{
-					"name": "/orders/{{orderId}}/lines/{{polineId}} - invalid orderId - 422",
+					"name": "/orders/poId/lines/lineId - invalid orderId - 422",
 					"event": [
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
 								"exec": [
-									""
+									"let utils = eval(globals.loadUtils);",
+									"let lineId = utils.getLastPoLineId();",
+									"if (lineId) {",
+									"    pm.variables.set(\"poline_id\", lineId);",
+									"}"
 								],
 								"type": "text/javascript"
 							}
@@ -1463,8 +2377,10 @@
 							"script": {
 								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
 								"exec": [
+									"var jsonData = pm.response.json();",
 									"pm.test(\"Status code is 422\", function () {",
 									"    pm.response.to.have.status(422);",
+									"    pm.expect(jsonData.errors).to.have.lengthOf(1);",
 									"});",
 									""
 								],
@@ -1493,7 +2409,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/invalido-rder-idit-note-xists0000000/lines/{{polineId}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{$guid}}/lines/{{poline_id}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -1501,9 +2417,9 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"orders",
-								"invalido-rder-idit-note-xists0000000",
+								"{{$guid}}",
 								"lines",
-								"{{polineId}}"
+								"{{poline_id}}"
 							]
 						},
 						"description": "GET /orders/id/lines/id requests that return 422"
@@ -1511,7 +2427,7 @@
 					"response": []
 				},
 				{
-					"name": "/orders/{{orderId}}/lines/{{polineId}} - invalid polineId - 404",
+					"name": "/orders/poId/lines/lineId - invalid polineId - 404",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -1575,6 +2491,143 @@
 							]
 						},
 						"description": "GET /orders/ requests that return 422"
+					},
+					"response": []
+				},
+				{
+					"name": "/orders/poId/lines/lineId - invalid orderId - 422",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"let lineId = utils.getLastPoLineId();",
+									"if (lineId) {",
+									"    pm.variables.set(\"poline_id\", lineId);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
+								"exec": [
+									"pm.test(\"Status code is 422\", function () {",
+									"    pm.response.to.have.status(422);",
+									"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{$guid}}/lines/{{poline_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{$guid}}",
+								"lines",
+								"{{poline_id}}"
+							]
+						},
+						"description": "GET /orders/id/lines/id requests that return 422"
+					},
+					"response": []
+				},
+				{
+					"name": "/orders/poId/lines/lineId - invalid orderId in line - 400",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"exec": [
+									"var uuid = require('uuid');",
+									"let line = JSON.parse(pm.globals.get(\"po_listed_print_monograph\")).po_lines[0];",
+									"line.purchase_order_id = uuid.v4();",
+									"pm.variables.set(\"po_line_listed_print_monograph\", JSON.stringify(line));"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ccc9c5b5-89d5-413c-8c48-5d7b817d6dc6",
+								"exec": [
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-Okapi-Tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{po_line_listed_print_monograph}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/{{order_id}}/lines",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"{{order_id}}",
+								"lines"
+							]
+						},
+						"description": "GET /orders/id/lines/id requests that return 422"
 					},
 					"response": []
 				}
@@ -1778,7 +2831,11 @@
 							"script": {
 								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 								"exec": [
-									""
+									"let utils = eval(globals.loadUtils);",
+									"let lineId = utils.getLastPoLineId();",
+									"if (lineId) {",
+									"    pm.variables.set(\"complete_poline_id\", lineId);",
+									"}"
 								],
 								"type": "text/javascript"
 							}
@@ -1904,7 +2961,129 @@
 				"id": "29271af0-d608-4fd0-a6d0-7f47697b19ba",
 				"type": "text/javascript",
 				"exec": [
-					""
+					"postman.setGlobalVariable(\"loadUtils\", function loadUtils() {",
+					"    let utils = {};",
+					"",
+					"    /**",
+					"     * Validates presence of the PO line sub-object elements",
+					"     */",
+					"    utils.validatePoLineSubObjetcsPresence = function(jsonData) {",
+					"        pm.expect(jsonData.acquisition_method, \"acquisition_method expected\").to.exist;",
+					"        pm.expect(jsonData.adjustment, \"adjustment expected\").to.exist;",
+					"        pm.expect(jsonData.alerts, \"alerts expected\").to.exist;",
+					"        pm.expect(jsonData.cancellation_restriction, \"cancellation_restriction expected\").to.exist;",
+					"        pm.expect(jsonData.cancellation_restriction_note, \"cancellation_restriction_note expected\").to.exist;",
+					"        pm.expect(jsonData.claims, \"claims expected\").to.exist;",
+					"        pm.expect(jsonData.contributors, \"contributors expected\").to.exist;",
+					"        pm.expect(jsonData.cost, \"cost expected\").to.exist;",
+					"        pm.expect(jsonData.description, \"description expected\").to.exist;",
+					"        pm.expect(jsonData.donor, \"donor expected\").to.exist;",
+					"        pm.expect(jsonData.fund_distribution, \"fund_distribution expected\").to.exist;",
+					"        pm.expect(jsonData.location, \"location expected\").to.exist;",
+					"        pm.expect(jsonData.order_format, \"order_format expected\").to.exist;",
+					"        pm.expect(jsonData.owner, \"owner expected\").to.exist;",
+					"        pm.expect(jsonData.payment_status, \"payment_status expected\").to.exist;",
+					"        pm.expect(jsonData.physical, \"physical expected\").to.exist;",
+					"        pm.expect(jsonData.po_line_description, \"po_line_description expected\").to.exist;",
+					"        pm.expect(jsonData.po_line_number, \"po_line_number expected\").to.exist;",
+					"        pm.expect(jsonData.po_line_workflow_status, \"po_line_workflow_status expected\").to.exist;",
+					"        pm.expect(jsonData.publication_date, \"publication_date expected\").to.exist;",
+					"        pm.expect(jsonData.publisher, \"publisher expected\").to.exist;",
+					"        pm.expect(jsonData.receipt_date, \"receipt_date expected\").to.exist;",
+					"        pm.expect(jsonData.receipt_status, \"receipt_status expected\").to.exist;",
+					"        pm.expect(jsonData.reporting_codes, \"reporting_codes expected\").to.exist;",
+					"        pm.expect(jsonData.requester, \"requester expected\").to.exist;",
+					"        pm.expect(jsonData.rush, \"rush expected\").to.exist;",
+					"        pm.expect(jsonData.selector, \"selector expected\").to.exist;",
+					"        //pm.expect(jsonData.source, \"source expected\").to.exist;",
+					"        pm.expect(jsonData.tags, \"tags expected\").to.exist;",
+					"        pm.expect(jsonData.title, \"title expected\").to.exist;",
+					"        pm.expect(jsonData.vendor_detail, \"vendor_detail expected\").to.exist;",
+					"    };",
+					"    ",
+					"    /**",
+					"     * Adds PO line id to `complete_poline_ids` array and stores as global variable.",
+					"     */",
+					"    utils.rememberPoLineId = function(jsonData) {",
+					"        if (jsonData && jsonData.id) {",
+					"            let complete_poline_ids = pm.globals.get(\"complete_poline_ids\") ? JSON.parse(pm.globals.get(\"complete_poline_ids\")) : [];",
+					"            complete_poline_ids.push(jsonData.id);",
+					"            pm.globals.set(\"complete_poline_ids\", JSON.stringify(complete_poline_ids));",
+					"        }",
+					"    };",
+					"",
+					"    /**",
+					"     * Gets last id from `complete_poline_ids` array (global variable).",
+					"     * In case the `withRemoval==true`, the last id is removed from array.",
+					"     * In case the array is empty, `null` is returned",
+					"     */",
+					"    utils.getLastPoLineId = function(withRemoval) {",
+					"        let complete_poline_ids = globals.complete_poline_ids ? JSON.parse(globals.complete_poline_ids) : [];",
+					"        console.log(\"PO lines length=\" + complete_poline_ids.length);",
+					"        if (complete_poline_ids.length > 0) {",
+					"            let lineId = complete_poline_ids.pop();",
+					"            if (withRemoval) {",
+					"                pm.globals.set(\"complete_poline_ids\", JSON.stringify(complete_poline_ids));",
+					"            }",
+					"            return lineId;",
+					"        }",
+					"        return null;",
+					"    };",
+					"",
+					"    /**",
+					"     * Validates the PO line content against schemas",
+					"     */",
+					"    utils.validatePoLineAgainstSchema = function(jsonData) {",
+					"        let schema = JSON.parse(pm.environment.get(\"schema_composite_po_line_content\"));",
+					"        utils._validateAgainstSchema(jsonData, schema);",
+					"    };",
+					"",
+					"    /**",
+					"     * Validates the PO content against schemas",
+					"     */",
+					"    utils.validateOrderAgainstSchema = function(jsonData) {",
+					"        let schema = JSON.parse(pm.environment.get(\"schema_composite_purchase_order_content\"));",
+					"        utils._validateAgainstSchema(jsonData, schema);",
+					"    };",
+					"",
+					"    /**",
+					"     * Internal function to validate object against specified schema",
+					"     */",
+					"    utils._validateAgainstSchema = function(jsonData, schema) {",
+					"        utils._addSchemas();",
+					"        var result = tv4.validateMultiple(jsonData, schema);",
+					"        pm.expect(result.valid).to.equal(true, \"Schema validation error: \" + JSON.stringify(result.errors));",
+					"        //make sure no schemas are missing",
+					"        pm.expect(result.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(result.missing));",
+					"    };",
+					"",
+					"    /**",
+					"     * Internal function to load schema defenitions to tv4",
+					"     */",
+					"    utils._addSchemas = function() {",
+					"        //Create and add schemas for validation",
+					"        //https://github.com/folio-org/acq-models/blob/master/composite_purchase_order.json",
+					"        //https://github.com/folio-org/acq-models/blob/master/composite_po_line.json",
+					"        tv4.addSchema(\"composite_purchase_order.json\", JSON.parse(pm.environment.get(\"schema_composite_purchase_order_content\")));",
+					"        tv4.addSchema(\"composite_po_line.json\", JSON.parse(pm.environment.get(\"schema_composite_po_line_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/adjustment.json\", JSON.parse(pm.environment.get(\"schema_adjustment_content\")));",
+					"        //tv4.addSchema(\"mod-orders-storage/schemas/alert.json\", JSON.parse(pm.environment.get(\"schema_alert_content\")));",
+					"        //tv4.addSchema(\"mod-orders-storage/schemas/claim.json\", JSON.parse(pm.environment.get(\"schema_claim_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/cost.json\", JSON.parse(pm.environment.get(\"schema_cost_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/details.json\", JSON.parse(pm.environment.get(\"schema_details_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/eresource.json\", JSON.parse(pm.environment.get(\"schema_eresource_content\")));",
+					"        //tv4.addSchema(\"mod-orders-storage/schemas/fund_distribution.json\", JSON.parse(pm.environment.get(\"schema_fund_distribution_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/location.json\", JSON.parse(pm.environment.get(\"schema_location_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/physical.json\", JSON.parse(pm.environment.get(\"schema_physical_content\")));",
+					"        //tv4.addSchema(\"mod-orders-storage/schemas/renewal.json\", JSON.parse(pm.environment.get(\"schema_renewal_content\")));",
+					"        //tv4.addSchema(\"mod-orders-storage/schemas/reporting_code.json\", JSON.parse(pm.environment.get(\"schema_reporting_code_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/source.json\", JSON.parse(pm.environment.get(\"schema_source_content\")));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/vendor_detail.json\", JSON.parse(pm.environment.get(\"schema_vendor_detail_content\")));",
+					"    };",
+					"",
+					"    return utils;",
+					"",
+					"} + '; loadUtils();');"
 				]
 			}
 		},
@@ -1927,6 +3106,12 @@
 			"type": "string"
 		},
 		{
+			"id": "c12f42d4-73a2-407c-91b5-a00b68c86914",
+			"key": "schema_loc",
+			"value": "https://raw.githubusercontent.com/folio-org/acq-models/master",
+			"type": "string"
+		},
+		{
 			"id": "6055da93-6880-48de-a0d9-b7eb56de521e",
 			"key": "schema_composite_purchase_order",
 			"value": "composite_purchase_order.json",
@@ -1936,6 +3121,18 @@
 			"id": "568e4f64-6afb-40e4-82bd-5d11841a627d",
 			"key": "schema_adjustment",
 			"value": "adjustment.json",
+			"type": "string"
+		},
+		{
+			"id": "5e1053a1-63b6-4728-914e-cbd51177b688",
+			"key": "schema_alert",
+			"value": "alert.json",
+			"type": "string"
+		},
+		{
+			"id": "faf7ff79-ee4f-479e-ad93-a3168808e0ac",
+			"key": "schema_claim",
+			"value": "claim.json",
 			"type": "string"
 		},
 		{
@@ -1957,6 +3154,18 @@
 			"type": "string"
 		},
 		{
+			"id": "4ba909d7-acd7-40d6-8d32-e538cc0a301d",
+			"key": "schema_eresource",
+			"value": "eresource.json",
+			"type": "string"
+		},
+		{
+			"id": "ed767052-dea6-4b07-a0df-e36b75192a57",
+			"key": "schema_fund_distribution",
+			"value": "fund_distribution.json",
+			"type": "string"
+		},
+		{
 			"id": "09335df3-adc3-4464-9430-e13691140b1a",
 			"key": "schema_location",
 			"value": "location.json",
@@ -1969,6 +3178,24 @@
 			"type": "string"
 		},
 		{
+			"id": "551c9ec5-d972-44b1-8e18-de1d4d81535f",
+			"key": "schema_renewal",
+			"value": "renewal.json",
+			"type": "string"
+		},
+		{
+			"id": "6d59480c-70e7-438c-be5b-6c37809608e7",
+			"key": "schema_reporting_code",
+			"value": "reporting_code.json",
+			"type": "string"
+		},
+		{
+			"id": "6206c4c3-c590-4ab4-8e9d-358a947f1d21",
+			"key": "schema_source",
+			"value": "source.json",
+			"type": "string"
+		},
+		{
 			"id": "0e121f3b-d145-4101-8db0-b1b870750a50",
 			"key": "schema_vendor_detail",
 			"value": "vendor_detail.json",
@@ -1978,12 +3205,6 @@
 			"id": "b11aa64a-f5fe-493a-830b-1211b3381089",
 			"key": "module",
 			"value": "mod-orders-storage",
-			"type": "string"
-		},
-		{
-			"id": "23551492-e406-462c-a2e3-2bdd17fde6a4",
-			"key": "schema_loc",
-			"value": "https://raw.githubusercontent.com/folio-org/acq-models/master",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
### Purpose
* Per [MODORDERS-76](https://issues.folio.org/browse/MODORDERS-76) we want to have API Tests for [POST /orders/{id}/lines endpoint](https://s3.amazonaws.com/foliodocs/api/mod-orders/order.html#orders__id__lines_post)
* Per [MODORDERS-78](https://issues.folio.org/browse/MODORDERS-78) we want to have API Tests for [GET /orders/{id}/lines/{id} endpoint](https://s3.amazonaws.com/foliodocs/api/mod-orders/order.html#orders__id__lines__lineid__get)
* Per [MODORDERS-79](https://issues.folio.org/browse/MODORDERS-79) we want to have API Tests for [DELETE /orders/{id}/lines/{id} endpoint](https://s3.amazonaws.com/foliodocs/api/mod-orders/order.html#orders__id__lines__lineid__delete)

### Approach
* Added API tests to the mod-orders postman collection to check positive and negative scenarios. For positive scenario the approach is following:
  * Add new PO line 
  * Retrieve PO line to verify it can be retrieved by order + line ids
  * Retrieve the order to verify that new PO line appeared
  * Delete PO line
  * Retrieve the order to verify that PO line disappeared
* The `utils` are added at collection level introducing commonly used functions in Pre-request scripts and tests:

  Function | Description
   --- | ---
  validatePoLineSubObjetcsPresence(jsonData) | validates presence of the PO line sub-object elements
  rememberPoLineId(jsonData) | adds PO line id to `complete_poline_ids` array as global variable
  getLastPoLineId(withRemoval) | gets last id from `complete_poline_ids` array (global variable). In case the `withRemoval==true`, the last id is removed from array. In case the array is empty, `null` is returned
  validatePoLineAgainstSchema(jsonData) | validates the PO line content against schemas
  validateOrderAgainstSchema(jsonData) | validates the PO content against schemas
* Added additional retrieval of the alert.json, claim.json, eresource.json, fund_distribution.json, renewal.json, reporting_code.json, source.json to validate content of the PO line (some of them are still ignored due to yet missing content)

### Screenshots

The positive and negative requests structure:

![image](https://user-images.githubusercontent.com/43410167/49789642-8e7a1d00-fd3d-11e8-8afa-06f9390e6629.png)

The test run results for 3 iterations:

![image](https://user-images.githubusercontent.com/43410167/49789565-62f73280-fd3d-11e8-95f5-feebe38f82e4.png)

Collection level Pre-request script to define utility functions:

![image](https://user-images.githubusercontent.com/43410167/49789904-2415ac80-fd3e-11e8-9b64-ed408f1d634a.png)
