### PR TITLE
MODORDSTOR-59 added missing schemas for validation

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cef54600-18a1-4748-8357-611c20355f34",
+		"_postman_id": "f86884e1-38e9-46a8-a2bb-fd5c391a0545",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1180,6 +1180,86 @@
 										"{{business_module}}",
 										"schemas",
 										"{{schema_po_number}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "order_format.json",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
+										"exec": [
+											"pm.test(pm.variables.get(\"schema_order_format\") + \" GET OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.globals.set(\"schema_order_format_content\", responseBody);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_order_format}}",
+									"host": [
+										"{{schema_loc}}"
+									],
+									"path": [
+										"{{storage_module}}",
+										"schemas",
+										"{{schema_order_format}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "receipt_status.json",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
+										"exec": [
+											"pm.test(pm.variables.get(\"schema_receipt_status\") + \" GET OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.globals.set(\"schema_receipt_status_content\", responseBody);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_receipt_status}}",
+									"host": [
+										"{{schema_loc}}"
+									],
+									"path": [
+										"{{storage_module}}",
+										"schemas",
+										"{{schema_receipt_status}}"
 									]
 								}
 							},
@@ -7961,6 +8041,8 @@
 					"        pm.globals.unset(\"schema_vendor_detail_content\");",
 					"        pm.globals.unset(\"schema_metadata_content\");",
 					"        pm.globals.unset(\"schema_po_number_content\");",
+					"        pm.globals.unset(\"schema_order_format_content\");",
+					"        pm.globals.unset(\"schema_receipt_status_content\");",
 					"        pm.globals.unset(\"empty_order_id\");",
 					"        pm.globals.unset(\"po_listed_print_monograph\");",
 					"        pm.globals.unset(\"complete_poline_ids\");",
@@ -8018,6 +8100,8 @@
 					"        tv4.addSchema(\"mod-orders-storage/schemas/source.json\", JSON.parse(globals.schema_source_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/vendor_detail.json\", JSON.parse(globals.schema_vendor_detail_content));",
 					"        tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(globals.schema_metadata_content));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/order_format.json\", JSON.parse(globals.schema_order_format_content));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/receipt_status.json\", JSON.parse(globals.schema_receipt_status_content));",
 					"    };",
 					"",
 					"    /**",
@@ -8066,139 +8150,151 @@
 	],
 	"variable": [
 		{
-			"id": "661c7f79-8b3d-412f-8054-7d2a1e16fb14",
+			"id": "9c0e204f-c0ad-4ef8-babd-3fbcc6ab5373",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "f4a5d66e-d7f1-49b7-a9e1-060f077e487b",
+			"id": "d8794ea1-22a2-4b42-8a46-de8a149bf060",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/acq-models/master",
 			"type": "string"
 		},
 		{
-			"id": "e31813d1-2484-41fb-9261-1b71edf77252",
+			"id": "855b1683-f330-4bb6-83b8-debd442188a4",
 			"key": "schema_composite_purchase_order",
 			"value": "composite_purchase_order.json",
 			"type": "string"
 		},
 		{
-			"id": "e6dbf054-72c3-48f4-b5fe-798ef34b0d4a",
+			"id": "66c17199-cdb1-465f-ad9c-2548ee4b4882",
 			"key": "schema_adjustment",
 			"value": "adjustment.json",
 			"type": "string"
 		},
 		{
-			"id": "a0a66236-e6c8-4c3b-b767-310a4439db8d",
+			"id": "1824e20f-9c4b-4191-ad92-d56d57c4a437",
 			"key": "schema_alert",
 			"value": "alert.json",
 			"type": "string"
 		},
 		{
-			"id": "7b7b01fa-57c3-460e-8a62-97dadc5dc70f",
+			"id": "e27f2bde-d95b-443c-9738-42b288a6b13a",
 			"key": "schema_claim",
 			"value": "claim.json",
 			"type": "string"
 		},
 		{
-			"id": "a4550385-6645-477e-83d1-18183d82a5bf",
+			"id": "aa05dd7b-609b-4a6e-9c32-9347ca40493e",
 			"key": "schema_composite_po_line",
 			"value": "composite_po_line.json",
 			"type": "string"
 		},
 		{
-			"id": "bf74ccf9-3d9d-4a69-bf88-a8fb90c95d18",
+			"id": "58d6a7a4-1e49-429a-b25d-1c6d81073703",
 			"key": "schema_cost",
 			"value": "cost.json",
 			"type": "string"
 		},
 		{
-			"id": "b7d48c3e-1095-441a-a00d-fab212aea777",
+			"id": "3bff641e-1eff-43c7-8d66-27c68cb9ae96",
 			"key": "schema_details",
 			"value": "details.json",
 			"type": "string"
 		},
 		{
-			"id": "3640d806-8191-453b-b322-477e2273b276",
+			"id": "af0a0097-ca00-4dfe-ab23-ffac69a7f967",
 			"key": "schema_eresource",
 			"value": "eresource.json",
 			"type": "string"
 		},
 		{
-			"id": "20c12ac7-3423-404d-b7b8-84313ec2bbf0",
+			"id": "7964eeca-2dab-43b7-aff2-15000c564927",
 			"key": "schema_fund_distribution",
 			"value": "fund_distribution.json",
 			"type": "string"
 		},
 		{
-			"id": "a9f64ac4-e5e9-4aee-8c18-b1bea2455728",
+			"id": "6cfe3206-db5a-4679-a5f9-4fbeb2ca42d3",
 			"key": "schema_location",
 			"value": "location.json",
 			"type": "string"
 		},
 		{
-			"id": "9cfaa830-e65b-448e-8978-d78f52b62117",
+			"id": "bd5f457f-64fd-49e1-a33c-73fd449d4c7d",
 			"key": "schema_physical",
 			"value": "physical.json",
 			"type": "string"
 		},
 		{
-			"id": "d6d01fcd-f46a-4123-8594-aaaf6dbb5067",
+			"id": "2b4819d5-9de2-4ca2-9e4f-56d5e30c2ef8",
 			"key": "schema_renewal",
 			"value": "renewal.json",
 			"type": "string"
 		},
 		{
-			"id": "2a853707-c1c6-4926-8503-351dc7e01472",
+			"id": "51e22b26-5037-411b-8637-040f2e641336",
 			"key": "schema_reporting_code",
 			"value": "reporting_code.json",
 			"type": "string"
 		},
 		{
-			"id": "5f989c84-964c-482e-9e1a-e38708930a06",
+			"id": "f9f00b37-1d5a-4e99-91bd-d1338031a6f4",
 			"key": "schema_source",
 			"value": "source.json",
 			"type": "string"
 		},
 		{
-			"id": "78e71a73-a921-4e25-8e8d-ba792bcd84c2",
+			"id": "5f5e9a63-4733-40e0-bbe9-400ff0853caa",
 			"key": "schema_vendor_detail",
 			"value": "vendor_detail.json",
 			"type": "string"
 		},
 		{
-			"id": "1cfda99b-abcc-4ecb-ac84-1e3a38fd073f",
+			"id": "023df824-7912-45f7-954d-e8d5941c6c34",
+			"key": "schema_order_format",
+			"value": "order_format.json",
+			"type": "string"
+		},
+		{
+			"id": "bc72308d-bde8-4b39-aa6d-5ce28d2bba04",
+			"key": "schema_receipt_status",
+			"value": "receipt_status.json",
+			"type": "string"
+		},
+		{
+			"id": "470fc98a-8d92-44e4-92f3-a9984a138429",
 			"key": "storage_module",
 			"value": "mod-orders-storage",
 			"type": "string"
 		},
 		{
-			"id": "0995d48f-5ecb-4516-bf92-3d8efb374557",
+			"id": "366e29bf-0b91-4ae8-83cc-f3ffb9dc301d",
 			"key": "business_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "f7fba9a3-ed9b-4ed4-aa6f-9bf3b9cf43fd",
+			"id": "0ed1edd7-9c94-4c30-90b7-23d5434c0531",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "95aee99e-f9bb-40a3-8840-6fa3625bab4c",
+			"id": "474c8714-5469-4e79-9443-d4dfaa403644",
 			"key": "schema_po_number",
 			"value": "po_number.json",
 			"type": "string"
 		},
 		{
-			"id": "cf1738b1-a9de-4890-b71c-5028be5ef195",
+			"id": "3a04f91f-fdc2-41b2-aae9-0e368c1ec9b6",
 			"key": "raml_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/raml/raml1.0",
 			"type": "string"
 		},
 		{
-			"id": "b3ddb871-be27-4c2d-86d5-63b81375c182",
+			"id": "93648307-7a1f-4c52-9db7-ce0eea589d30",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"


### PR DESCRIPTION
## Purpose
API tests are failing after splitting PO sub-objects `order_format` and `receipt_status` into separate schemas due PR https://github.com/folio-org/acq-models/pull/98

## Approach
Adding schemas `order_format.json` and `receipt_status.json` to "Load schemas for validation" folder and update schemas loading script.