### PR TITLE
MODKBEKBJ-155 - Refactor Postman API test

### DIFF
--- a/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "81075d09-13b5-45f5-ade8-a562d81f1b42",
+		"_postman_id": "6085f7ca-0d1b-4e4f-945e-59b496b5fff3",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -9,2487 +9,35 @@
 			"name": "schemas",
 			"item": [
 				{
-					"name": "setup",
-					"item": [
-						{
-							"name": "setup environment variables",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "41dde41e-77c3-4f8a-a8e9-5125e58d8897",
-										"exec": [
-											"const moduleName = 'mod-kb-ebsco-java';",
-											"pm.test(\"GET json schemas response OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET json schemas has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"pm.test(\"GET contains ebsco-java module\", function () {",
-											"    pm.expect(pm.response.text()).to.include(moduleName);",
-											"});",
-											"",
-											"let json = JSON.parse(responseBody);",
-											"json.forEach((element) => {",
-											"\tvar moduleId = element.id;",
-											"\tif(moduleId.includes(moduleName)){",
-											"\t\tpm.environment.set('kb-ebsco-java-module-id', moduleId);",
-											"\t}",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{xokapitenant}}/interfaces/_jsonSchemas",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"proxy",
-										"tenants",
-										"{{xokapitenant}}",
-										"interfaces",
-										"_jsonSchemas"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "package",
-					"item": [
-						{
-							"name": "GET package collection schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "93293945-b442-4fea-9469-f263180e0bd2",
-										"exec": [
-											"pm.test(\"GET schema_parameters OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_parameters has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"packageCollection\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/packages/packageCollection.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/packages/packageCollection.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "GET package by Id schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "f782e6b7-79d1-47e3-b0f1-3e13ead3c2c5",
-										"exec": [
-											"pm.test(\"GET schema_package OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_package has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"var response =  pm.response.text();",
-											"setEnvironmentVariable(\"package\", replaceResponseRefWithName(response));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"type": "text",
-										"value": "{{kb-ebsco-java-module-id}}"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/packages/package.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/packages/package.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "GET package post schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "08b3608d-8d28-4013-88e3-fec45d3dd9d2",
-										"exec": [
-											"pm.test(\"GET schema_packagePostRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_packagePostRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"var response =  pm.response.text();",
-											"setEnvironmentVariable(\"packagePostRequest\", replaceResponseRefWithName(response));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/packages/packagePostRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/packages/packagePostRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "package put schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "d5847b0b-e0fb-401c-a10a-d8af13757d5e",
-										"exec": [
-											"pm.test(\"GET schema_packagePutRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_packagePutRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"packagePutRequest\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/packages/packagePutRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/packages/packagePutRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "94f9f95c-3d5d-423d-806b-c33085e8502f",
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "c2f559ca-8246-4235-980e-871472f7bba6",
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "provider",
-					"item": [
-						{
-							"name": "provider collection schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "21f0812d-fe54-4062-b0ba-837ef40a69a2",
-										"exec": [
-											"pm.test(\"GET schema_providerCollection OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_providerCollection has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"providerCollection\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/providers/providerCollection.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/providers/providerCollection.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "provider by id schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "64fb42d1-6bbc-425e-a171-ad00fce9c2be",
-										"exec": [
-											"pm.test(\"GET schema_provider OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_provider has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"provider\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/providers/provider.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/providers/provider.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "provider put schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "7633572e-8118-4c9d-acee-99e4dd7aa576",
-										"exec": [
-											"pm.test(\"GET schema_providerPutRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_providerPutRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"providerPutRequest\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/providers/providerPutRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/providers/providerPutRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "title",
-					"item": [
-						{
-							"name": "title collection schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22922cb4-11cb-4e3d-bfe7-f8d538cdcb68",
-										"exec": [
-											"pm.test(\"GET schema_titleCollection OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_titleCollection has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"titleCollection\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/titles/titleCollection.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/titles/titleCollection.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "title by id schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "51d73086-db70-43b2-968b-c3a41f4c054d",
-										"exec": [
-											"pm.test(\"GET schema_title OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_title has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"title\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/titles/title.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/titles/title.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "title post schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "e7bebd27-511c-49ca-86bb-85d99b0382c5",
-										"exec": [
-											"pm.test(\"GET schema_titlePostRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_titlePostRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"titlePostRequest\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/titles/titlePostRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/titles/titlePostRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "status",
-					"item": [
-						{
-							"name": "GET status shema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "77293c92-40c5-4a2d-8a31-d292a2cd784c",
-										"exec": [
-											"pm.test(\"GET schema_status OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_status has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"var response =  pm.response.text();",
-											"setEnvironmentVariable(\"status\", replaceResponseRefWithName(response));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/status/status.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/status/status.json"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "proxy",
-					"item": [
-						{
-							"name": "proxy types schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "0b61b834-3636-4f50-812c-754a6214d49e",
-										"exec": [
-											"pm.test(\"GET schema_proxyTypes OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_proxyTypes has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"proxyTypes\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/proxies/proxyTypes.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/proxies/proxyTypes.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "root proxy schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "82d91ef2-1a33-45de-9a5e-d90e3be03157",
-										"exec": [
-											"pm.test(\"GET schema_rootProxy OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_rootProxy has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"rootProxy\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/proxies/rootProxy.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/proxies/rootProxy.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "root proxy put schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "d87bccd2-4e24-478c-9102-702b80e48449",
-										"exec": [
-											"pm.test(\"GET schema_rootProxyPutRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_prootProxyPutRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"rootProxyPutRequest\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/proxies/rootProxyPutRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/proxies/rootProxyPutRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "configuration",
-					"item": [
-						{
-							"name": "GET configuration schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "833b4b8a-b77e-4c69-8877-6a4c43285fcd",
-										"exec": [
-											"pm.test(\"GET schema_configuration OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_configuration has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"configuration\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/configuration/configuration.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/configuration/configuration.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "GET configuration put schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "73bdeb5a-3381-43a3-b592-3c4848ea6ccf",
-										"exec": [
-											"pm.test(\"GET schema_configurationPutRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_configurationPutRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"configurationPutRequest\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/configuration/configurationPutRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/configuration/configurationPutRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "resource",
-					"item": [
-						{
-							"name": "resource collection schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "8af112c9-9f75-44a9-af08-e602de4af165",
-										"exec": [
-											"pm.test(\"GET schema_resourceCollection OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_resourceCollection has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"resourceCollection\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/resources/resourceCollection.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/resources/resourceCollection.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "resource by id schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "bf2cbd16-6fd5-412c-b620-dd550fc5e9ee",
-										"exec": [
-											"pm.test(\"GET schema_resource OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_resource has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"resource\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/resources/resource.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/resources/resource.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "resource post schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "ea965066-f314-4676-8963-ce8a29d9c89c",
-										"exec": [
-											"pm.test(\"GET schema_resourcePostRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_resourcePostRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"resourcePostRequest\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/resources/resourcePostRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/resources/resourcePostRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "resource put schema",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "3665a224-1855-4642-818e-94c6ade5afb0",
-										"exec": [
-											"pm.test(\"GET schema_resourcePutRequest OK\", function () {",
-											"    pm.response.to.be.ok;",
-											"});",
-											"",
-											"pm.test(\"GET schema_resourcePutRequest has JSON body\", function () {",
-											"    pm.response.to.have.jsonBody();",
-											"});",
-											"",
-											"setEnvironmentVariable(\"resourcePutRequest\", replaceResponseRefWithName(pm.response.text()));",
-											"",
-											"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
-											"",
-											"function setEnvironmentVariable(name, data){ pm.environment.set(\"schema_\"+ name, data) }",
-											"",
-											"function extractName(url){ return url.substring(url.lastIndexOf(\"/\") + 1, url.lastIndexOf(\".\")); }",
-											"",
-											"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
-											"",
-											"function fetchSchema(url){",
-											"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
-											"  const echoGetRequest = {",
-											"    url: url,",
-											"    method: 'GET',",
-											"    header: {",
-											"      'X-Okapi-Module-Id' : pm.variables.get(\"kb-ebsco-java-module-id\"),",
-											"      'X-Okapi-Tenant' : pm.variables.get(\"xokapitenant\")",
-											"  }",
-											"};",
-											"return new Promise(function(resolve, reject) {",
-											"  pm.sendRequest(echoGetRequest, (err, response) => {",
-											"   if (!err) {",
-											"      var resp = response.text(); ",
-											"      var name = extractName(url);",
-											"      if(!checkVariableExist(name)){",
-											"        resp = replaceResponseRefWithName(resp);",
-											"        setEnvironmentVariable(name, resp);",
-											"      }",
-											"       traverse(JSON.parse(response.text()));",
-											"       resolve(resp);",
-											"   }else{",
-											"       reject(err);",
-											"   }",
-											"  });",
-											"});",
-											"}",
-											"",
-											"function traverse(data){",
-											"     Object.entries(data).forEach(([key, value]) => {",
-											"     if(key == '$ref'){",
-											"          fetchSchema(value).then(response => {",
-											"              response = replaceResponseRefWithName(response);",
-											"              var name = extractName(value);",
-											"              if(!checkVariableExist(name)){",
-											"                setEnvironmentVariable(name, response);",
-											"              }",
-											"          });",
-											"     }",
-											"     if ((typeof value === 'object') && (value !== null)){",
-											"        traverse(value);",
-											"      }",
-											"    });",
-											"}",
-											"",
-											"traverse(JSON.parse(responseBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Module-Id",
-										"value": "{{kb-ebsco-java-module-id}}",
-										"type": "text"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/resources/resourcePutRequest.json",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"jsonSchemas"
-									],
-									"query": [
-										{
-											"key": "path",
-											"value": "types/resources/resourcePutRequest.json"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "JSON API schema",
+					"name": "setup environment variables",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "1568b4da-e2aa-4152-9cd3-2486e86df10b",
-								"type": "text/javascript",
+								"id": "41dde41e-77c3-4f8a-a8e9-5125e58d8897",
 								"exec": [
-									"pm.test(\"GET schema_parameters OK\", function () {",
+									"const moduleName = 'mod-kb-ebsco-java';",
+									"pm.test(\"GET json schemas response OK\", function () {",
 									"    pm.response.to.be.ok;",
 									"});",
 									"",
-									"pm.test(\"GET schema_parameters has JSON body\", function () {",
+									"pm.test(\"GET json schemas has JSON body\", function () {",
 									"    pm.response.to.have.jsonBody();",
 									"});",
 									"",
-									"pm.environment.set(\"schema_jsonapi_content\", responseBody);"
-								]
+									"pm.test(\"GET contains ebsco-java module\", function () {",
+									"    pm.expect(pm.response.text()).to.include(moduleName);",
+									"});",
+									"",
+									"let json = JSON.parse(responseBody);",
+									"json.forEach((element) => {",
+									"\tvar moduleId = element.id;",
+									"\tif(moduleId.includes(moduleName)){",
+									"\t\tpm.environment.set('kb-ebsco-java-module-id', moduleId);",
+									"\t}",
+									"});"
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2498,15 +46,8 @@
 						"header": [
 							{
 								"key": "X-Okapi-Tenant",
-								"value": "{{xokapitenant}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
+								"value": "{{xokapitenant}}",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -2514,37 +55,39 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "http://jsonapi.org/schema",
-							"protocol": "http",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{xokapitenant}}/interfaces/_jsonSchemas",
+							"protocol": "{{protocol}}",
 							"host": [
-								"jsonapi",
-								"org"
+								"{{url}}"
 							],
+							"port": "{{okapiport}}",
 							"path": [
-								"schema"
+								"_",
+								"proxy",
+								"tenants",
+								"{{xokapitenant}}",
+								"interfaces",
+								"_jsonSchemas"
 							]
-						},
-						"description": "GET JSON API standard schema and store in collection environment variable - schema_jsonapi_content"
+						}
 					},
 					"response": []
 				},
 				{
-					"name": "jsonapi error",
+					"name": "get schemas",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "d13c1f35-28df-47ff-b9b9-cccffa9f1a3e",
+								"id": "d8ecfe03-eebf-4c4f-ad52-09495684b3e0",
 								"exec": [
-									"pm.test(\"GET schema_jsonapiError OK\", function () {",
+									"pm.test(\"GET schema_parameters OK\", function () {",
 									"    pm.response.to.be.ok;",
 									"});",
 									"",
-									"pm.test(\"GET schema_jsonapiError has JSON body\", function () {",
+									"pm.test(\"GET schema_parameters has JSON body\", function () {",
 									"    pm.response.to.have.jsonBody();",
 									"});",
-									"",
-									"setEnvironmentVariable(\"jsonapiError\", replaceResponseRefWithName(pm.response.text()));",
 									"",
 									"function checkVariableExist(name){ return pm.environment.has(\"schema_\"+ name);}",
 									"",
@@ -2555,7 +98,10 @@
 									"function replaceResponseRefWithName(text){ return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*\\.json)/g, \"\\\"$ref\\\":\\\"schema_\"); }",
 									"",
 									"function fetchSchema(url){",
-									"  url = url.replace(/\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/, pm.variables.get(\"url\"));",
+									"  url = pm.variables.get(\"protocol\") + \"://\" + ",
+									"        pm.variables.get(\"url\") + \":\" + ",
+									"        pm.variables.get(\"okapiport\") + ",
+									"        \"/_/jsonSchemas?path=\" + url;",
 									"  const echoGetRequest = {",
 									"    url: url,",
 									"    method: 'GET',",
@@ -2566,36 +112,29 @@
 									"};",
 									"return new Promise(function(resolve, reject) {",
 									"  pm.sendRequest(echoGetRequest, (err, response) => {",
+									"      setTimeout(() => {",
 									"   if (!err) {",
-									"      var resp = response.text(); ",
-									"      var name = extractName(url);",
-									"      if(!checkVariableExist(name)){",
-									"        resp = replaceResponseRefWithName(resp);",
-									"        setEnvironmentVariable(name, resp);",
-									"      }",
-									"       traverse(JSON.parse(response.text()));",
-									"       resolve(resp);",
+									"       resolve(response.text());",
 									"   }else{",
-									"       reject(err);",
+									"       reject(err, echoGetRequest);",
 									"   }",
+									"      }, 5000);",
 									"  });",
 									"});",
 									"}",
 									"",
 									"function traverse(data){",
 									"     Object.entries(data).forEach(([key, value]) => {",
-									"     if(key == '$ref'){",
 									"          fetchSchema(value).then(response => {",
 									"              response = replaceResponseRefWithName(response);",
 									"              var name = extractName(value);",
 									"              if(!checkVariableExist(name)){",
 									"                setEnvironmentVariable(name, response);",
 									"              }",
-									"          });",
-									"     }",
-									"     if ((typeof value === 'object') && (value !== null)){",
-									"        traverse(value);",
-									"      }",
+									"          }).catch((err, req) => {",
+									"            console.log(err);",
+									"            console.log(req);",
+								    "          });",
 									"    });",
 									"}",
 									"",
@@ -2624,7 +163,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas?path=types/jsonapiError.json",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -2633,12 +172,6 @@
 							"path": [
 								"_",
 								"jsonSchemas"
-							],
-							"query": [
-								{
-									"key": "path",
-									"value": "types/jsonapiError.json"
-								}
 							]
 						}
 					},
@@ -3486,8 +1019,7 @@
 									"});",
 									"",
 									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-									"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"});",
 									"",
@@ -3609,8 +1141,7 @@
 									"});",
 									"",
 									"pm.test(\"Validate schema\", function () {",
-									"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-									"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+									"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"});",
 									"",
@@ -3682,6 +1213,39 @@
 						}
 					},
 					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "360b68b9-cda9-4f18-aabb-84229468570b",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "7ea03f74-742e-4515-9806-0569f2bef3f4",
+						"type": "text/javascript",
+						"exec": [
+							"    tv4.addSchema(\"schema_package.json\", JSON.parse(pm.variables.get(\"schema_package\")));",
+							"    tv4.addSchema(\"schema_packageCollectionItem.json\", JSON.parse(pm.variables.get(\"schema_packageCollectionItem\")));",
+							"    tv4.addSchema(\"schema_packageDataAttributes.json\", JSON.parse(pm.variables.get(\"schema_packageDataAttributes\")));",
+							"    tv4.addSchema(\"schema_packageRelationships.json\", JSON.parse(pm.variables.get(\"schema_packageRelationships\")));",
+							"    tv4.addSchema(\"schema_contentTypeEnum.json\", JSON.parse(pm.variables.get(\"schema_contentTypeEnum\")));",
+							"    tv4.addSchema(\"schema_coverage.json\", JSON.parse(pm.variables.get(\"schema_coverage\")));",
+							"    tv4.addSchema(\"schema_visibilityData.json\", JSON.parse(pm.variables.get(\"schema_visibilityData\")));",
+							"    tv4.addSchema(\"schema_proxy.json\", JSON.parse(pm.variables.get(\"schema_proxy\")));",
+							"    tv4.addSchema(\"schema_hasManyRelationship.json\", JSON.parse(pm.variables.get(\"schema_hasManyRelationship\")));",
+							"    tv4.addSchema(\"schema_hasOneRelationship.json\", JSON.parse(pm.variables.get(\"schema_hasOneRelationship\")));",
+							"    tv4.addSchema(\"schema_included.json\", JSON.parse(pm.variables.get(\"schema_included\")));",
+							"    tv4.addSchema(\"schema_jsonapi.json\", JSON.parse(pm.variables.get(\"schema_jsonapi\")));"
+						]
+					}
 				}
 			]
 		},
@@ -4849,8 +2413,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -4928,8 +2491,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -5069,8 +2631,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -5340,8 +2901,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -5727,8 +3287,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -5807,8 +3366,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -6562,8 +4120,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"//Ensure that errors array is not empty",
@@ -6693,8 +4250,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"//Ensure that errors array is not empty",
@@ -6847,8 +4403,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -6932,8 +4487,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -7017,8 +4571,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"//Ensure that errors array is not empty",
@@ -7106,8 +4659,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -7228,7 +4780,9 @@
 							"tv4.addSchema(\"schema_coverage.json\", JSON.parse(pm.variables.get(\"schema_coverage\")));",
 							"tv4.addSchema(\"schema_visibilityData.json\", JSON.parse(pm.variables.get(\"schema_visibilityData\")));",
 							"tv4.addSchema(\"schema_hasManyRelationship.json\", JSON.parse(pm.variables.get(\"schema_hasManyRelationship\")));",
-							"tv4.addSchema(\"schema_hasOneRelationship.json\", JSON.parse(pm.variables.get(\"schema_hasOneRelationship\")));"
+							"tv4.addSchema(\"schema_hasOneRelationship.json\", JSON.parse(pm.variables.get(\"schema_hasOneRelationship\")));",
+							"tv4.addSchema(\"schema_jsonapiError.json\", JSON.parse(pm.variables.get(\"schema_jsonapiError\")));",
+							"tv4.addSchema(\"schema_jsonapiErrorResponse.json\", JSON.parse(pm.variables.get(\"schema_jsonapiErrorResponse\")));"
 						]
 					}
 				}
@@ -8257,8 +5811,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -8399,8 +5952,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -8479,8 +6031,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -8563,8 +6114,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -8648,8 +6198,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -8729,8 +6278,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"// Per https://issues.folio.org/browse/UIEH-483 -- only true is allowed",
@@ -9013,8 +6561,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"//Ensure that errors array is not empty",
@@ -9654,8 +7201,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -9728,8 +7274,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -9802,8 +7347,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -9875,8 +7419,7 @@
 													"",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -9949,8 +7492,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -10283,8 +7825,7 @@
 															"",
 															"//Validate response against json api schema",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -10363,8 +7904,7 @@
 															"",
 															"//Validate response against json api schema",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -10443,8 +7983,7 @@
 															"",
 															"//Validate response against json api schema",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -10532,8 +8071,7 @@
 															"",
 															"//Validate response against json api schema",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -10798,8 +8336,7 @@
 															"",
 															"//Validate response against json api schema",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -10879,8 +8416,7 @@
 															"",
 															"//Validate response against json api schema",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -11278,8 +8814,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -11347,8 +8882,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -11421,8 +8955,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -11631,8 +9164,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"//Ensure that errors array is not empty",
@@ -11706,8 +9238,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"//Ensure that errors array is *not* empty",
@@ -11781,8 +9312,7 @@
 													"",
 													"//Validate response against json api schema",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -11903,7 +9433,9 @@
 							"tv4.addSchema(\"schema_identifier.json\", JSON.parse(pm.variables.get(\"schema_identifier\")));",
 							"tv4.addSchema(\"schema_publicationType.json\", JSON.parse(pm.variables.get(\"schema_publicationType\")));",
 							"tv4.addSchema(\"schema_subject.json\", JSON.parse(pm.variables.get(\"schema_subject\")));",
-							"tv4.addSchema(\"schema_embargo.json\", JSON.parse(pm.variables.get(\"schema_embargo\")));"
+							"tv4.addSchema(\"schema_embargo.json\", JSON.parse(pm.variables.get(\"schema_embargo\")));",
+							"tv4.addSchema(\"schema_jsonapiError.json\", JSON.parse(pm.variables.get(\"schema_jsonapiError\")));",
+							"tv4.addSchema(\"schema_jsonapiErrorResponse.json\", JSON.parse(pm.variables.get(\"schema_jsonapiErrorResponse\")));"
 						]
 					}
 				}
@@ -12163,8 +9695,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -12259,8 +9790,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -12354,8 +9884,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -12436,8 +9965,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -12539,8 +10067,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -13485,8 +11012,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -13979,8 +11505,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14213,8 +11738,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14296,8 +11820,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14381,8 +11904,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14466,8 +11988,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14549,8 +12070,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14780,8 +12300,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14863,8 +12382,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -14948,8 +12466,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -15018,7 +12535,6 @@
 													"listen": "test",
 													"script": {
 														"id": "6fae833a-63c5-49f6-b981-82d782c6c0c1",
-														"type": "text/javascript",
 														"exec": [
 															"pm.test(\"Status is 400\", function () {",
 															"    pm.response.to.have.status(400);",
@@ -15031,8 +12547,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -15043,18 +12558,19 @@
 															"",
 															"",
 															""
-														]
+														],
+														"type": "text/javascript"
 													}
 												},
 												{
 													"listen": "prerequest",
 													"script": {
 														"id": "7d0514e8-3021-4a00-9ab8-4f98eaf6bb81",
-														"type": "text/javascript",
 														"exec": [
 															"let toRepeat = \"0\";",
 															"pm.variables.set(\"long-coverage\", toRepeat.repeat(201));"
-														]
+														],
+														"type": "text/javascript"
 													}
 												}
 											],
@@ -15114,8 +12630,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -15195,8 +12710,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -15422,8 +12936,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -15939,8 +13452,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -16038,8 +13550,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -16137,8 +13648,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -16235,8 +13745,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -16333,8 +13842,7 @@
 															"var jsonData = pm.response.json();",
 															"",
 															"pm.test(\"Validate schema\", function () {",
-															"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
@@ -16598,8 +14106,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -16684,8 +14191,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -16771,8 +14277,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -16875,7 +14380,9 @@
 							"tv4.addSchema(\"schema_included.json\", JSON.parse(pm.variables.get(\"schema_included\")));",
 							"tv4.addSchema(\"schema_relationshipData.json\", JSON.parse(pm.variables.get(\"schema_relationshipData\")));",
 							"tv4.addSchema(\"schema_contributor.json\", JSON.parse(pm.variables.get(\"schema_contributor\")));",
-							"tv4.addSchema(\"schema_coverage.json\", JSON.parse(pm.variables.get(\"schema_coverage\")));"
+							"tv4.addSchema(\"schema_coverage.json\", JSON.parse(pm.variables.get(\"schema_coverage\")));",
+							"tv4.addSchema(\"schema_jsonapiError.json\", JSON.parse(pm.variables.get(\"schema_jsonapiError\")));",
+							"tv4.addSchema(\"schema_jsonapiErrorResponse.json\", JSON.parse(pm.variables.get(\"schema_jsonapiErrorResponse\")));"
 						]
 					}
 				}
@@ -18119,8 +15626,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -18202,8 +15708,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -18293,8 +15798,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -18381,8 +15885,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -18548,8 +16051,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -19086,8 +16588,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -19346,8 +16847,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -19440,8 +16940,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -19586,8 +17085,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -19811,8 +17309,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -19957,8 +17454,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -20046,8 +17542,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -20213,8 +17708,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -20314,8 +17808,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -20416,8 +17909,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -20515,8 +18007,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function() {",
-													"    tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -20615,8 +18106,7 @@
 													"var jsonData = pm.response.json();",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -20865,6 +18355,9 @@
 							"tv4.addSchema(\"schema_titles.json\", JSON.parse(pm.variables.get(\"schema_titles\")));",
 							"tv4.addSchema(\"schema_titleListDataAttributes.json\", JSON.parse(pm.variables.get(\"schema_titleListDataAttributes\")));",
 							"tv4.addSchema(\"schema_metaIncluded.json\", JSON.parse(pm.variables.get(\"schema_metaIncluded\")));",
+							"tv4.addSchema(\"schema_metaTotalResults.json\", JSON.parse(pm.variables.get(\"schema_metaTotalResults\")));",
+							"tv4.addSchema(\"schema_jsonapiError.json\", JSON.parse(pm.variables.get(\"schema_jsonapiError\")));",
+							"tv4.addSchema(\"schema_jsonapiErrorResponse.json\", JSON.parse(pm.variables.get(\"schema_jsonapiErrorResponse\")));",
 							""
 						]
 					}
@@ -22005,8 +19498,7 @@
 													"",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -22086,8 +19578,7 @@
 													"",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -22167,8 +19658,7 @@
 													"",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -22248,8 +19738,7 @@
 													"",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -22329,8 +19818,7 @@
 													"",
 													"",
 													"pm.test(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -22410,8 +19898,7 @@
 													"// The schema does not validate for PUT request",
 													"// Check after https://issues.folio.org/browse/UIEH-575 is addressed",
 													"pm.test.skip(\"Validate schema\", function () {",
-													"     tv4.addSchema(\"JSONAPI.json\", JSON.parse(pm.variables.get(\"schema_jsonapi_content\")));",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapi_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
@@ -22550,7 +20037,9 @@
 						"exec": [
 							"tv4.addSchema(\"schema_configurationData.json\", JSON.parse(pm.variables.get(\"schema_configurationData\")));",
 							"tv4.addSchema(\"schema_jsonapi.json\", JSON.parse(pm.variables.get(\"schema_jsonapi\")));",
-							"tv4.addSchema(\"schema_configurationAttributes.json\", JSON.parse(pm.variables.get(\"schema_configurationAttributes\")));"
+							"tv4.addSchema(\"schema_configurationAttributes.json\", JSON.parse(pm.variables.get(\"schema_configurationAttributes\")));",
+							"tv4.addSchema(\"schema_jsonapiError.json\", JSON.parse(pm.variables.get(\"schema_jsonapiError\")));",
+							"tv4.addSchema(\"schema_jsonapiErrorResponse.json\", JSON.parse(pm.variables.get(\"schema_jsonapiErrorResponse\")));"
 						]
 					}
 				}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-155 we want to use modifications made for RMB module related to /_/jsonSchemas endpoint.

## Approach

- used /_/jsonSchemas endpoint to get a list of JSON schemas available for module
<img width="1166" alt="screen shot 2019-01-29 at 2 57 24 pm" src="https://user-images.githubusercontent.com/37537790/51909869-5191e480-23d6-11e9-877d-39ed9cca3c6e.png">

- updated schema download script to retrieve a list of JSON schemas and download them at once

- removed requests for fetching schemas associated with a separate endpoint

- changed validation of JSON API schema in case of negative test cases to use mod-kb-ebsco-java module JSON error schemas.

Run API tests on local environment against testing-backend using Postman collection runner and newnan.