### PR TITLE
MODKBEKBJ-72 - API Tests GET /eholdings/packages/{packageId}/resources endpoint

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "6c3781db-1989-44d3-9047-28d56be8310e",
+		"_postman_id": "2e7c16bc-7ee8-4940-9bb7-61d48586d4fa",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7237,6 +7237,388 @@
 								}
 							],
 							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "GET resources by packageId",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "with valid packageId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "d0116162-80a9-4d6c-b85b-52e9b7e71c7f",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of resources in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Test that if no count is provided, default should be 25 records",
+													"        pm.test('no count provided', function(){",
+													"            pm.expect(len).eq(25);",
+													"        });",
+													"        ",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is packages",
+													"        pm.test('type is resources', function() {",
+													"            pm.expect(firstRecord.type).eq('resources');",
+													"        });",
+													"        ",
+													"        //Test that data.attributes has expected attributes",
+													"        pm.test('expected data.attributes are present', function() {",
+													"            pm.expect(firstRecord.attributes).to.include.all.keys(\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", ",
+													"            \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\", \"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\", \"providerId\", \"providerName\", \"visibilityData\", \"managedCoverages\", \"customCoverages\");",
+													"        });",
+													"        ",
+													"        //Test that packageId matches what we passed in ",
+													"        pm.test('packageId matches value passed in', function() {",
+													"            pm.expect(firstRecord.attributes.packageId).to.eq(pm.variables.get('packageId'));",
+													"        });",
+													"        ",
+													"        //Test that relationships has expected attributes",
+													"        pm.test('expected relationships are present', function() {",
+													"            pm.expect(firstRecord.relationships).to.include.all.keys(\"title\", \"provider\", \"package\");",
+													"        });",
+													"    ",
+													"        //Test that title is not included in relationships",
+													"        pm.test('relationships meta should not include title', function() {",
+													"            pm.expect(firstRecord.relationships.title.meta.included).to.be.false;",
+													"        });",
+													"        ",
+													"        //Test that provider are not included in relationships",
+													"        pm.test('relationships meta should not include provider', function() {",
+													"            pm.expect(firstRecord.relationships.provider.meta.included).to.be.false;",
+													"        });",
+													"        ",
+													"        //Test that package is not included in relationships",
+													"        pm.test('relationships meta should not include package', function() {",
+													"            pm.expect(firstRecord.relationships.package.meta.included).to.be.false;",
+													"        });",
+													"    } else {",
+													"        console.log('No resources found for this package');",
+													"    }",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}/resources",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"{{packageId}}",
+												"resources"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "with non-existing packageId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "0d504b5b-cd53-450d-9e0b-bc7383d8ee3e",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 404",
+													"pm.test(\"Status is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"//Ensure that errors array is not empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package not found');",
+													"    }); ",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/583-1/resources",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"583-1",
+												"resources"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with invalid packageId without providerId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "0fc407a0-f0a4-4f01-9b56-ee07d29089ca",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"//Ensure that errors array is *not* empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package and provider id are required');",
+													"    });",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc/resources",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"abc",
+												"resources"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with invalid packageId and providerId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "8d8d3807-44fe-49d2-b1ae-96b4f6d39d76",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Ensure that errors array is *not* empty",
+													"if(response.errors) {",
+													"    pm.test('Ensure that errors array is not empty', function() {",
+													"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    });",
+													"",
+													"    //Test that we get expected error message",
+													"    pm.test('Ensure that we get expected error message', function() {",
+													"        pm.expect(response.errors[0].title).to.eq('Package or provider id are invalid');",
+													"    });",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/abc-abc/resources",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"abc-abc",
+												"resources"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "13f98e77-bdc3-423c-9480-2ca29433f0d2",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "187dccd0-3dbf-4f1e-83a7-7ca132a4955a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						}
 					],
 					"_postman_isSubFolder": true


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-72 we want to have API Tests for GET /eholdings/packages/{packageId}/resources endpoint
## Approach

- checked if tests from https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json pass for the endpoint in Java
-  added api tests to the mod-kb-ebsco-java postman collection