### PR TITLE
EDGOAIPMH-28 - Upgrade to edge-common v2.0.0

### DIFF
--- a/edge-oai-pmh/edge-oai-pmh.postman_collection.json
+++ b/edge-oai-pmh/edge-oai-pmh.postman_collection.json
@@ -1381,7 +1381,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=Identify&apikey={{edge.apikey}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=Identify&apikey={{institutional.user.edge.apikey}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -1397,7 +1397,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										}
 									]
 								}
@@ -1489,7 +1489,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=Identify",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=Identify",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -1497,7 +1497,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -1593,7 +1593,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{edge.apikey}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{institutional.user.edge.apikey}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -1609,7 +1609,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										}
 									]
 								}
@@ -1675,7 +1675,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{institutional.user.edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -1691,7 +1691,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -1758,7 +1758,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=ListMetadataFormats",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=ListMetadataFormats",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -1766,7 +1766,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -1837,7 +1837,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=ListMetadataFormats&identifier={{identifierPrefix}}/{{identifier}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=ListMetadataFormats&identifier={{identifierPrefix}}/{{identifier}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -1845,7 +1845,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -1950,7 +1950,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListSets&apikey={{edge.apikey}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListSets&apikey={{institutional.user.edge.apikey}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -1966,7 +1966,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										}
 									]
 								}
@@ -2034,7 +2034,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=ListSets",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=ListSets",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2042,7 +2042,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -2129,7 +2129,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{dc}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{institutional.user.edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{dc}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2145,7 +2145,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -2229,7 +2229,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=GetRecord&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{dc}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=GetRecord&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{dc}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2237,7 +2237,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -2326,7 +2326,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{marc}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{institutional.user.edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{marc}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2342,7 +2342,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -2426,7 +2426,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=GetRecord&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{marc}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=GetRecord&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix={{marc}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2434,7 +2434,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -2533,7 +2533,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{edge.apikey}}&metadataPrefix={{marc}}&from={{from}}&set=all",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{marc}}&from={{from}}&set=all",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2549,7 +2549,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -2639,7 +2639,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=ListIdentifiers&metadataPrefix={{marc}}&from={{from}}&set=all",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=ListIdentifiers&metadataPrefix={{marc}}&from={{from}}&set=all",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2647,7 +2647,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -2749,7 +2749,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=ListIdentifiers&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=ListIdentifiers&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2757,7 +2757,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -2864,7 +2864,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?apikey={{edge.apikey}}&verb=ListIdentifiers&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?apikey={{institutional.user.edge.apikey}}&verb=ListIdentifiers&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2876,7 +2876,7 @@
 									"query": [
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "verb",
@@ -2980,7 +2980,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{edge.apikey}}&metadataPrefix={{dc}}&from={{from}}&set=all",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{dc}}&from={{from}}&set=all",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -2996,7 +2996,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -3085,7 +3085,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=ListRecords&metadataPrefix={{dc}}&from={{from}}&set=all",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=ListRecords&metadataPrefix={{dc}}&from={{from}}&set=all",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3093,7 +3093,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -3196,7 +3196,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{edge.apikey}}&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3212,7 +3212,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -3313,7 +3313,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{edge.apikey}}?verb=ListRecords&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai/{{institutional.user.edge.apikey}}?verb=ListRecords&metadataPrefix={{dc}}&set=all&from={{from}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3321,7 +3321,7 @@
 									"port": "{{edge.port}}",
 									"path": [
 										"oai",
-										"{{edge.apikey}}"
+										"{{institutional.user.edge.apikey}}"
 									],
 									"query": [
 										{
@@ -3416,7 +3416,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=Identify&apikey={{edge.apikey}}&metadataPrefix={{dc}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=Identify&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{dc}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3432,7 +3432,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -3515,7 +3515,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{edge.apikey}}&identifier=invalid-identifier",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{institutional.user.edge.apikey}}&identifier=invalid-identifier",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3531,7 +3531,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -3597,7 +3597,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}A",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListMetadataFormats&apikey={{institutional.user.edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}A",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3613,7 +3613,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -3708,7 +3708,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListSets&apikey={{edge.apikey}}&metadataPrefix=oai_dc",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListSets&apikey={{institutional.user.edge.apikey}}&metadataPrefix=oai_dc",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3724,7 +3724,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -3792,7 +3792,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListSets&apikey={{edge.apikey}}&resumptionToken=any_resumption_token",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListSets&apikey={{institutional.user.edge.apikey}}&resumptionToken=any_resumption_token",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3808,7 +3808,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "resumptionToken",
@@ -3872,7 +3872,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{edge.apikey}}&identifier=invalid-identifier&metadataPrefix={{marc}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{institutional.user.edge.apikey}}&identifier=invalid-identifier&metadataPrefix={{marc}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3888,7 +3888,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -3948,7 +3948,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}B&metadataPrefix={{dc}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{institutional.user.edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}B&metadataPrefix={{dc}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -3964,7 +3964,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -4024,7 +4024,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{institutional.user.edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4040,7 +4040,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -4099,7 +4099,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix=mark_xml",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=GetRecord&apikey={{institutional.user.edge.apikey}}&identifier={{identifierPrefix}}/{{identifier}}&metadataPrefix=mark_xml",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4115,7 +4115,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "identifier",
@@ -4202,7 +4202,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{edge.apikey}}&metadataPrefix={{marc}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{marc}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4218,7 +4218,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -4298,7 +4298,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{edge.apikey}}&metadataPrefix={{marc}}&from=2018-11-13T12:13:50",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{marc}}&from=2018-11-13T12:13:50",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4314,7 +4314,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -4376,7 +4376,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{edge.apikey}}&metadataPrefix=mark_xml",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{institutional.user.edge.apikey}}&metadataPrefix=mark_xml",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4392,7 +4392,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -4469,7 +4469,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{edge.apikey}}&resumptionToken=bWV0YWRhdGFQcmVmaXhhPW9haV9kYyZzZXQ9YWxsJnRvdGFsUmVjb3Jkcz0xMSZvZmZzZXQ9MiZuZXh0UmVjb3JkSWQ9NmI0YWUwODktZTFlZS00MzFmLWFmODMtZTExMzNmOGUzZGEwJnVudGlsPTIwMTgtMTEtMTRUMTQ6MzY6NTZa",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{institutional.user.edge.apikey}}&resumptionToken=bWV0YWRhdGFQcmVmaXhhPW9haV9kYyZzZXQ9YWxsJnRvdGFsUmVjb3Jkcz0xMSZvZmZzZXQ9MiZuZXh0UmVjb3JkSWQ9NmI0YWUwODktZTFlZS00MzFmLWFmODMtZTExMzNmOGUzZGEwJnVudGlsPTIwMTgtMTEtMTRUMTQ6MzY6NTZa",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4485,7 +4485,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "resumptionToken",
@@ -4564,7 +4564,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{edge.apikey}}&metadataPrefix={{marc}}&from={{from}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListIdentifiers&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{marc}}&from={{from}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4580,7 +4580,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -4671,7 +4671,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{edge.apikey}}&resumptionToken=bWV0YWRhdGFQcmVmaXhhPW9haV9kYyZzZXQ9YWxsJnRvdGFsUmVjb3Jkcz0xMSZvZmZzZXQ9MiZuZXh0UmVjb3JkSWQ9NmI0YWUwODktZTFlZS00MzFmLWFmODMtZTExMzNmOGUzZGEwJnVudGlsPTIwMTgtMTEtMTRUMTQ6MzY6NTZa",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{institutional.user.edge.apikey}}&resumptionToken=bWV0YWRhdGFQcmVmaXhhPW9haV9kYyZzZXQ9YWxsJnRvdGFsUmVjb3Jkcz0xMSZvZmZzZXQ9MiZuZXh0UmVjb3JkSWQ9NmI0YWUwODktZTFlZS00MzFmLWFmODMtZTExMzNmOGUzZGEwJnVudGlsPTIwMTgtMTEtMTRUMTQ6MzY6NTZa",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4687,7 +4687,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "resumptionToken",
@@ -4764,7 +4764,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{edge.apikey}}&metadataPrefix={{marc}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{marc}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4780,7 +4780,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -4860,7 +4860,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{edge.apikey}}&metadataPrefix={{marc}}&from=2018-11-13T12:13:50",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{marc}}&from=2018-11-13T12:13:50",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4876,7 +4876,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -4938,7 +4938,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{edge.apikey}}&metadataPrefix=mark_xml",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{institutional.user.edge.apikey}}&metadataPrefix=mark_xml",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -4954,7 +4954,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -5033,7 +5033,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{edge.apikey}}&metadataPrefix={{marc}}&from={{from}}&until={{until}}",
+									"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=ListRecords&apikey={{institutional.user.edge.apikey}}&metadataPrefix={{marc}}&from={{from}}&until={{until}}",
 									"protocol": "{{edge.protocol}}",
 									"host": [
 										"{{edge.host}}"
@@ -5049,7 +5049,7 @@
 										},
 										{
 											"key": "apikey",
-											"value": "{{edge.apikey}}"
+											"value": "{{institutional.user.edge.apikey}}"
 										},
 										{
 											"key": "metadataPrefix",
@@ -5079,7 +5079,7 @@
 							"script": {
 								"id": "930715a0-e0fd-4545-9cd3-9740f467a953",
 								"exec": [
-									"pm.variables.set(\"edge.badApiKey\", pm.environment.get(\"edge.apikey\").replace(\"=\", \"\") + \"wrong\");"
+									"pm.variables.set(\"edge.badApiKey\", pm.environment.get(\"institutional.user.edge.apikey\").replace(\"=\", \"\") + \"wrong\");"
 								],
 								"type": "text/javascript"
 							}
@@ -5147,7 +5147,7 @@
 							"script": {
 								"id": "930715a0-e0fd-4545-9cd3-9740f467a953",
 								"exec": [
-									"pm.variables.set(\"edge.badApiKey\", pm.environment.get(\"edge.apikey\").replace(\"=\", \"\") + \"wrong\");"
+									"pm.variables.set(\"edge.badApiKey\", pm.environment.get(\"institutional.user.edge.apikey\").replace(\"=\", \"\") + \"wrong\");"
 								],
 								"type": "text/javascript"
 							}
@@ -5390,7 +5390,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=badVerb&apikey={{edge.apikey}}",
+							"raw": "{{edge.protocol}}://{{edge.host}}:{{edge.port}}/oai?verb=badVerb&apikey={{institutional.user.edge.apikey}}",
 							"protocol": "{{edge.protocol}}",
 							"host": [
 								"{{edge.host}}"
@@ -5406,7 +5406,7 @@
 								},
 								{
 									"key": "apikey",
-									"value": "{{edge.apikey}}"
+									"value": "{{institutional.user.edge.apikey}}"
 								}
 							]
 						}
@@ -6309,7 +6309,7 @@
 					"                + pm.variables.get(\"edge.host\") + \":\" ",
 					"                + pm.variables.get(\"edge.port\") + \"/\"",
 					"                + path + \"?apikey=\"",
-					"                + pm.variables.get(\"edge.apikey\") + \"&resumptionToken=\"",
+					"                + pm.variables.get(\"institutional.user.edge.apikey\") + \"&resumptionToken=\"",
 					"                + resumptionToken + \"&verb=\"",
 					"                + verb,",
 					"            method: \"GET\",",
@@ -6390,6 +6390,12 @@
 			"id": "8c7a7995-b630-4f51-bd11-4fa71d5ca158",
 			"key": "repository.maxRecordsPerResponse",
 			"value": "10",
+			"type": "string"
+		},
+		{
+			"id": "5f484807-9279-473c-ba6e-76ce3fab6042",
+			"key": "institutional.user.edge.apikey",
+			"value": "eyJzIjoiYktMS0s2Mks3cCIsInQiOiJkaWt1IiwidSI6InVzZXIifQ==",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
Changing apikey as a result of migration to edge-common-2.0.0 and edge-oai-pmh updating