### PR TITLE
MODORDERS-175 Add ability to move a received piece back to "Expected"

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -4431,7 +4431,91 @@
 										"receive"
 									]
 								},
-								"description": "Receives all remaining piece records and Inventory items for a PO Line with `Physical Resource` order format from an order created by `Create Open order with physical and electronic lines` request (see [MODORDERS-103](https://issues.folio.org/browse/MODORDERS-103))."
+								"description": "Receives all piece records and Inventory items for a PO Line with `P/E Mix` order format from an order created by `Create Open order with P/E Mix and Electronic lines` request (see [MODORDERS-163](https://issues.folio.org/browse/MODORDERS-163))."
+							},
+							"response": []
+						},
+						{
+							"name": "Revert all received pieces for P/E Mix line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.complete_open_order_id, \"P/E Mix\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"receivingRqBody\"));",
+											"let receivingPoLineId = pm.variables.get(\"receivingPoLineId\");",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has all pieces successfully processed\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeReceived.length);",
+											"    // All pieces should be successfully processed",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + receivingPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Awaiting Receipt\");",
+											"    utils.validateInventoryItemsReceived(line, 0);",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 0, \"Received\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{receivingRqBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								},
+								"description": "Revert all received piece records and Inventory items for a PO Line with `P/E Mix` order format from an order created by `Create Open order with P/E Mix and Electronic lines` request (see [MODORDERS-175](https://issues.folio.org/browse/MODORDERS-175))."
 							},
 							"response": []
 						},
@@ -4520,7 +4604,91 @@
 							"response": []
 						},
 						{
-							"name": "Receive all remaining pieces for physical line",
+							"name": "Revert all received pieces for physical line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.phys_el_open_order_id, \"Physical Resource\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"receivingRqBody\"));",
+											"let receivingPoLineId = pm.variables.get(\"receivingPoLineId\");",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has all pieces successfully processed\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeReceived.length);",
+											"    // All pieces should be successfully processed",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + receivingPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Awaiting Receipt\");",
+											"    utils.validateInventoryItemsReceived(line, 0);",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 0, \"Received\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{receivingRqBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								},
+								"description": "Revert 10 received piece records back to `Expected` and Inventory items back to `On order` for a PO Line with `Physical Resource` order format from an order created by `Create Open order with physical and electronic lines` request (see [MODORDERS-175](https://issues.folio.org/browse/MODORDERS-175))."
+							},
+							"response": []
+						},
+						{
+							"name": "Receive all pieces for physical line",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -4688,6 +4856,91 @@
 							"response": []
 						},
 						{
+							"name": "Revert 2 received pieces for electronic line (without items in Inventory)",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.phys_el_open_order_id, \"Electronic Resource\", 2);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"receivingRqBody\"));",
+											"let receivingPoLineId = pm.variables.get(\"receivingPoLineId\");",
+											"let receivingHistoryTotalRecords = pm.variables.get(\"receivingHistoryTotalRecords\");",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has all pieces successfully processed\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeReceived.length);",
+											"    // All pieces should be successfully processed",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + receivingPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Partially Received\");",
+											"    utils.validateInventoryItemsReceived(line, 0);",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 2, \"Expected\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{receivingRqBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								},
+								"description": "Revert 2 received piece records back to `Expected` for a PO Line with `Electronic Resource` order format from an order created by `Create Open order with physical and electronic lines` request (see [MODORDERS-175](https://issues.folio.org/browse/MODORDERS-175))."
+							},
+							"response": []
+						},
+						{
 							"name": "Receive pieces for electronic line (with items in Inventory)",
 							"event": [
 								{
@@ -4767,7 +5020,92 @@
 										"receive"
 									]
 								},
-								"description": "Receives all piece records without Inventory items for a PO Line with `Electronic Resource` order format from an order created by `Create Open order with physical and electronic lines` request (see [MODORDERS-162](https://issues.folio.org/browse/MODORDERS-162)). The PO Line is with 10 pieces, create inventory is `false`."
+								"description": "Receives all piece records without Inventory items for a PO Line with `Electronic Resource` order format from an order created by `Create Open order with P/E Mix and Electronic lines` request (see [MODORDERS-162](https://issues.folio.org/browse/MODORDERS-162)). The PO Line is with 3 pieces, create inventory is `true`."
+							},
+							"response": []
+						},
+						{
+							"name": "Revert 1 received piece for electronic line (with items in Inventory)",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.complete_open_order_id, \"Electronic Resource\", 1);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"receivingRqBody\"));",
+											"let receivingPoLineId = pm.variables.get(\"receivingPoLineId\");",
+											"let receivingHistoryTotalRecords = pm.variables.get(\"receivingHistoryTotalRecords\");",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has all pieces successfully received\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeReceived.length);",
+											"    // All pieces should be successfully received",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + receivingPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Partially Received\");",
+											"    utils.validateInventoryItemsReceived(line, receivingHistoryTotalRecords - 1);",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 1, \"Expected\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{receivingRqBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								},
+								"description": "Revert 1 received piece record back to `Expected` and associated Inventory item back to `On order` for a PO Line with `Electronic Resource` order format from an order created by `Create Open order with P/E Mix and Electronic lines` request (see [MODORDERS-175](https://issues.folio.org/browse/MODORDERS-175))."
 							},
 							"response": []
 						},
