### PR TITLE
MODKBEKBJ-81 - API Tests PUT /eholdings/resources/{resourceId} endpoint

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d7bd6246-0a9d-40f2-aaa8-9f67f1d30313",
+		"_postman_id": "81075d09-13b5-45f5-ade8-a562d81f1b42",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -9532,101 +9532,102 @@
 													"key": "include",
 													"value": "provider"
 												}
-                                            ]
-                                        }
-                                    },
-                                  "response": []
-                                },
-                              {
-                                "name": "with valid packageId including resources",
-                                "event": [
-                                  {
-                                    "listen": "test",
-                                    "script": {
-                                      "id": "121ce590-7390-4ac7-994d-d93f5d3fab06",
-                                      "exec": [
-                                        "pm.test(\"success test\", function() {",
-                                        "    pm.response.to.be.json;",
-                                        "});",
-                                        "",
-                                        "let response = pm.response.json();",
-                                        "",
-                                        "//Check that status is 200",
-                                        "pm.test(\"Status is 200\", function () {",
-                                        "    pm.response.to.have.status(200);",
-                                        "});",
-                                        "",
-                                        "pm.test(\"Validate schema\", function () {",
-                                        "    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-                                        "    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-                                        "});",
-                                        "",
-                                        "//Test that object has the expected keys",
-                                        "pm.test('expected keys are present in response object', function() {",
-                                        "    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
-                                        "});",
-                                        "",
-                                        "//Test that resources are included in relationships",
-                                        "pm.test('relationships meta should include resources', function() {",
-                                        "    pm.expect(response.data.relationships.resources.data).is.not.empty;",
-                                        "});",
-                                        "",
-                                        "//Test that list of resources are included",
-                                        "pm.test('include resources list', function() {",
-                                        "    if (response.included === undefined || response.included.length === 0) {",
-                                        "        // array empty or does not exist",
-                                        "        console.log(\"No resources included\");",
-                                        "    } else {",
-                                        "        //Test that resources are included",
-                                        "        pm.test('should include resources', function() {",
-                                        "            pm.expect(response.included[0].type).to.eq('resources');",
-                                        "        });",
-                                        "    }",
-                                        "});",
-                                        "",
-                                        ""
-                                      ],
-                                      "type": "text/javascript"
-                                    }
-                                  }
-                                ],
-                                "request": {
-                                  "method": "GET",
-                                  "header": [
-                                    {
-                                      "key": "x-okapi-tenant",
-                                      "value": "{{xokapitenant}}"
-                                    },
-                                    {
-                                      "key": "x-okapi-token",
-                                      "value": "{{xokapitoken}}"
-                                    }
-                                  ],
-                                  "body": {
-                                    "mode": "raw",
-                                    "raw": ""
-                                  },
-                                  "url": {
-                                    "raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}?include=resources",
-                                    "protocol": "{{protocol}}",
-                                    "host": [
-                                      "{{url}}"
-                                    ],
-                                    "port": "{{okapiport}}",
-                                    "path": [
-                                      "eholdings",
-                                      "packages",
-                                      "{{packageId}}"
-                                    ],
-                                    "query": [
-                                      {
-                                        "key": "include",
-                                        "value": "resources"
-                                      }
-                                    ]
-                                  }
-                                },"response" : []
-                              }
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with valid packageId including resources",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "121ce590-7390-4ac7-994d-d93f5d3fab06",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in response object', function() {",
+													"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"//Test that resources are included in relationships",
+													"pm.test('relationships meta should include resources', function() {",
+													"    pm.expect(response.data.relationships.resources.data).is.not.empty;",
+													"});",
+													"",
+													"//Test that list of resources are included",
+													"pm.test('include resources list', function() {",
+													"    if (response.included === undefined || response.included.length === 0) {",
+													"        // array empty or does not exist",
+													"        console.log(\"No resources included\");",
+													"    } else {",
+													"        //Test that resources are included",
+													"        pm.test('should include resources', function() {",
+													"            pm.expect(response.included[0].type).to.eq('resources');",
+													"        });",
+													"    }",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}?include=resources",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages",
+												"{{packageId}}"
+											],
+											"query": [
+												{
+													"key": "include",
+													"value": "resources"
+												}
+											]
+										}
+									},
+									"response": []
+								}
 							],
 							"_postman_isSubFolder": true
 						},
