### PR TITLE
MODINVOSTO-2 Define APIs

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ebca41cc-1bf7-434e-a62f-d172c663a537",
+		"_postman_id": "d590b88f-be2b-4528-a8e3-8e733b1e90bc",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -382,11 +382,13 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{schema_composite_purchase_order}}",
+									"raw": "{{schema_loc}}/{{orders_module}}/schemas/{{schema_composite_purchase_order}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
+										"{{orders_module}}",
+										"schemas",
 										"{{schema_composite_purchase_order}}"
 									]
 								},
@@ -533,11 +535,13 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{schema_composite_po_line}}",
+									"raw": "{{schema_loc}}/{{orders_module}}/schemas/{{schema_composite_po_line}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
+										"{{orders_module}}",
+										"schemas",
 										"{{schema_composite_po_line}}"
 									]
 								},
@@ -1260,6 +1264,46 @@
 										"{{storage_module}}",
 										"schemas",
 										"{{schema_receipt_status}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "product_id_type.json",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
+										"exec": [
+											"pm.test(pm.variables.get(\"schema_product_id_type\") + \" GET OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.globals.set(\"schema_product_id_type_content\", responseBody);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{schema_loc}}/{{common_folder}}/schemas/{{schema_product_id_type}}",
+									"host": [
+										"{{schema_loc}}"
+									],
+									"path": [
+										"{{common_folder}}",
+										"schemas",
+										"{{schema_product_id_type}}"
 									]
 								}
 							},
@@ -9146,6 +9190,7 @@
 					"        pm.globals.unset(\"schema_po_number_content\");",
 					"        pm.globals.unset(\"schema_order_format_content\");",
 					"        pm.globals.unset(\"schema_receipt_status_content\");",
+					"        pm.globals.unset(\"schema_product_id_type_content\");",
 					"        pm.globals.unset(\"empty_order_id\");",
 					"        pm.globals.unset(\"po_listed_print_monograph\");",
 					"        pm.globals.unset(\"complete_poline_ids\");",
@@ -9207,6 +9252,7 @@
 					"        tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(globals.schema_metadata_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/order_format.json\", JSON.parse(globals.schema_order_format_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/receipt_status.json\", JSON.parse(globals.schema_receipt_status_content));",
+					"        tv4.addSchema(\"common/schemas/product_id_type.json\", JSON.parse(globals.schema_product_id_type_content));",
 					"    };",
 					"",
 					"    /**",
