### PR TITLE
MODKBEKBJ-70 - API Tests PUT /eholdings/packages/{packageId} endpoint

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "2e7c16bc-7ee8-4940-9bb7-61d48586d4fa",
+		"_postman_id": "a648a7cd-7b13-4a65-899a-d1d006f8aa1c",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7234,6 +7234,1191 @@
 										}
 									},
 									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "PUT package by packageId",
+					"item": [
+						{
+							"name": "Custom Package",
+							"item": [
+								{
+									"name": "Positive",
+									"item": [
+										{
+											"name": "update custom package",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "cfd8e1ba-9886-4d30-86d1-283899a48f28",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 200",
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in response object', function() {",
+															"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+															"});",
+															"",
+															"//Test that id matches what was provided in query",
+															"pm.test('id matches as provided in query', function(){",
+															"    pm.expect(response.data.id).eq(pm.environment.get('custom-package-id-created-in-post'));",
+															"});    ",
+															"",
+															"//Test that type is packages",
+															"pm.test('type is packages', function(){",
+															"    pm.expect(response.data.type).eq('packages');",
+															"});",
+															"    ",
+															"//Test that data.attributes has expected attributes",
+															"pm.test('expected data.attributes are present', function() {",
+															"    pm.expect(response.data.attributes).to.be.an('object');",
+															"    pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\",\"isSelected\",\"name\", \"packageId\", ",
+															"    \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\",\"proxy\");",
+															"});",
+															"",
+															"//Test that name matches name provided in request",
+															"pm.test('name matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.name).eq('new sample package one');",
+															"});",
+															"",
+															"//Test that contentType matches as provided in request",
+															"//This should be re-visited after https://issues.folio.org/browse/UIEH-490 is fixed.",
+															"pm.test('contentType matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.contentType).eq('Print');",
+															"});",
+															"",
+															"//Test that isSelected matches as provided in request",
+															"pm.test('isSelected matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.isSelected).to.be.true;",
+															"});",
+															"",
+															"//Test that visibilityData matches as provided in request",
+															"pm.test('visibilityData matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.visibilityData.isHidden).to.be.true;",
+															"});",
+															"",
+															"//Test that custom coverage matches provided in request",
+															"pm.test('customCoverage matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.customCoverage.beginCoverage).to.eq('2003-01-01');",
+															"    pm.expect(response.data.attributes.customCoverage.endCoverage).to.eq('2003-12-01');",
+															"});",
+															"",
+															"//Test that resources are not included in relationships",
+															"pm.test('relationships meta should not include resources', function() {",
+															"    pm.expect(response.data.relationships.resources.meta.included).to.be.false;",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"new sample package one\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "visibility data and coverage update",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "301a2429-04c2-4ebc-b71b-5a1f64acca2c",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 200",
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in response object', function() {",
+															"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+															"});",
+															"",
+															"//Test that id matches what was provided in query",
+															"pm.test('id matches as provided in query', function(){",
+															"    pm.expect(response.data.id).eq(pm.environment.get('custom-package-id-created-in-post'));",
+															"});    ",
+															"",
+															"//Test that type is packages",
+															"pm.test('type is packages', function(){",
+															"    pm.expect(response.data.type).eq('packages');",
+															"});",
+															"    ",
+															"//Test that data.attributes has expected attributes",
+															"pm.test('expected data.attributes are present', function() {",
+															"    pm.expect(response.data.attributes).to.be.an('object');",
+															"    pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\",\"isSelected\",\"name\", \"packageId\", ",
+															"    \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\",\"proxy\");",
+															"});",
+															"",
+															"//Test that name matches name provided in request",
+															"pm.test('name matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.name).eq('new sample package two');",
+															"});",
+															"",
+															"//Test that contentType matches as provided in request",
+															"//This should be re-visited after https://issues.folio.org/browse/UIEH-490 is fixed.",
+															"pm.test('contentType matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.contentType).eq('Print');",
+															"});",
+															"",
+															"//Test that isSelected matches as provided in request",
+															"pm.test('isSelected matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.isSelected).to.be.true;",
+															"});",
+															"",
+															"//Test that visibilityData matches as provided in request",
+															"pm.test('visibilityData matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.visibilityData.isHidden).to.be.false;",
+															"});",
+															"",
+															"//Test that custom coverage matches provided in request",
+															"pm.test('customCoverage matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.customCoverage.beginCoverage).to.eq('2004-01-01');",
+															"    pm.expect(response.data.attributes.customCoverage.endCoverage).to.eq('2004-12-01');",
+															"});",
+															"",
+															"//Test that resources are not included in relationships",
+															"pm.test('relationships meta should not include resources', function() {",
+															"    pm.expect(response.data.relationships.resources.meta.included).to.be.false;",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"new sample package two\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2004-01-01\",\n        \"endCoverage\": \"2004-12-01\"\n      },\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": false\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"name": "Negative",
+									"item": [
+										{
+											"name": "update custom package without name",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "110f2939-ad30-406a-9074-e3bf05f43fb4",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Invalid name');",
+															"        pm.expect(response.errors[0].detail).to.eq('name must be empty');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "update custom package without contentType",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "1257c13b-620f-4ee0-a1d3-e90bc6acba18",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Invalid contentType');",
+															"        pm.expect(response.errors[0].detail).to.eq('contentType must not be null');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"some test custom package\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "update custom package with name that already exists",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "256f95b4-827a-4ee6-b316-f9e8c6e23037",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 400",
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Package name already exists');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "aa4f6bef-01a6-42c5-9582-71dee701cf91",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"{{custom-package-name-that-exists}}\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "update custom package with isSelected false should delete it",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "eb2e7fc5-bb68-457e-bc47-447e4ebc8f67",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 404",
+															"pm.test(\"Status is 404\", function () {",
+															"    pm.response.to.have.status(404);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Package not found');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"random test package\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": false,\n      \"visibilityData\": {\n        \"isHidden\": true\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post-again}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post-again}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "invalid contentType",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "b6988fa9-e19d-4319-acab-0486899854e8",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.eq(true);",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"hello world\",\n      \"contentType\": \"invalid\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Managed Package",
+							"item": [
+								{
+									"name": "Positive",
+									"item": [
+										{
+											"name": "update managed package",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6b350358-c50d-431a-8891-635afafb9d77",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 200",
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in response object', function() {",
+															"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+															"});",
+															"",
+															"//Test that id matches what was provided in query",
+															"pm.test('id matches as provided in query', function(){",
+															"    pm.expect(response.data.id).eq(pm.variables.get('packageId'));",
+															"});    ",
+															"",
+															"//Test that type is packages",
+															"pm.test('type is packages', function(){",
+															"    pm.expect(response.data.type).eq('packages');",
+															"});",
+															"    ",
+															"//Test that data.attributes has expected attributes",
+															"pm.test('expected data.attributes are present', function() {",
+															"    pm.expect(response.data.attributes).to.be.an('object');",
+															"    pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\",\"isSelected\",\"name\", \"packageId\", ",
+															"    \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\",\"proxy\");",
+															"});",
+															"",
+															"",
+															"//Test that isSelected matches as provided in request",
+															"pm.test('isSelected matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.isSelected).to.be.true;",
+															"});",
+															"",
+															"//Test that visibilityData matches as provided in request",
+															"pm.test('visibilityData matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.visibilityData.isHidden).to.be.true;",
+															"});",
+															"",
+															"//Test that allowKbToAddTitles matches as provided in request",
+															"pm.test('allowKbToAddTitles matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.allowKbToAddTitles).to.be.true;",
+															"});",
+															"",
+															"//Test that resources are not included in relationships",
+															"pm.test('relationships meta should not include resources', function() {",
+															"    pm.expect(response.data.relationships.resources.meta.included).to.be.false;",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"allowKbToAddTitles\": true,\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-13\",\n        \"endCoverage\": \"2018-09-13\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"name": "Negative",
+									"item": [
+										{
+											"name": "try updating managed package with isSelected false",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "e48701c8-2cb6-43e3-9876-5b5b011b4c69",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    //This should be re-visited after https://issues.folio.org/browse/UIEH-492 is fixed.",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Invalid customCoverage.beginCoverage');",
+															"        pm.expect(response.errors[0].detail).to.eq('customCoverage.beginCoverage must be empty');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isSelected\": false,\n      \"visibilityData\": {\n        \"isHidden\": false\n      },\n      \"allowKbToAddTitles\": false,\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-13\",\n        \"endCoverage\": \"2018-09-13\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "invalid dates for coverage",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "35fd9abe-ff7a-441b-ba68-11529d2d00db",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Invalid beginCoverage');",
+															"        pm.expect(response.errors[0].detail).to.eq('beginCoverage has invalid format. Should be YYYY-MM-DD');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"allowKbToAddTitles\": true,\n      \"customCoverage\": {\n        \"beginCoverage\": \"13-08-2018\",\n        \"endCoverage\": \"13-09-2018\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "invalid isSelected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "ab9b4cb8-0847-4426-968a-4015d2df8d0f",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.eq(true);",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isSelected\": \"invalid\",\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"allowKbToAddTitles\": true,\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-13\",\n        \"endCoverage\": \"2018-09-12\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "invalid isHidden",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "93ca8f23-f8a4-4a77-82bd-d898f94a214b",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.eq(true);",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": \"invalid\"\n      },\n      \"allowKbToAddTitles\": true,\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-13\",\n        \"endCoverage\": \"2018-09-13\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "invalid allowKbToAddTitles",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "a9f78de4-a7d9-41ff-b1aa-7d135f74530c",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.eq(true);",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": false\n      },\n      \"allowKbToAddTitles\": \"invalid\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-13\",\n        \"endCoverage\": \"2018-09-13\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "invalid json in request",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "ac2914b6-ff59-4e3c-b990-000db174b758",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.eq(true);",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"allowKbToAddTitles\": true,\n      \"customCoverage\": {\n        \"beginCoverage\": 13-08-2018,\n        \"endCoverage\": 13-09-2018\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
 								}
 							],
 							"_postman_isSubFolder": true

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a648a7cd-7b13-4a65-899a-d1d006f8aa1c",
+		"_postman_id": "aae099d8-3f08-4254-86cc-7c23ba13bf4c",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7531,7 +7531,7 @@
 															"    //Test that we get expected error message",
 															"    pm.test('Ensure that we get expected error message', function() {",
 															"        pm.expect(response.errors[0].title).to.eq('Invalid name');",
-															"        pm.expect(response.errors[0].detail).to.eq('name must be empty');",
+															"        pm.expect(response.errors[0].detail).to.eq('name must not be empty');",
 															"    }); ",
 															"}",
 															""


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-70 we want to have API Tests for PUT `/eholdings/packages/{packageId}` endpoint
## Approach

- checked if tests from https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json pass for the endpoint in Java
-  added api tests to the mod-kb-ebsco-java postman collection