@@ -13741,7 +13742,7 @@
 															"   pm.expect(firstAttributes.visibilityData.isHidden).to.eql(false);",
 															"});",
 															"",
-															"pm.test(\"custome embargo period is as expected\", function () {",
+															"pm.test(\"custom embargo period is as expected\", function () {",
 															"   pm.expect(firstAttributes.customEmbargoPeriod.embargoUnit).to.eql(\"Months\");",
 															"   pm.expect(firstAttributes.customEmbargoPeriod.embargoValue).to.eql(5);",
 															"});",
@@ -13768,7 +13769,8 @@
 													"script": {
 														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
 														"exec": [
-															""
+															"var uuid = require('uuid');",
+															"pm.variables.set(\"custom-resource-uuid\", uuid.v4());"
 														],
 														"type": "text/javascript"
 													}
@@ -13792,7 +13794,7 @@
 												],
 												"body": {
 													"mode": "raw",
-													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isPeerReviewed\": false,\n      \"name\": \"custom title-b72f107f-ceff-49e1-8a3f-e7a9b8dffa13\",\n      \"publicationType\": \"Book\",\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Months\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      }\n    }\n  }\n}"
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isPeerReviewed\": false,\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"publicationType\": \"Book\",\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Months\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      }\n    }\n  }\n}"
 												},
 												"url": {
 													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
@@ -13966,8 +13968,8 @@
 													"script": {
 														"id": "387aa985-9032-414b-8639-8b7f40af3cd6",
 														"exec": [
-															"pm.test(\"Status is 500\", function () {",
-															"    pm.response.to.have.status(500);",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
 															"});",
 															"",
 															"pm.test(\"Response must have a json body\", function () {",
@@ -13985,7 +13987,8 @@
 															"// Error text as returned from rm api",
 															"pm.test(\"Errors array contains 1 entry\", function () {",
 															"    pm.expect(jsonData.errors.length).to.eql(1);",
-															"    pm.expect(jsonData.errors[0].title.startsWith(\"An error occurred\")).to.be.true;",
+															"    pm.expect(jsonData.errors[0].title).to.eq(\"Invalid identifier id\");",
+															"    pm.expect(jsonData.errors[0].detail).to.eq(\"identifier id must not be null\");",
 															"});",
 															"",
 															"",
@@ -14043,7 +14046,7 @@
 											"response": []
 										},
 										{
-											"name": "/resources PUT update custom resource invalid idenitifer subtype",
+											"name": "/resources PUT update custom resource invalid identifer subtype",
 											"event": [
 												{
 													"listen": "test",
@@ -14118,7 +14121,7 @@
 											"response": []
 										},
 										{
-											"name": "/resources PUT update custom resource invalid idenitifer type",
+											"name": "/resources PUT update custom resource invalid identifer type",
 											"event": [
 												{
 													"listen": "test",
@@ -15867,9 +15870,6 @@
 															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
 															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
 															"});",
-															"",
-															"// Response should have JSONAPI formatted error message",
-															"// https://issues.folio.org/browse/UIEH-482",
 															"",
 															""
 														],

--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ff5f72c8-6fa7-4b23-a05b-b16858cfd0ee",
+		"_postman_id": "d7bd6246-0a9d-40f2-aaa8-9f67f1d30313",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -13680,6 +13680,2792 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "PUT resource by resourceId",
+					"item": [
+						{
+							"name": "Custom Resource",
+							"item": [
+								{
+									"name": "Positive",
+									"item": [
+										{
+											"name": "/resources PUT update custom resource",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "1bbccb9f-00b3-497f-bc84-db593ca5f27a",
+														"exec": [
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.ok;",
+															"    pm.response.to.be.withBody;",
+															"    pm.response.to.be.json; ",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_resource\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Get the first record",
+															"let firstRecord = jsonData.data;",
+															"    ",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in a record', function() {",
+															"    pm.expect(firstRecord).to.be.an('object');",
+															"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+															"});",
+															"",
+															"// Test that attributes have the expected keys",
+															"let firstAttributes = firstRecord.attributes;",
+															"pm.test('expected attributes are present in a record', function() {",
+															"    pm.expect(firstAttributes).to.be.an('object');",
+															"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"coverageStatement\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+															"});",
+															"",
+															"pm.test(\"data type is as expected\", function () {",
+															"    pm.expect(firstRecord.type).eq(\"resources\");",
+															"});",
+															"",
+															"pm.test(\"isSelected is as expected\", function () {",
+															"   pm.expect(firstAttributes.isSelected).to.eql(true);",
+															"});",
+															"",
+															"pm.test(\"isHidden is as expected\", function () {",
+															"   pm.expect(firstAttributes.visibilityData.isHidden).to.eql(false);",
+															"});",
+															"",
+															"pm.test(\"custome embargo period is as expected\", function () {",
+															"   pm.expect(firstAttributes.customEmbargoPeriod.embargoUnit).to.eql(\"Months\");",
+															"   pm.expect(firstAttributes.customEmbargoPeriod.embargoValue).to.eql(5);",
+															"});",
+															"",
+															"pm.test(\"custom coverages is as expected\", function () {",
+															"   pm.expect(firstAttributes.customCoverages.length).to.eql(1);",
+															"   pm.expect(firstAttributes.customCoverages[0].beginCoverage).to.eql(\"2001-01-01\");",
+															"   pm.expect(firstAttributes.customCoverages[0].endCoverage).to.eql(\"2004-02-01\");",
+															"});",
+															"",
+															"pm.test(\"coverage statement is as expected\", function () {",
+															"   pm.expect(firstAttributes.coverageStatement).to.eql(\"Test Coverage Statement\");",
+															"});",
+															"",
+															"pm.test(\"proxy is as expected\", function () {",
+															"   pm.expect(firstAttributes.proxy.id).to.eql(\"<n>\");",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isPeerReviewed\": false,\n      \"name\": \"custom title-b72f107f-ceff-49e1-8a3f-e7a9b8dffa13\",\n      \"publicationType\": \"Book\",\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Months\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource - custom only fields",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "ae2da187-5d56-41af-8eb4-8e362b0004b6",
+														"exec": [
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.ok;",
+															"    pm.response.to.be.withBody;",
+															"    pm.response.to.be.json; ",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_resource\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"",
+															"//Get the first record",
+															"let firstRecord = jsonData.data;",
+															"    ",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in a record', function() {",
+															"    pm.expect(firstRecord).to.be.an('object');",
+															"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+															"});",
+															"",
+															"// Test that attributes have the expected keys",
+															"let firstAttributes = firstRecord.attributes;",
+															"pm.test('expected attributes are present in a record', function() {",
+															"    pm.expect(firstAttributes).to.be.an('object');",
+															"    pm.expect(firstAttributes).to.include.all.keys(\"description\", \"edition\", \"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"url\",\"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+															"});",
+															"",
+															"pm.test(\"data type is as expected\", function () {",
+															"    pm.expect(firstRecord.type).eq(\"resources\");",
+															"});",
+															"",
+															"pm.test(\"name is as expected\", function () {",
+															"   pm.expect(firstAttributes.name).eq(\"custom title-\" + pm.variables.get(\"custom-resource-uuid\"));",
+															"});",
+															"",
+															"pm.test(\"isPeerReviewed is as expected\", function () {",
+															"   pm.expect(firstAttributes.isPeerReviewed).to.eql(true);",
+															"});",
+															"",
+															"pm.test(\"publication type is as expected\", function () {",
+															"   pm.expect(firstAttributes.publicationType).to.eql(\"Newspaper\");",
+															"});",
+															"",
+															"pm.test(\"publisherName is as expected\", function () {",
+															"   pm.expect(firstAttributes.publisherName).to.eql(\"test publisher\");",
+															"});",
+															"",
+															"pm.test(\"edition is as expected\", function () {",
+															"   pm.expect(firstAttributes.edition).to.eql(\"5\");",
+															"});",
+															"",
+															"pm.test(\"description is as expected\", function () {",
+															"   pm.expect(firstAttributes.description).to.eql(\"Test Description\");",
+															"});",
+															"",
+															"pm.test(\"url is as expected\", function () {",
+															"   pm.expect(firstAttributes.url).to.eql(\"https://test\");",
+															"});",
+															"",
+															"pm.test(\"contributors are as expected\", function () {",
+															"   pm.expect(firstAttributes.contributors).to.be.an('array').that.is.not.empty;",
+															"   pm.expect(firstAttributes.contributors.length).to.eql(2);",
+															"   pm.expect(firstAttributes.contributors[0].type.toLowerCase()).to.eql(\"author\");",
+															"   pm.expect(firstAttributes.contributors[0].contributor).to.eql(\"smith, john\");",
+															"   pm.expect(firstAttributes.contributors[1].type.toLowerCase()).to.eql(\"illustrator\");",
+															"   pm.expect(firstAttributes.contributors[1].contributor).to.eql(\"smith, ralph\");",
+															"});",
+															"",
+															"pm.test(\"identifiers are as expected\", function () {",
+															"   pm.expect(firstAttributes.identifiers).to.be.an('array').that.is.not.empty;",
+															"   pm.expect(firstAttributes.identifiers.length).to.eql(1);",
+															"   pm.expect(firstAttributes.identifiers[0].id).to.eql(\"11-2222-3333\");",
+															"   pm.expect(firstAttributes.identifiers[0].type).to.eql(\"ISSN\");",
+															"   pm.expect(firstAttributes.identifiers[0].subtype).to.eql(\"Online\");",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "ac19979a-6f62-4778-b688-ac03fe5b2f41",
+														"exec": [
+															"var uuid = require('uuid');",
+															"pm.variables.set(\"custom-resource-uuid\", uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"visibilityData\": {\n        \"isHidden\" : false\n      },\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"name": "Negative",
+									"item": [
+										{
+											"name": "/resources PUT update custom resource missing identifier id",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "387aa985-9032-414b-8639-8b7f40af3cd6",
+														"exec": [
+															"pm.test(\"Status is 500\", function () {",
+															"    pm.response.to.have.status(500);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"// Error text as returned from rm api",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title.startsWith(\"An error occurred\")).to.be.true;",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "73d82c84-122a-4314-bbe2-6bbdb34e982b",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-description\", toRepeat.repeat(1501));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"test publisher name\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid idenitifer subtype",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "bdabde56-3342-4cb6-be9b-d4ab6263ec43",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.be.true;",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "73d82c84-122a-4314-bbe2-6bbdb34e982b",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-description\", toRepeat.repeat(1501));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"test publisher name\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Invalid\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid idenitifer type",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "4b9f34c9-13fc-4d2a-bf8d-d832abc23fe0",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.be.true;",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "73d82c84-122a-4314-bbe2-6bbdb34e982b",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-description\", toRepeat.repeat(1501));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"test publisher name\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"Invalid\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid contributor",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "49155118-e9a1-4cd7-93b6-b32fc69a0dfc",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Attribute Type is invalid.\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "73d82c84-122a-4314-bbe2-6bbdb34e982b",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-description\", toRepeat.repeat(1501));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"test publisher name\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"invalid type\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid url",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "b06b7a5a-202c-45b8-96cc-fa12dfa39069",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"   pm.expect(jsonData.errors.length).to.eql(1);",
+															"   pm.expect(jsonData.errors[0].title).to.equal(\"Invalid url\");",
+															"   pm.expect(jsonData.errors[0].detail).to.equal(\"url has invalid format. Should start with https:// or http://\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "73d82c84-122a-4314-bbe2-6bbdb34e982b",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-description\", toRepeat.repeat(1501));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isPeerReviewed\": false,\n      \"name\": \"custom title-b72f107f-ceff-49e1-8a3f-e7a9b8dffa13\",\n      \"publicationType\": \"Book\",\n     \"isSelected\": true,\n      \"url\": \"not a url\"\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid description",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "f37c0de8-9541-43aa-b595-625a0a492564",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid description\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"description is too long (maximum is 400 characters)\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "73d82c84-122a-4314-bbe2-6bbdb34e982b",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-description\", toRepeat.repeat(1501));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"test publisher name\",\n      \"edition\": \"5\",\n      \"description\": \"{{long-description}}\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid edition",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "948f47fb-e735-417d-b1fc-db046d626ae2",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid edition\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f157005-53de-4726-a829-dd42d8c07e5a",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-edition\", toRepeat.repeat(251));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"test publisher name\",\n      \"edition\": \"{{long-edition}}\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid publisher name",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6e1c43ce-df97-47ca-a556-e0a05814426e",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid publisherName\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"publisherName is too long (maximum is 250 characters)\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "92cc3d10-9a96-4ff8-8496-9e38fce73d61",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-publisher-name\", toRepeat.repeat(251));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"{{long-publisher-name}}\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid publication type",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "b02569ca-d848-4cfa-832d-86d223bd82bf",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.be.true;",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "8cfb66a4-95f6-428b-9e9f-210f3a44060e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"invalid\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource invalid peer review",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "2ccbd802-3237-4606-a6cb-12922a7232ca",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.be.true;",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "22f85bb4-90b8-45c4-bde8-b1b246236656",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-title-name\", toRepeat.repeat(401));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": \"invalid\",\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource duplicate title name",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "c1f761a8-63c0-416d-8959-ad7ef26a3188",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Custom Title with the provided name already exists\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "22f85bb4-90b8-45c4-bde8-b1b246236656",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-title-name\", toRepeat.repeat(401));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"{{custom-titlename-for-resource-duplicate}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource Invalid name",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "7d191ee7-6250-41c2-b873-b393fc52f0c5",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid name\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"name is too long (maximum is 400 characters)\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "22f85bb4-90b8-45c4-bde8-b1b246236656",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-title-name\", toRepeat.repeat(401));"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"{{long-title-name}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource Invalid proxy",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "b13dea4e-6435-4cac-bb59-a1730bc713d1",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid Proxy ID\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "277fe43d-4760-49a2-975d-34947faa4ab6",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"invalid\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource Invalid coverageStatement",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6fae833a-63c5-49f6-b981-82d782c6c0c1",
+														"type": "text/javascript",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Attribute CoverageStatement is longer than 200 characters.\");",
+															"});",
+															"",
+															"",
+															""
+														]
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "7d0514e8-3021-4a00-9ab8-4f98eaf6bb81",
+														"type": "text/javascript",
+														"exec": [
+															"let toRepeat = \"0\";",
+															"pm.variables.set(\"long-coverage\", toRepeat.repeat(201));"
+														]
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"{{long-coverage}}\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource Invalid customCoverages",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "f7381f54-f2ad-443f-8cb1-f82d441d7ea4",
+														"type": "text/javascript",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"BeginCoverage should be smaller than EndCoverage.\");",
+															"});",
+															"",
+															"",
+															""
+														]
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2004-01-01\",\n      \"endCoverage\" : \"2001-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource Invalid embargoValue",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "d0c08ed8-28fc-46cc-af2b-39625dbe4616",
+														"type": "text/javascript",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Attribute EmbargoValue is less than 0.\");",
+															"});",
+															"",
+															"",
+															""
+														]
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Days\",\n      \"embargoValue\" : -1\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource Invalid embargoUnit",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "b081502e-2257-4d61-a66c-73b38b1a0137",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.be.true;",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"minutes\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource Invalid visibilityData",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "4aabfc91-c964-48fd-8700-7b3b3df15b35",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.be.true;",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n     \"isSelected\": true,\n      \"visibilityData\": {\n    \t\"isHidden\" : \"invalid\"\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Months\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      },\n      \"name\": \"custom title-{{custom-resource-uuid}}\",\n      \"isPeerReviewed\": true,\n      \"isSelected\" : true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"contributors\": [\n        {\n        \"type\":\"author\",\n        \"contributor\":\"smith, john\"\n        },\n        {\n        \"type\":\"illustrator\",\n        \"contributor\":\"smith, ralph\"\n        }\n      ],\n      \"identifiers\": [\n        {\n        \"id\":\"11-2222-3333\",\n        \"type\":\"ISSN\",\n        \"subtype\":\"Online\"\n        }      \n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update custom resource without isSelected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "5c76e40f-fdf1-4350-bfea-86d0169ddf27",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//verify headers",
+															"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+															"    pm.response.to.have.header(\"Content-Type\");",
+															"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+															"});",
+															"",
+															"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+															"    pm.response.to.have.header(\"Transfer-Encoding\");",
+															"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entries\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid request body\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"isSelected must not be empty\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"visibilityData\": {\n    \t\"isHidden\" : true\n      },\n      \"customEmbargoPeriod\": null,\n      \"customCoverages\" : []\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{custom-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Managed Resource",
+							"item": [
+								{
+									"name": "Positive",
+									"item": [
+										{
+											"name": "/resources PUT update managed resource",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "8e1c9ae0-815e-4ed7-a25f-3296f32487b6",
+														"exec": [
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.ok;",
+															"    pm.response.to.be.withBody;",
+															"    pm.response.to.be.json; ",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_resource\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Get the first record",
+															"let firstRecord = jsonData.data;",
+															"    ",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in a record', function() {",
+															"    pm.expect(firstRecord).to.be.an('object');",
+															"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+															"});",
+															"",
+															"// Test that attributes have the expected keys",
+															"let firstAttributes = firstRecord.attributes;",
+															"pm.test('expected attributes are present in a record', function() {",
+															"    pm.expect(firstAttributes).to.be.an('object');",
+															"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"coverageStatement\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+															"});",
+															"",
+															"pm.test(\"data type is as expected\", function () {",
+															"    pm.expect(firstRecord.type).eq(\"resources\");",
+															"});",
+															"",
+															"pm.test(\"isSelected is as expected\", function () {",
+															"   pm.expect(firstAttributes.isSelected).to.eql(true);",
+															"});",
+															"",
+															"pm.test(\"isHidden is as expected\", function () {",
+															"   pm.expect(firstAttributes.visibilityData.isHidden).to.eql(false);",
+															"});",
+															"",
+															"pm.test(\"custome embargo period is as expected\", function () {",
+															"   pm.expect(firstAttributes.customEmbargoPeriod.embargoUnit).to.eql(\"Months\");",
+															"   pm.expect(firstAttributes.customEmbargoPeriod.embargoValue).to.eql(5);",
+															"});",
+															"",
+															"pm.test(\"custom coverages is as expected\", function () {",
+															"   pm.expect(firstAttributes.customCoverages.length).to.eql(1);",
+															"   pm.expect(firstAttributes.customCoverages[0].beginCoverage).to.eql(\"2001-01-01\");",
+															"   pm.expect(firstAttributes.customCoverages[0].endCoverage).to.eql(\"2004-02-01\");",
+															"});",
+															"",
+															"pm.test(\"coverage statement is as expected\", function () {",
+															"   pm.expect(firstAttributes.coverageStatement).to.eql(\"Test Coverage Statement\");",
+															"});",
+															"",
+															"pm.test(\"proxy is as expected\", function () {",
+															"   pm.expect(firstAttributes.proxy.id).to.eql(\"<n>\");",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "  {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isPeerReviewed\": false,\n      \"publicationType\": \"Book\",\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\" : false\n      },\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Months\",\n      \"embargoValue\" : 5\n      },\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-01\",\n      \"endCoverage\" : \"2004-02-01\"\n      }\n      ],\n      \"coverageStatement\": \"Test Coverage Statement\",\n      \"proxy\" : {\n      \"id\" : \"<n>\"\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update managed resource in custom package - custom resource only fields",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "a7c53527-ac95-41d1-bc8e-61c912de678e",
+														"exec": [
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.ok;",
+															"    pm.response.to.be.withBody;",
+															"    pm.response.to.be.json; ",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_resource\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Get the first record",
+															"let firstRecord = jsonData.data;",
+															"    ",
+															"// Test that attributes have the expected keys",
+															"let firstAttributes = firstRecord.attributes;",
+															"pm.test('expected attributes are present in a record', function() {",
+															"    pm.expect(firstAttributes).to.be.an('object');",
+															"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+															"});",
+															"",
+															"pm.test(\"data type is as expected\", function () {",
+															"    pm.expect(firstRecord.type).eq(\"resources\");",
+															"});",
+															"",
+															"//description should be undefined because user is not allowed to update description for a managed resource",
+															"pm.test(\"description should be undefined\", function () {",
+															"   pm.expect(firstAttributes.description).to.eq(undefined);",
+															"});",
+															"",
+															"//edition should be undefined because user is not allowed to update edition for a managed resource",
+															"pm.test(\"edition should be undefined\", function () {",
+															"   pm.expect(firstAttributes.edition).to.eql(undefined);",
+															"});",
+															"",
+															"//isPeerReviewed should be false because user is not allowed to update isPeerReviewed for a managed resource",
+															"pm.test(\"isPeerReviewed should be null\", function () {",
+															"   pm.expect(firstAttributes.isPeerReviewed).to.be.false;",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"name\": \"Update a managed title name\",\n      \"isPeerReviewed\": true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\" : false\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update managed resource in managed package - custom resource only fields",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "da14ec73-71ad-4cad-9f15-629abd7a7178",
+														"exec": [
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.ok;",
+															"    pm.response.to.be.withBody;",
+															"    pm.response.to.be.json; ",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_resource\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Get the first record",
+															"let firstRecord = jsonData.data;",
+															"    ",
+															"// Test that attributes have the expected keys",
+															"let firstAttributes = firstRecord.attributes;",
+															"pm.test('expected attributes are present in a record', function() {",
+															"    pm.expect(firstAttributes).to.be.an('object');",
+															"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"publisherName\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\");",
+															"});",
+															"",
+															"pm.test(\"data type is as expected\", function () {",
+															"    pm.expect(firstRecord.type).eq(\"resources\");",
+															"});",
+															"",
+															"//description should be undefined because user is not allowed to update description for a managed resource",
+															"pm.test(\"description should be undefined\", function () {",
+															"   pm.expect(firstAttributes.description).to.eql(undefined);",
+															"});",
+															"",
+															"//edition should be undefined because user is not allowed to update edition for a managed resource",
+															"pm.test(\"edition should be undefined\", function () {",
+															"   pm.expect(firstAttributes.edition).to.eql(undefined);",
+															"});",
+															"",
+															"//isPeerReviewed should be false because user is not allowed to update isPeerReviewed for a managed resource",
+															"pm.test(\"isPeerReviewed should be null\", function () {",
+															"   pm.expect(firstAttributes.isPeerReviewed).to.be.false;",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"name\": \"Update a managed title name 2\",\n      \"isPeerReviewed\": true,\n      \"publicationType\": \"Newspaper\",\n      \"publisherName\": \"Test Publisher\",\n      \"edition\": \"5\",\n      \"description\": \"Test Description\",\n      \"url\": \"https://test\",\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\" : false\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-title-package-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-title-package-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"name": "Negative",
+									"item": [
+										{
+											"name": "/resources PUT update managed resource invalid JSON",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "ec14829b-a960-4136-84e2-1deddbe8b044",
+														"exec": [
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Response must have body with error message\", function () {",
+															"    pm.expect(pm.response.text().startsWith('Json content error')).to.be.true;",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"// Response should have JSONAPI formatted error message",
+															"// https://issues.folio.org/browse/UIEH-482",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isSelected\": false,\n      \"visibilityData\": null,\n      },\n      \"customEmbargoPeriod\": null,\n      \"customCoverages\" : [\n      {\n      \"beginCoverage\" : \"2001-01-02\"\n      }\n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update managed resource coverageStatement if not selected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "5aa881bf-7b84-42cb-b32f-8785a2778a43",
+														"exec": [
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.be.withBody;",
+															"    pm.response.to.be.json; ",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"",
+															"//verify headers",
+															"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+															"    pm.response.to.have.header(\"Content-Type\");",
+															"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+															"});",
+															"",
+															"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+															"    pm.response.to.have.header(\"Transfer-Encoding\");",
+															"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entry\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource cannot be updated unless added to holdings\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"Resource must be added to holdings to be able to update\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isSelected\": false,\n      \"visibilityData\": null,\n      \"customEmbargoPeriod\":null,\n      \"customCoverages\" : [],\n      \"coverageStatement\": \"Test Coverage Statement\"\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update managed resource embargo if not selected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "a613b6e5-8cec-4a5a-aeff-eb65a0dc0b7f",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"",
+															"//verify headers",
+															"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+															"    pm.response.to.have.header(\"Content-Type\");",
+															"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+															"});",
+															"",
+															"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+															"    pm.response.to.have.header(\"Transfer-Encoding\");",
+															"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entries\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource cannot be updated unless added to holdings\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"Resource must be added to holdings to be able to update\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isSelected\": false,\n      \"visibilityData\": null,\n      \"customEmbargoPeriod\": {\n      \"embargoUnit\" : \"Weeks\",\n      \"embargoValue\" : 6\n      },\n      \"customCoverages\" : []\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update managed resource custom coverage if not selected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6cc1289b-9084-40e4-8eac-a9365d32956d",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//verify headers",
+															"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+															"    pm.response.to.have.header(\"Content-Type\");",
+															"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+															"});",
+															"",
+															"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+															"    pm.response.to.have.header(\"Transfer-Encoding\");",
+															"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entries\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource cannot be updated unless added to holdings\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"Resource must be added to holdings to be able to update\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isSelected\": false,\n      \"visibilityData\": null,\n      \"customEmbargoPeriod\": null,\n      \"customCoverages\" : [\n      {\n    \t\"beginCoverage\" : \"2001-01-02\"\n      }\n      ]\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update managed resource visibility if not selected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "5c76e40f-fdf1-4350-bfea-86d0169ddf27",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//verify headers",
+															"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+															"    pm.response.to.have.header(\"Content-Type\");",
+															"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+															"});",
+															"",
+															"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+															"    pm.response.to.have.header(\"Transfer-Encoding\");",
+															"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entries\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource cannot be updated unless added to holdings\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"Resource must be added to holdings to be able to update\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"isSelected\": false,\n      \"visibilityData\": {\n    \t\"isHidden\" : true\n      },\n      \"customEmbargoPeriod\": null,\n      \"customCoverages\" : []\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "/resources PUT update managed resource without isSelected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "5c76e40f-fdf1-4350-bfea-86d0169ddf27",
+														"exec": [
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"pm.test(\"Response must have a json body\", function () {",
+															"    pm.response.to.have.jsonBody();",
+															"});",
+															"",
+															"var jsonData = pm.response.json();",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//verify headers",
+															"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+															"    pm.response.to.have.header(\"Content-Type\");",
+															"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+															"});",
+															"",
+															"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+															"    pm.response.to.have.header(\"Transfer-Encoding\");",
+															"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+															"});",
+															"",
+															"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+															"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+															"});",
+															"",
+															"pm.test(\"Errors array contains 1 entries\", function () {",
+															"    pm.expect(jsonData.errors.length).to.eql(1);",
+															"    pm.expect(jsonData.errors[0].title).to.equal(\"Invalid request body\");",
+															"    pm.expect(jsonData.errors[0].detail).to.equal(\"isSelected must not be empty\");",
+															"});",
+															"",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "prerequest",
+													"script": {
+														"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+														"exec": [
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													},
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"type\": \"resources\",\n    \"attributes\": {\n      \"visibilityData\": {\n    \t\"isHidden\" : true\n      },\n      \"customEmbargoPeriod\": null,\n      \"customCoverages\" : []\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{managed-resourceid}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"resources",
+														"{{managed-resourceid}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "bf0b9cf5-95df-4112-bfa3-8703aea6d96e",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "7038e48d-bc8f-4e65-b4f4-62e25dd5ccd3",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "cc54df14-4680-4c4e-b726-18a590eeb645",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "7834655a-45ef-4ef2-b79d-b3ef66dd4bf7",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "DELETE resource by resourceId",
 					"item": [
 						{
@@ -14088,7 +16874,8 @@
 							"tv4.addSchema(\"schema_jsonapi.json\", JSON.parse(pm.variables.get(\"schema_jsonapi\")));",
 							"tv4.addSchema(\"schema_included.json\", JSON.parse(pm.variables.get(\"schema_included\")));",
 							"tv4.addSchema(\"schema_relationshipData.json\", JSON.parse(pm.variables.get(\"schema_relationshipData\")));",
-							"tv4.addSchema(\"schema_contributor.json\", JSON.parse(pm.variables.get(\"schema_contributor\")));"
+							"tv4.addSchema(\"schema_contributor.json\", JSON.parse(pm.variables.get(\"schema_contributor\")));",
+							"tv4.addSchema(\"schema_coverage.json\", JSON.parse(pm.variables.get(\"schema_coverage\")));"
 						]
 					}
 				}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-81 we want to have API Tests for PUT /eholdings/resources/{resourceId} endpoint
## Approach

- checked if tests from https://github.com/folio-org/folio-api-tests/blob/master/mod-kb-ebsco/mod-kb-ebsco.postman_collection.json pass for the endpoint in Java
-  added api tests to the mod-kb-ebsco-java postman collection

#### TODOS and Open Questions

- this pr should be merged only after https://github.com/folio-org/mod-kb-ebsco-java/pull/85 id done. Without it a test "/resources PUT update custom resource missing identifier id" will fail