@@ -9255,153 +9301,171 @@
 	],
 	"variable": [
 		{
-			"id": "9c0e204f-c0ad-4ef8-babd-3fbcc6ab5373",
+			"id": "3573e6fb-0948-43c3-bd6a-01d7577421f4",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "d8794ea1-22a2-4b42-8a46-de8a149bf060",
+			"id": "7958a9af-3b13-4a03-99ce-afd2cabd58bc",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/acq-models/master",
 			"type": "string"
 		},
 		{
-			"id": "855b1683-f330-4bb6-83b8-debd442188a4",
+			"id": "3a2d1381-e8f2-4a7c-aae8-2c0e4c1987fd",
 			"key": "schema_composite_purchase_order",
 			"value": "composite_purchase_order.json",
 			"type": "string"
 		},
 		{
-			"id": "66c17199-cdb1-465f-ad9c-2548ee4b4882",
+			"id": "bd1a87f0-27d3-4285-b688-818ad8a05309",
 			"key": "schema_adjustment",
 			"value": "adjustment.json",
 			"type": "string"
 		},
 		{
-			"id": "1824e20f-9c4b-4191-ad92-d56d57c4a437",
+			"id": "c1771ded-244a-4538-9c38-743a191a31cc",
 			"key": "schema_alert",
 			"value": "alert.json",
 			"type": "string"
 		},
 		{
-			"id": "e27f2bde-d95b-443c-9738-42b288a6b13a",
+			"id": "0c08282f-4845-4163-b626-3f7c4cf78342",
 			"key": "schema_claim",
 			"value": "claim.json",
 			"type": "string"
 		},
 		{
-			"id": "aa05dd7b-609b-4a6e-9c32-9347ca40493e",
+			"id": "d8c22c9a-fd01-44de-ac29-ca026cf5c551",
 			"key": "schema_composite_po_line",
 			"value": "composite_po_line.json",
 			"type": "string"
 		},
 		{
-			"id": "58d6a7a4-1e49-429a-b25d-1c6d81073703",
+			"id": "713caa13-11ee-4b50-8f2e-1668876b66f6",
 			"key": "schema_cost",
 			"value": "cost.json",
 			"type": "string"
 		},
 		{
-			"id": "3bff641e-1eff-43c7-8d66-27c68cb9ae96",
+			"id": "9f63b425-d6b0-4067-a1e6-72668868f9e1",
 			"key": "schema_details",
 			"value": "details.json",
 			"type": "string"
 		},
 		{
-			"id": "af0a0097-ca00-4dfe-ab23-ffac69a7f967",
+			"id": "15c5fe03-5c76-434c-87f0-28f0087b5758",
 			"key": "schema_eresource",
 			"value": "eresource.json",
 			"type": "string"
 		},
 		{
-			"id": "7964eeca-2dab-43b7-aff2-15000c564927",
+			"id": "65885c7c-af3c-4e3c-a59c-f644c19146f7",
 			"key": "schema_fund_distribution",
 			"value": "fund_distribution.json",
 			"type": "string"
 		},
 		{
-			"id": "6cfe3206-db5a-4679-a5f9-4fbeb2ca42d3",
+			"id": "1488c2f3-4c07-4295-bd3b-d5aba2c9b6d4",
 			"key": "schema_location",
 			"value": "location.json",
 			"type": "string"
 		},
 		{
-			"id": "bd5f457f-64fd-49e1-a33c-73fd449d4c7d",
+			"id": "d8a99dd7-b79f-4c3b-9884-575b807890ae",
 			"key": "schema_physical",
 			"value": "physical.json",
 			"type": "string"
 		},
 		{
-			"id": "2b4819d5-9de2-4ca2-9e4f-56d5e30c2ef8",
+			"id": "5b799621-ddcf-44b4-b950-d8ebf63a52f2",
 			"key": "schema_renewal",
 			"value": "renewal.json",
 			"type": "string"
 		},
 		{
-			"id": "51e22b26-5037-411b-8637-040f2e641336",
+			"id": "b04d48de-94e7-420c-a379-948eacb3fe8a",
 			"key": "schema_reporting_code",
 			"value": "reporting_code.json",
 			"type": "string"
 		},
 		{
-			"id": "f9f00b37-1d5a-4e99-91bd-d1338031a6f4",
+			"id": "b2206055-48f7-40e3-9ff8-8dfe9b8e063b",
 			"key": "schema_source",
 			"value": "source.json",
 			"type": "string"
 		},
 		{
-			"id": "5f5e9a63-4733-40e0-bbe9-400ff0853caa",
+			"id": "28fe1d0e-890d-4bbb-ae5f-3225f7424309",
 			"key": "schema_vendor_detail",
 			"value": "vendor_detail.json",
 			"type": "string"
 		},
 		{
-			"id": "023df824-7912-45f7-954d-e8d5941c6c34",
+			"id": "fc845e50-429c-44e6-abf5-56a256a32257",
 			"key": "schema_order_format",
 			"value": "order_format.json",
 			"type": "string"
 		},
 		{
-			"id": "bc72308d-bde8-4b39-aa6d-5ce28d2bba04",
+			"id": "486aca6b-4f3c-43d6-baaf-4bb577f755c1",
 			"key": "schema_receipt_status",
 			"value": "receipt_status.json",
 			"type": "string"
 		},
 		{
-			"id": "470fc98a-8d92-44e4-92f3-a9984a138429",
+			"id": "5e7c5ba1-f8ba-4397-a7c3-006b16d78fb8",
 			"key": "storage_module",
 			"value": "mod-orders-storage",
 			"type": "string"
 		},
 		{
-			"id": "366e29bf-0b91-4ae8-83cc-f3ffb9dc301d",
+			"id": "301fea28-aebc-4308-a1f3-8c3d8a903bfe",
 			"key": "business_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "0ed1edd7-9c94-4c30-90b7-23d5434c0531",
+			"id": "dcb5cb4b-f683-4151-b458-86ade9bd7cd6",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "474c8714-5469-4e79-9443-d4dfaa403644",
+			"id": "cc32d61d-bd8f-4ab5-86ad-bedcbd1eed44",
 			"key": "schema_po_number",
 			"value": "po_number.json",
 			"type": "string"
 		},
 		{
-			"id": "3a04f91f-fdc2-41b2-aae9-0e368c1ec9b6",
+			"id": "90068f31-c201-443f-a229-869ab5b8e083",
 			"key": "raml_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/raml/raml1.0",
 			"type": "string"
 		},
 		{
-			"id": "93648307-7a1f-4c52-9db7-ce0eea589d30",
+			"id": "ce7309f6-aac5-4a37-8452-bde81da022f1",
 			"key": "poLines-limit",
 			"value": "10",
+			"type": "string"
+		},
+		{
+			"id": "8d40040d-c8d4-4ec1-ad55-7c8661069370",
+			"key": "orders_module",
+			"value": "mod-orders",
+			"type": "string"
+		},
+		{
+			"id": "33142d57-2ac3-460b-a153-8cbf81fb0922",
+			"key": "schema_product_id_type",
+			"value": "product_id_type.json",
+			"type": "string"
+		},
+		{
+			"id": "5ad91fec-2fd0-4368-9eaf-99658dcc880a",
+			"key": "common_folder",
+			"value": "common",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
## Purpose
Fix API tests after moving productIdType from details.json to separate file in common folder and moving schemas for composite purchase order and composite poLine to mod-orders folder due PR [folio-org/acq-models#99](https://github.com/folio-org/acq-models/pull/99)

## Approach
- Adding schema `product_id_type.json` to "Load schemas for validation" folder and update schemas loading script.
- updated requests paths for retrieving  composite_purchase_order.json and composite_po_line.json