@@ -8470,38 +8808,57 @@
 					"    /**",
 					"     * Prepare receiving request body for all PO Lines of an order",
 					"     * The function sets following variable:",
+					"     * - `receivingHistoryTotalRecords` total records of the expected piece status indicated by receiving history response",
 					"     * - `receivingRqBody` the body for receiving request",
 					"     * @param orderId order id to receive one PO Line of the desired order format",
 					"     * @param quantityToReceive number of pieces to receive. In case if not specified, all pieces will be received",
+					"     * @param itemStatus desired status of the item",
 					"     */",
-					"    utils.prepareReceivingRequestForOrder = function(orderId, quantityToReceive) {",
+					"    utils.prepareReceivingRequestForOrder = function(orderId, quantityToReceive, itemStatus) {",
+					"        if (typeof itemStatus === \"undefined\") {",
+					"            itemStatus = \"Received\";",
+					"        }",
+					"        let pieceStatus = (itemStatus === \"On order\") ? \"Received\" : \"Expected\";",
 					"        utils.sendGetRequest(\"/orders/composite-orders/\" + orderId, (err, res) => {",
-					"            let order;",
-					"            pm.test(\"Retrieving order by id=\" + orderId, function () {",
+					"            pm.test(\"Preparing receiving request for entire order with id=\" + orderId, function () {",
 					"                pm.expect(res).to.have.property('code', 200);",
-					"                order = res.json();",
 					"            });",
 					"",
 					"            if (typeof quantityToReceive === \"undefined\") {",
 					"                quantityToReceive = 1000;",
 					"            }",
-					"            utils.sendGetRequest(\"/orders/receiving-history?limit=\" + quantityToReceive + \"&query=receivingStatus==Expected and purchaseOrderId=\" + orderId, (err, res) => {",
-					"                let receivingRq = utils.prepareReceivingRequest(res.json().receiving_history);",
+					"            utils.sendGetRequest(\"/orders/receiving-history?limit=\" + quantityToReceive + \"&query=receivingStatus==\" + pieceStatus + \" and purchaseOrderId=\" + orderId, (err, res) => {",
+					"                let receivingRq = utils.prepareReceivingRequest(res.json().receiving_history, itemStatus);",
+					"                pm.variables.set(\"receivingHistoryTotalRecords\", res.json().total_records);",
 					"                pm.variables.set(\"receivingRqBody\", JSON.stringify(receivingRq));",
 					"            });",
 					"        });",
+					"    };",
+					"",
+					"    utils.prepareRollBackReceivingRequestForOrder = function(orderId, quantity) {",
+					"        utils.prepareReceivingRequestForOrder(orderId, quantity, \"On order\");",
+					"    };",
+					"",
+					"    utils.prepareRollBackReceivingRequestForPoLineOfFormat = function(orderId, orderFormat, quantity) {",
+					"        utils.prepareReceivingRequestForPoLineOfFormat(orderId, orderFormat, quantity, \"On order\");",
 					"    };",
 					"",
 					"    /**",
 					"     * Prepare receiving request body for PO Line of expected order format",
 					"     * The function sets 2 variables:",
 					"     * - `receivingPoLineId` the PO Line id receiving request is going to be sent",
+					"     * - `receivingHistoryTotalRecords` total records of the expected piece status indicated by receiving history response",
 					"     * - `receivingRqBody` the body for receiving request",
-					"     * @param orderId order id to receive one PO Line of the desired order format",
-					"     * @param orderFormat PO Line of the desired order format",
-					"     * @param quantityToReceive number of pieces to receive. In case if not specified, all pieces will be received",
+					"     * @param orderId order id to receive/revert pieces of the PO Line of the desired order format",
+					"     * @param orderFormat the desired order format of the PO Line",
+					"     * @param quantityToReceive number of pieces to receive/revert. In case if not specified, all pieces will be received/reverted",
+					"     * @param itemStatus desired status of the item",
 					"     */",
-					"    utils.prepareReceivingRequestForPoLineOfFormat = function(orderId, orderFormat, quantityToReceive) {",
+					"    utils.prepareReceivingRequestForPoLineOfFormat = function(orderId, orderFormat, quantityToReceive, itemStatus) {",
+					"        if (typeof itemStatus === \"undefined\") {",
+					"            itemStatus = \"Received\";",
+					"        }",
+					"        let pieceStatus = (itemStatus === \"On order\") ? \"Received\" : \"Expected\";",
 					"        utils.sendGetRequest(\"/orders/composite-orders/\" + orderId, (err, res) => {",
 					"            let poLine;",
 					"            pm.test(\"One PO Line with \" + orderFormat + \" order format expected\", function () {",
@@ -8516,8 +8873,9 @@
 					"            if (typeof quantityToReceive === \"undefined\" || quantityToReceive > piecesQuantity) {",
 					"                quantityToReceive = piecesQuantity;",
 					"            }",
