### PR TITLE
MODKBEKBJ-69 - API Tests GET /eholdings/packages/{packageId}?include=provider

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "87ccc0fc-c1cf-4811-a4c1-c3f2983a9584",
+		"_postman_id": "a7d443e0-2311-4a1b-9426-c1221a0f9a4f",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -9436,6 +9436,102 @@
 												"eholdings",
 												"packages",
 												"{{packageId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with valid packageId including provider",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "121ce590-7390-4ac7-994d-d93f5d3fab06",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in response object', function() {",
+													"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"//Test that resources are not included in relationships",
+													"pm.test('relationships meta should not include resources', function() {",
+													"    pm.expect(response.data.relationships.resources.meta.included).to.be.false;",
+													"});",
+													"",
+													"//Test that provider is included in relationships",
+													"pm.test('relationships meta should include provider', function() {",
+													"    pm.expect(response.data.relationships.provider.data).is.not.empty;",
+													"});",
+													"",
+													"//Test that provider is included",
+													"pm.test('include provider', function() {",
+													"    if (response.included === undefined || response.included.length === 0) {",
+													"        // array empty or does not exist",
+													"        console.log(\"No provider included\");",
+													"    } else {",
+													"        //Test that provider is included",
+													"        pm.test('should include provider', function() {",
+													"            pm.expect(response.included[0].type).to.eq('providers');",
+													"        });",
+													"    }",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}?include=provider",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"{{packageId}}"
+											],
+											"query": [
+												{
+													"key": "include",
+													"value": "provider"
+												}
 											]
 										}
 									},


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-69 we want to have API Tests for GET /eholdings/packages/{packageId}?include=provider endpoint that are not in https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json
## Approach

-  added api tests to the mod-kb-ebsco-java postman collection