### PR TITLE
MODKBEKBJ-96 - API Tests PUT /eholdings/root-proxy endpoint

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "077b071b-64d6-4090-bca4-b3458b15e890",
+		"_postman_id": "6c3781db-1989-44d3-9047-28d56be8310e",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -16070,9 +16070,9 @@
 													"    pm.response.to.be.json;",
 													"});",
 													"",
-													"//Check that status is 500",
-													"pm.test(\"Status is 500\", function () {",
-													"    pm.response.to.have.status(500);",
+													"//Check that status is 422",
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
 													"});",
 													"",
 													"pm.test(\"Response must have a json body\", function () {",
@@ -16085,7 +16085,10 @@
 													"",
 													"//Test that response has expected error message",
 													"pm.test('expected error message is present in response', function() {",
-													"    pm.expect(response.errors[0].title).to.eq('Internal server error');",
+													"    pm.expect(response.errors[0].message).to.eq('may not be null');",
+													"    pm.expect(response.errors[0].parameters[0].key).to.eq('data.attributes');",
+													"    pm.expect(response.errors[0].parameters[0].value).to.eq('null');",
+													"    ",
 													"});",
 													""
 												],


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-96 we want to have API Tests for PUT `/eholdings/root-proxy` endpoint
## Approach

-  added api tests to the mod-kb-ebsco-java postman collection
-  compared responses from mod-kb-ebsco-java with mod-kb-ebsco module