-					"            utils.sendGetRequest(\"/orders/receiving-history?limit=\" + quantityToReceive + \"&query=receivingStatus==Expected and poLineId=\" + poLine.id, (err, res) => {",
-					"                let receivingRq = utils.prepareReceivingRequest(res.json().receiving_history);",
+					"            utils.sendGetRequest(\"/orders/receiving-history?limit=\" + quantityToReceive + \"&query=receivingStatus==\" + pieceStatus + \" and poLineId=\" + poLine.id, (err, res) => {",
+					"                let receivingRq = utils.prepareReceivingRequest(res.json().receiving_history, itemStatus);",
+					"                pm.variables.set(\"receivingHistoryTotalRecords\", res.json().total_records);",
 					"                pm.variables.set(\"receivingRqBody\", JSON.stringify(receivingRq));",
 					"            });",
 					"        });",
@@ -8526,7 +8884,12 @@
 					"    /**",
 					"     * Prepare receiving request body based on receiving history array (MODORDERS-103)",
 					"     */",
-					"    utils.prepareReceivingRequest = function(receivingHistory) {",
+					"    utils.prepareReceivingRequest = function(receivingHistory, itemStatus) {",
+					"        if (typeof itemStatus === \"undefined\") {",
+					"            itemStatus = \"Received\";",
+					"        }",
+					"        let isRevertCase = itemStatus === \"On order\";",
+					"",
 					"        let totalQty = receivingHistory.length;",
 					"        let piecesGroupedByPol = new Map();",
 					"        for(let i = 0; i < totalQty; i++) {",
@@ -8540,7 +8903,17 @@
 					"        let receivingRq = globals.testData.receiving.bodyTemplate;",
 					"        let toBeReceivedTemplate = receivingRq.toBeReceived.pop();",
 					"        let receivedItemTemplate = toBeReceivedTemplate.receivedItems.pop();",
-					"        let barcode = parseInt(pm.environment.get(\"receivingItemBarcode\") ? pm.environment.get(\"receivingItemBarcode\") : receivedItemTemplate.barcode);",
+					"        receivedItemTemplate.itemStatus = itemStatus;",
+					"",
+					"        let barcode;",
+					"        if (isRevertCase) {",
+					"            delete receivedItemTemplate.barcode;",
+					"            delete receivedItemTemplate.comment;",
+					"            delete receivedItemTemplate.caption;",
+					"            delete receivedItemTemplate.locationId;",
+					"        } else {",
+					"            barcode = parseInt(pm.environment.get(\"receivingItemBarcode\") ? pm.environment.get(\"receivingItemBarcode\") : receivedItemTemplate.barcode);",
+					"        }",
 					"",
 					"        let total = 0;",
 					"        for (var [polId, pieceIds] of piecesGroupedByPol) {",
@@ -8550,8 +8923,10 @@
 					"            for(let i = 0; i < pieceIds.length; i++) {",
 					"                let receivedItem = utils.copyJsonObj(receivedItemTemplate);",
 					"                receivedItem.pieceId = pieceIds[i];",
-					"                // Inventory requires unique barcodes",
-					"                receivedItem.barcode = ++barcode;",
+					"                if (!isRevertCase) {",
+					"                    // Inventory requires unique barcodes",
+					"                    receivedItem.barcode = ++barcode;",
+					"                }",
 					"                toBeReceived.receivedItems.push(receivedItem);",
 					"                total++;",
 					"            }",
@@ -8559,7 +8934,9 @@
 					"        }",
 					"        receivingRq.totalRecords = total;",
 					"",
-					"        pm.environment.set(\"receivingItemBarcode\", barcode);",
+					"        if (!isRevertCase) {",
+					"            pm.environment.set(\"receivingItemBarcode\", barcode);",
+					"        }",
 					"        return receivingRq;",
 					"    };",
 					"",


### PR DESCRIPTION
[MODORDERS-175](https://issues.folio.org/browse/MODORDERS-175) Add ability to move a received piece back to "Expected"

The following requests added:
- `Revert all received pieces for P/E Mix line` 
  also verifies that PO Line's receipt status changed from `Fully Received` to `Awaiting Receipt`  
  ![image](https://user-images.githubusercontent.com/43410167/53802891-0b3f2080-3f54-11e9-8848-6536b76e8b76.png)
- `Revert all received pieces for physical line` 
  also verifies that PO Line's receipt status changed from `Partially Received` to `Awaiting Receipt`
  ![image](https://user-images.githubusercontent.com/43410167/53802927-34f84780-3f54-11e9-86eb-ad5a115fc916.png)
- `Revert 2 received pieces for electronic line (without items in Inventory)` 
  also verifies that PO Line's receipt status changed from `Fully Received` to `Partially Received`
  ![image](https://user-images.githubusercontent.com/43410167/53802995-5f4a0500-3f54-11e9-9605-56cf41f85e09.png)
- `Revert 1 received piece for electronic line (with items in Inventory)` 
  also verifies that PO Line's receipt status changed from `Fully Received` to `Partially Received`
  ![image](https://user-images.githubusercontent.com/43410167/53803023-78eb4c80-3f54-11e9-90b9-0f5cc16b7de9.png)