### PR TITLE
Updating mod-orders API tests after schema refactoring

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -550,6 +550,46 @@
 							"response": []
 						},
 						{
+							"name": "contributor.json",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
+										"exec": [
+											"pm.test(\"contributor.json GET OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.globals.set(\"schema_contributor_content\", responseBody);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/contributor.json",
+									"host": [
+										"{{schema_loc}}"
+									],
+									"path": [
+										"{{storage_module}}",
+										"schemas",
+										"contributor.json"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "cost.json",
 							"event": [
 								{
@@ -771,12 +811,12 @@
 									"script": {
 										"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
 										"exec": [
-											"pm.test(pm.variables.get(\"schema_fund_distribution\") + \" GET OK\", function () {",
+											"pm.test(pm.variables.get(\"schema_fundDistribution\") + \" GET OK\", function () {",
 											"    pm.response.to.be.ok;",
 											"    pm.response.to.be.withBody;",
 											"});",
 											"",
-											"pm.globals.set(\"schema_fund_distribution_content\", responseBody);"
+											"pm.globals.set(\"schema_fundDistribution_content\", responseBody);"
 										],
 										"type": "text/javascript"
 									}
@@ -790,17 +830,57 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_fund_distribution}}",
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_fundDistribution}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"{{storage_module}}",
 										"schemas",
-										"{{schema_fund_distribution}}"
+										"{{schema_fundDistribution}}"
 									]
 								},
 								"description": "GET schema validation"
+							},
+							"response": []
+						},
+						{
+							"name": "license.json",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
+										"exec": [
+											"pm.test(\"license.json GET OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.globals.set(\"schema_license_content\", responseBody);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/license.json",
+									"host": [
+										"{{schema_loc}}"
+									],
+									"path": [
+										"{{storage_module}}",
+										"schemas",
+										"license.json"
+									]
+								}
 							},
 							"response": []
 						},
@@ -1077,12 +1157,12 @@
 									"script": {
 										"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
 										"exec": [
-											"pm.test(pm.variables.get(\"schema_vendor_detail\") + \" GET OK\", function () {",
+											"pm.test(pm.variables.get(\"schema_vendorDetail\") + \" GET OK\", function () {",
 											"    pm.response.to.be.ok;",
 											"    pm.response.to.be.withBody;",
 											"});",
 											"",
-											"pm.globals.set(\"schema_vendor_detail_content\", responseBody);"
+											"pm.globals.set(\"schema_vendorDetail_content\", responseBody);"
 										],
 										"type": "text/javascript"
 									}
@@ -1096,14 +1176,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_vendor_detail}}",
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_vendorDetail}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"{{storage_module}}",
 										"schemas",
-										"{{schema_vendor_detail}}"
+										"{{schema_vendorDetail}}"
 									]
 								},
 								"description": "GET schema validation"
@@ -1157,12 +1237,12 @@
 									"script": {
 										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
 										"exec": [
-											"pm.test(pm.variables.get(\"schema_po_number\") + \" GET OK\", function () {",
+											"pm.test(pm.variables.get(\"schema_poNumber\") + \" GET OK\", function () {",
 											"    pm.response.to.be.ok;",
 											"    pm.response.to.be.withBody;",
 											"});",
 											"",
-											"pm.globals.set(\"schema_po_number_content\", responseBody);"
+											"pm.globals.set(\"schema_poNumber_content\", responseBody);"
 										],
 										"type": "text/javascript"
 									}
@@ -1176,14 +1256,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{business_module}}/schemas/{{schema_po_number}}",
+									"raw": "{{schema_loc}}/{{business_module}}/schemas/{{schema_poNumber}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"{{business_module}}",
 										"schemas",
-										"{{schema_po_number}}"
+										"{{schema_poNumber}}"
 									]
 								}
 							},
@@ -1197,12 +1277,12 @@
 									"script": {
 										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
 										"exec": [
-											"pm.test(pm.variables.get(\"schema_order_format\") + \" GET OK\", function () {",
+											"pm.test(pm.variables.get(\"schema_orderFormat\") + \" GET OK\", function () {",
 											"    pm.response.to.be.ok;",
 											"    pm.response.to.be.withBody;",
 											"});",
 											"",
-											"pm.globals.set(\"schema_order_format_content\", responseBody);"
+											"pm.globals.set(\"schema_orderFormat_content\", responseBody);"
 										],
 										"type": "text/javascript"
 									}
@@ -1216,14 +1296,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_order_format}}",
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_orderFormat}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"{{storage_module}}",
 										"schemas",
-										"{{schema_order_format}}"
+										"{{schema_orderFormat}}"
 									]
 								}
 							},
@@ -1237,12 +1317,12 @@
 									"script": {
 										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
 										"exec": [
-											"pm.test(pm.variables.get(\"schema_receipt_status\") + \" GET OK\", function () {",
+											"pm.test(pm.variables.get(\"schema_receiptStatus\") + \" GET OK\", function () {",
 											"    pm.response.to.be.ok;",
 											"    pm.response.to.be.withBody;",
 											"});",
 											"",
-											"pm.globals.set(\"schema_receipt_status_content\", responseBody);"
+											"pm.globals.set(\"schema_receiptStatus_content\", responseBody);"
 										],
 										"type": "text/javascript"
 									}
@@ -1256,14 +1336,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_receipt_status}}",
+									"raw": "{{schema_loc}}/{{storage_module}}/schemas/{{schema_receiptStatus}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"{{storage_module}}",
 										"schemas",
-										"{{schema_receipt_status}}"
+										"{{schema_receiptStatus}}"
 									]
 								}
 							},
@@ -1277,12 +1357,12 @@
 									"script": {
 										"id": "8a9792a3-7f93-41cd-8b8f-e00b68d10c0e",
 										"exec": [
-											"pm.test(pm.variables.get(\"schema_product_id_type\") + \" GET OK\", function () {",
+											"pm.test(pm.variables.get(\"schema_productIdType\") + \" GET OK\", function () {",
 											"    pm.response.to.be.ok;",
 											"    pm.response.to.be.withBody;",
 											"});",
 											"",
-											"pm.globals.set(\"schema_product_id_type_content\", responseBody);"
+											"pm.globals.set(\"schema_productIdType_content\", responseBody);"
 										],
 										"type": "text/javascript"
 									}
@@ -1296,14 +1376,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{schema_loc}}/{{common_folder}}/schemas/{{schema_product_id_type}}",
+									"raw": "{{schema_loc}}/{{common_folder}}/schemas/{{schema_productIdType}}",
 									"host": [
 										"{{schema_loc}}"
 									],
 									"path": [
 										"{{common_folder}}",
 										"schemas",
-										"{{schema_product_id_type}}"
+										"{{schema_productIdType}}"
 									]
 								}
 							},
@@ -1333,6 +1413,86 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Prepare vendors",
+					"item": [
+						{
+							"name": "Get active vendor",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let configs = [];",
+											"pm.test(\"Storing active vendor\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"",
+											"    let vendors = pm.response.json().vendors;",
+											"    pm.expect(vendors).to.have.lengthOf(1);",
+											"",
+											"    pm.environment.set(\"activeVendorId\", vendors[0].id);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/vendor-storage/vendors?query=vendor_status==Active&limit=1",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"vendor-storage",
+										"vendors"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "vendor_status==Active"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			]
 		},
@@ -1351,7 +1511,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"pm.variables.set(\"order_body\", JSON.stringify(utils.buildOrderWithMinContent()));"
+											"pm.variables.set(\"orderBody\", JSON.stringify(utils.buildOrderWithMinContent()));"
 										],
 										"type": "text/javascript"
 									}
@@ -1373,15 +1533,15 @@
 											"    ",
 											"    pm.test(\"Each order has required fields\", function(){",
 											"        pm.expect(jsonData.id).to.exist;",
-											"        pm.globals.set(\"empty_order_id\", jsonData.id); ",
+											"        pm.globals.set(\"emptyOrderId\", jsonData.id); ",
 											"        pm.expect(jsonData.notes).to.exist;",
-											"        pm.expect(jsonData.po_number).to.exist;",
+											"        pm.expect(jsonData.poNumber).to.exist;",
 											"        pm.expect(jsonData.compositePoLines).to.exist;",
 											"        pm.expect(jsonData.compositePoLines).to.be.empty;",
 											"    });",
 											"    ",
 											"    pm.test(\"MODORDERS-145: Verify status to be Pending\", function(){",
-											"        pm.expect(jsonData.workflow_status).to.equal(\"Pending\");",
+											"        pm.expect(jsonData.workflowStatus).to.equal(\"Pending\");",
 											"    });",
 											"});"
 										],
@@ -1407,7 +1567,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{{order_body}}"
+									"raw": "{{orderBody}}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -1426,7 +1586,7 @@
 							"response": []
 						},
 						{
-							"name": "Update order with new po_number",
+							"name": "Update order with new poNumber",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -1435,13 +1595,13 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"// Get Order and update po_number only (MODORDERS-150)",
-											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.empty_order_id, (err, res) => {",
+											"// Get Order and update poNumber only (MODORDERS-150)",
+											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.emptyOrderId, (err, res) => {",
 											"    let order  = res.json();",
-											"    let number = \"UPD\" + order.po_number;",
-											"    order.po_number = number;",
-											"    pm.variables.set(\"updated_number\", number);",
-											"    pm.variables.set(\"updated_order\", JSON.stringify(order));",
+											"    let number = \"UPD\" + order.poNumber;",
+											"    order.poNumber = number;",
+											"    pm.variables.set(\"updatedNumber\", number);",
+											"    pm.variables.set(\"updatedOrder\", JSON.stringify(order));",
 											"});"
 										],
 										"type": "text/javascript"
@@ -1457,10 +1617,10 @@
 											"    pm.response.to.have.status(\"No Content\");",
 											"",
 											"    // The test can be run only if update succeded",
-											"    utils.sendGetRequest(\"/orders/composite-orders/\" + globals.empty_order_id, (err, res) => {",
+											"    utils.sendGetRequest(\"/orders/composite-orders/\" + globals.emptyOrderId, (err, res) => {",
 											"        pm.test(\"Verify order updated with new PO number\", function () {",
 											"            let order  = res.json();",
-											"            pm.expect(order.po_number).to.equal(pm.variables.get(\"updated_number\"));",
+											"            pm.expect(order.poNumber).to.equal(pm.variables.get(\"updatedNumber\"));",
 											"        });",
 											"    });",
 											"});   ",
@@ -1494,10 +1654,10 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{{updated_order}}"
+									"raw": "{{updatedOrder}}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{empty_order_id}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{emptyOrderId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -1506,7 +1666,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{empty_order_id}}"
+										"{{emptyOrderId}}"
 									]
 								},
 								"description": "Verify [MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) - the order can be updated if created without workflow status"
@@ -1560,7 +1720,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{empty_order_id}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{emptyOrderId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -1569,7 +1729,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{empty_order_id}}"
+										"{{emptyOrderId}}"
 									]
 								},
 								"description": "GET /orders/composite-orders/id requests that return 200"
@@ -1620,7 +1780,7 @@
 													"",
 													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
 													"    let order  = res.json();",
-													"    order.workflow_status = \"Pending\";",
+													"    order.workflowStatus = \"Pending\";",
 													"    order = utils.deletePoNumber(order);",
 													"    // Set retrieved content for further requests",
 													"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(utils.prepareOrder(order)));",
@@ -1641,18 +1801,18 @@
 													"    pm.response.to.have.status(201);",
 													"});",
 													"",
-													"pm.test(\"po_lines exist\", function () {",
+													"pm.test(\"PO Lines exist\", function () {",
 													"    utils.validatePoLines(jsonData, 2);",
 													"});",
 													"",
 													"pm.test(\"Each order has these optional fields\", function() {",
 													"    pm.expect(jsonData.id).to.exist;",
-													"    pm.globals.set(\"complete_order_id\", jsonData.id); ",
+													"    pm.globals.set(\"completeOrderId\", jsonData.id); ",
 													"    pm.expect(jsonData.approved).to.exist;",
-													"    pm.expect(jsonData.po_number).to.exist;",
-													"    pm.globals.set(\"complete_order_po_number\",\"\\\"\"+jsonData.po_number+\"\\\"\");",
+													"    pm.expect(jsonData.poNumber).to.exist;",
+													"    pm.globals.set(\"completeOrderPoNumber\",\"\\\"\"+jsonData.poNumber+\"\\\"\");",
 													"    pm.expect(jsonData.notes).to.exist;",
-													"    pm.expect(jsonData.total_items).to.exist;",
+													"    pm.expect(jsonData.totalItems).to.exist;",
 													"    pm.expect(jsonData.vendor).to.exist;",
 													"});",
 													""
@@ -1729,11 +1889,11 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema for composite_purchase_order.json\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validateOrderAgainstSchema(jsonData);",
 													"});",
 													"",
-													"pm.test(\"po_lines exist\", function () {",
+													"pm.test(\"PO Lines exist\", function () {",
 													"    utils.validatePoLines(jsonData, 2);",
 													"});"
 												],
@@ -1762,7 +1922,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -1771,7 +1931,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200"
@@ -1796,10 +1956,10 @@
 													"",
 													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json\", function (err, res) {",
 													"    var poline = utils.preparePoLine(res.json());",
-													"    poline.purchase_order_id = pm.globals.get(\"complete_order_id\");",
+													"    poline.purchaseOrderId = pm.globals.get(\"completeOrderId\");",
 													"    pm.variables.set(\"po_line_updated_content\", JSON.stringify(poline));",
 													"});",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());"
 												],
 												"type": "text/javascript"
 											}
@@ -1837,7 +1997,7 @@
 											"raw": "{{po_line_updated_content}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -1846,7 +2006,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "Verifies that second line can be sussessfully updated"
@@ -1862,7 +2022,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());"
 												],
 												"type": "text/javascript"
 											}
@@ -1879,9 +2039,9 @@
 													"    pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"po_line has content\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poline_id\"));",
-													"    pm.expect(jsonData.purchase_order_id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"pm.test(\"PO Line has content\", function () {",
+													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poLineId\"));",
+													"    pm.expect(jsonData.purchaseOrderId).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validatePoLineSubObjetcsPresence(jsonData);",
 													"});",
 													"",
@@ -1914,7 +2074,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -1923,7 +2083,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "GET /orders/order-lines/id requests that return 200"
@@ -1939,7 +2099,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId(true));"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));"
 												],
 												"type": "text/javascript"
 											}
@@ -1979,7 +2139,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -1988,7 +2148,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "GET /orders/order-lines/id requests that return 200"
@@ -2020,7 +2180,7 @@
 													"    pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"1 po_line exist\", function () {",
+													"pm.test(\"1 PO Line exist\", function () {",
 													"    utils.validatePoLines(jsonData, 1);",
 													"});"
 												],
@@ -2049,7 +2209,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2058,7 +2218,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200 and verifies that only one line exists"
@@ -2080,9 +2240,9 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"var poline = utils.buildPoLineWithMinContent(globals.complete_order_id);",
+													"var poline = utils.buildPoLineWithMinContent(globals.completeOrderId);",
 													"",
-													"pm.globals.set(\"new_empty_po_line\", JSON.stringify(poline));",
+													"pm.globals.set(\"newEmptyPoLine\", JSON.stringify(poline));",
 													"",
 													""
 												],
@@ -2105,7 +2265,7 @@
 													"",
 													"pm.test(\"Order line has required and optional fields\", function(){",
 													"    pm.expect(jsonData.id).to.exist;",
-													"    pm.expect(jsonData.purchase_order_id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"    pm.expect(jsonData.purchaseOrderId).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validatePoLineWithMinimalContent(jsonData);",
 													"});",
 													""
@@ -2132,7 +2292,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{{new_empty_po_line}}"
+											"raw": "{{newEmptyPoLine}}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
@@ -2159,7 +2319,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());"
 												],
 												"type": "text/javascript"
 											}
@@ -2176,9 +2336,9 @@
 													"    pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"po_line has minimal content\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poline_id\"));",
-													"    pm.expect(jsonData.purchase_order_id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"pm.test(\"PO Line has minimal content\", function () {",
+													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poLineId\"));",
+													"    pm.expect(jsonData.purchaseOrderId).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validatePoLineWithMinimalContent(jsonData);",
 													"});",
 													"",
@@ -2211,7 +2371,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2220,7 +2380,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "GET /orders/order-lines/id requests that return 200"
@@ -2239,10 +2399,10 @@
 													"",
 													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json\", function (err, res) {",
 													"    var poline = utils.preparePoLine(res.json());",
-													"    poline.purchase_order_id = pm.globals.get(\"complete_order_id\");",
+													"    poline.purchaseOrderId = pm.globals.get(\"completeOrderId\");",
 													"    pm.variables.set(\"po_line_updated_content\", JSON.stringify(poline));",
 													"});",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());"
 												],
 												"type": "text/javascript"
 											}
@@ -2280,7 +2440,7 @@
 											"raw": "{{po_line_updated_content}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2289,7 +2449,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "Validates that empty line can be updated with complex content"
@@ -2329,7 +2489,7 @@
 													"    utils.validateOrderAgainstSchema(jsonData);",
 													"});",
 													"",
-													"pm.test(\"2 po_lines exist\", function () {",
+													"pm.test(\"2 PO Lines exist\", function () {",
 													"    utils.validatePoLines(jsonData, 2, false);",
 													"});"
 												],
@@ -2358,7 +2518,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2367,7 +2527,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "`GET /orders/composite-orders/<id>` request and validate content"
@@ -2383,7 +2543,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId(true));"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));"
 												],
 												"type": "text/javascript"
 											}
@@ -2423,7 +2583,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2432,7 +2592,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "GET /orders/order-lines/id requests that return 204"
@@ -2456,9 +2616,9 @@
 													"let line = JSON.parse(pm.globals.get(\"po_listed_print_monograph\")).compositePoLines[0];",
 													"// make sure there is no id provided",
 													"delete line.id;",
-													"line.po_line_number += \"1\";",
-													"line.po_line_description += \" another PO Line\";",
-													"line.purchase_order_id = pm.globals.get(\"complete_order_id\");",
+													"line.poLineNumber += \"1\";",
+													"line.poLineDescription += \" another PO Line\";",
+													"line.purchaseOrderId = pm.globals.get(\"completeOrderId\");",
 													"pm.variables.set(\"po_line_listed_print_monograph\", JSON.stringify(line));"
 												],
 												"type": "text/javascript"
@@ -2480,7 +2640,7 @@
 													"",
 													"pm.test(\"Order line has required and optional fields\", function(){",
 													"    pm.expect(jsonData.id).to.exist;",
-													"    pm.expect(jsonData.purchase_order_id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"    pm.expect(jsonData.purchaseOrderId).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validatePoLineSubObjetcsPresence(jsonData);",
 													"});",
 													""
@@ -2534,7 +2694,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());"
 												],
 												"type": "text/javascript"
 											}
@@ -2551,9 +2711,9 @@
 													"    pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"po_line has content\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poline_id\"));",
-													"    pm.expect(jsonData.purchase_order_id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"pm.test(\"PO Line has content\", function () {",
+													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poLineId\"));",
+													"    pm.expect(jsonData.purchaseOrderId).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validatePoLineSubObjetcsPresence(jsonData);",
 													"});",
 													"",
@@ -2586,7 +2746,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2595,7 +2755,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "GET /orders/id requests that return 200"
@@ -2635,7 +2795,7 @@
 													"    utils.validateOrderAgainstSchema(jsonData);",
 													"});",
 													"",
-													"pm.test(\"2 po_lines exist\", function () {",
+													"pm.test(\"2 PO Lines exist\", function () {",
 													"    utils.validatePoLines(jsonData, 2);",
 													"});"
 												],
@@ -2664,7 +2824,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2673,7 +2833,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200"
@@ -2689,10 +2849,10 @@
 												"id": "570809ac-8aba-4c7c-b384-8ee934d027c0",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"var poline = utils.buildPoLineWithMinContent(globals.complete_order_id);",
+													"var poline = utils.buildPoLineWithMinContent(globals.completeOrderId);",
 													"",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());",
-													"pm.variables.set(\"new_empty_po_line\", JSON.stringify(poline));",
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());",
+													"pm.variables.set(\"newEmptyPoLine\", JSON.stringify(poline));",
 													"",
 													""
 												],
@@ -2729,10 +2889,10 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{{new_empty_po_line}}"
+											"raw": "{{newEmptyPoLine}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2741,7 +2901,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										}
 									},
@@ -2756,7 +2916,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());"
 												],
 												"type": "text/javascript"
 											}
@@ -2773,9 +2933,9 @@
 													"    pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"po_line has minimal content\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poline_id\"));",
-													"    pm.expect(jsonData.purchase_order_id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"pm.test(\"PO Line has minimal content\", function () {",
+													"    pm.expect(jsonData.id).to.equal(pm.variables.get(\"poLineId\"));",
+													"    pm.expect(jsonData.purchaseOrderId).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validatePoLineWithMinimalContent(jsonData);",
 													"});",
 													"",
@@ -2808,7 +2968,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2817,7 +2977,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "GET /orders/id requests that return 200"
@@ -2865,7 +3025,7 @@
 													"",
 													"// Using id of the last PO Line",
 													"let poLineId = utils.getLastPoLineId();",
-													"pm.variables.set(\"poline_id\", poLineId);",
+													"pm.variables.set(\"poLineId\", poLineId);",
 													"utils.sendGetRequest(\"/orders/order-lines/\" + poLineId, (err, res) => {",
 													"    // Get physical object",
 													"    let physical = JSON.parse(pm.globals.get(\"po_listed_print_monograph\")).compositePoLines[0].physical;",
@@ -2898,7 +3058,7 @@
 													"});   ",
 													"",
 													"// Get updated PO Line",
-													"utils.sendGetRequest(\"/orders/order-lines/\" + pm.variables.get(\"poline_id\"), function (err, res) {",
+													"utils.sendGetRequest(\"/orders/order-lines/\" + pm.variables.get(\"poLineId\"), function (err, res) {",
 													"    pm.test(\"PO Line updated with expected receipt date\", function () {",
 													"        let poLine  = res.json();",
 													"        // Dates should be in the same format",
@@ -2933,7 +3093,7 @@
 											"raw": "{{updated_po_line}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -2942,7 +3102,7 @@
 											"path": [
 												"orders",
 												"order-lines",
-												"{{poline_id}}"
+												"{{poLineId}}"
 											]
 										},
 										"description": "Gets content of last PO Line and updates it adding expected receipt date"
@@ -2950,7 +3110,7 @@
 									"response": []
 								}
 							],
-							"description": "[MODORDERS-135](https://issues.folio.org/browse/MODORDERS-135)\n\nAdd an `expected_receipt_date` field to the physical sub-object.",
+							"description": "[MODORDERS-135](https://issues.folio.org/browse/MODORDERS-135)\n\nAdd an `expectedReceiptDate` field to the physical sub-object.",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -2987,7 +3147,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poline_id\", utils.getLastPoLineId());"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());"
 												],
 												"type": "text/javascript"
 											}
@@ -3051,10 +3211,10 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assigned_to\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"order_type\": \"One-Time\",\n  \"po_number\": \"268758test2\",\n  \"re_encumber\": false,\n  \"total_estimated_price\": 100.99,\n  \"total_items\": 2,\n  \"vendor\": \"168f8a86-d26c-406e-813f-c7527f241ac3\",\n  \"workflow_status\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poline_id}}\",\n      \"acquisition_method\": \"Purchase At Vendor System\",\n      \"adjustment\": {\n            \"credit\": 0,\n            \"discount\": 0,\n            \"insurance\": 0,\n            \"invoice_id\": \"2d6d495c-c237-476f-aa48-57f7cbf74ca4\",\n            \"overhead\": 0,\n            \"shipment\": 0,\n            \"tax_1\": 0,\n            \"tax_2\": 0,\n            \"use_pro_rate\": false\n        },\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellation_restriction\": false,\n      \"cancellation_restriction_note\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributor_type\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"list_price\": 24.99,\n        \"currency\": \"USD\",\n        \"quantity_physical\": 2,\n        \"po_line_estimated_price\": 49.98\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receiving_note\": \"ABCDEFGHIJKL\",\n        \"product_ids\": [\n          {\n            \"product_id\": \"9780764354113\",\n            \"product_id_type\": \"ISBN\"\n          }\n        ],\n        \"material_types\": [\n          \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n        ],\n        \"subscription_from\": \"2018-10-09T00:00:00.000Z\",\n        \"subscription_interval\": 824,\n        \"subscription_to\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fund_distribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"location_id\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantity_electronic\": 0,\n        \"quantity_physical\": 2\n      }],\n      \"order_format\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"payment_status\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"material_supplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receipt_due\": \"2018-10-10T00:00:00.000Z\"\n      },\n      \"po_line_description\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"po_line_number\": \"268758-03\",\n      \"publication_date\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receipt_date\": \"2018-10-09T00:00:00.000Z\",\n      \"receipt_status\": \"Awaiting Receipt\", \n      \"reporting_codes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendor_detail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"note_from_vendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"ref_number\": \"123456-78\",\n        \"ref_number_type\": \"Supplier's unique order line reference number\",\n        \"vendor_account\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": \"268758test2\",\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"totalItems\": 2,\n  \"vendor\": \"168f8a86-d26c-406e-813f-c7527f241ac3\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poLineId}}\",\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"adjustment\": {\n            \"credit\": 0,\n            \"discount\": 0,\n            \"insurance\": 0,\n            \"invoiceId\": \"2d6d495c-c237-476f-aa48-57f7cbf74ca4\",\n            \"overhead\": 0,\n            \"shipment\": 0,\n            \"tax1\": 0,\n            \"tax2\": 0,\n            \"useProRate\": false\n        },\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listPrice\": 24.99,\n        \"currency\": \"USD\",\n        \"quantityPhysical\": 2,\n        \"poLineEstimatedPrice\": 49.98\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"ISBN\"\n          }\n        ],\n        \"materialTypes\": [\n          \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityElectronic\": 0,\n        \"quantityPhysical\": 2\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3063,7 +3223,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "PUT /orders/composite-orders/id requests that return 204\nReplaces content leaving only one line."
@@ -3095,11 +3255,11 @@
 													"    pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"1 po_line exist\", function () {",
+													"pm.test(\"1 PO Line exist\", function () {",
 													"    utils.validatePoLines(jsonData, 1);",
 													"});",
 													"",
-													"pm.test(\"Validate po_line_number\", function() {",
+													"pm.test(\"Validate poLineNumber\", function() {",
 													"    utils.validatePoLinesNumber(jsonData);",
 													"});"
 												],
@@ -3128,7 +3288,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3137,7 +3297,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200"
@@ -3163,8 +3323,8 @@
 													"pm.environment.set(\"adjustment_insurance_update\", 1.0);",
 													"pm.environment.set(\"adjustment_overhead_update\",1.0);",
 													"pm.environment.set(\"adjustment_shipment_update\",1.0);",
-													"pm.environment.set(\"adjustment_tax_1_update\",10.0);",
-													"pm.environment.set(\"adjustment_tax_2_update\",10.0);",
+													"pm.environment.set(\"adjustment_tax1_update\",10.0);",
+													"pm.environment.set(\"adjustment_tax2_update\",10.0);",
 													"pm.environment.set(\"adjustment_update_pro_rate\", true);"
 												],
 												"type": "text/javascript"
@@ -3229,10 +3389,10 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assigned_to\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"order_type\": \"One-Time\",\n  \"po_number\": {{complete_order_po_number}},\n  \"re_encumber\": false,\n  \"total_estimated_price\": 100.99,\n  \"total_items\": 1,\n  \"vendor\": \"168f8a86-d26c-406e-813f-c7527f241ac3\",\n  \"workflow_status\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisition_method\": \"Purchase At Vendor System\",\n      \"adjustment\": {\n        \"credit\": {{adjustment_credit_update}},\n        \"discount\": {{adjustment_discount_update}},\n        \"insurance\": {{adjustment_insurance_update}},\n        \"invoice_id\": \"2d6d495c-c237-476f-aa48-57f7cbf74ca4\",\n        \"overhead\": {{adjustment_overhead_update}},\n        \"shipment\": {{adjustment_shipment_update}},\n        \"tax_1\": {{adjustment_tax_1_update}},\n        \"tax_2\": {{adjustment_tax_2_update}},\n        \"use_pro_rate\": {{adjustment_update_pro_rate}}\n      },\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellation_restriction\": false,\n      \"cancellation_restriction_note\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributor_type\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"list_price\": 24.99,\n        \"currency\": \"USD\",\n        \"quantity_physical\": 1,\n        \"po_line_estimated_price\": 24.99\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receiving_note\": \"ABCDEFGHIJKL\",\n        \"product_ids\": [\n          {\n            \"product_id\": \"9780764354113\",\n            \"product_id_type\": \"ISBN\"\n          }\n        ],\n        \"material_types\": [\n          \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n        ],\n        \"subscription_from\": \"2018-10-09T00:00:00.000Z\",\n        \"subscription_interval\": 824,\n        \"subscription_to\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fund_distribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"location_id\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantity_physical\": 1\n      }],\n      \"order_format\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"payment_status\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"material_supplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receipt_due\": \"2018-10-10T00:00:00.000Z\"\n      },\n      \"po_line_description\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"po_line_number\": \"268758-03\",\n      \"publication_date\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receipt_date\": \"2018-10-09T00:00:00.000Z\",\n      \"receipt_status\": \"Awaiting Receipt\", \n      \"reporting_codes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendor_detail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"note_from_vendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"ref_number\": \"123456-78\",\n        \"ref_number_type\": \"Supplier's unique order line reference number\",\n        \"vendor_account\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": {{completeOrderPoNumber}},\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"totalItems\": 1,\n  \"vendor\": \"168f8a86-d26c-406e-813f-c7527f241ac3\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"adjustment\": {\n        \"credit\": {{adjustment_credit_update}},\n        \"discount\": {{adjustment_discount_update}},\n        \"insurance\": {{adjustment_insurance_update}},\n        \"invoiceId\": \"2d6d495c-c237-476f-aa48-57f7cbf74ca4\",\n        \"overhead\": {{adjustment_overhead_update}},\n        \"shipment\": {{adjustment_shipment_update}},\n        \"tax1\": {{adjustment_tax1_update}},\n        \"tax2\": {{adjustment_tax2_update}},\n        \"useProRate\": {{adjustment_update_pro_rate}}\n      },\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listPrice\": 24.99,\n        \"currency\": \"USD\",\n        \"quantityPhysical\": 1,\n        \"poLineEstimatedPrice\": 24.99\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"ISBN\"\n          }\n        ],\n        \"materialTypes\": [\n          \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityPhysical\": 1\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3241,7 +3401,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "PUT /orders/composite-orders/id requests that return 204"
@@ -3279,17 +3439,17 @@
 													"    pm.response.to.have.jsonBody(\"adjustment.insurance\", pm.environment.get(\"adjustment_insurance_update\"));",
 													"    pm.response.to.have.jsonBody(\"adjustment.overhead\", pm.environment.get(\"adjustment_overhead_update\"));",
 													"    pm.response.to.have.jsonBody(\"adjustment.shipment\", pm.environment.get(\"adjustment_shipment_update\"));",
-													"    pm.response.to.have.jsonBody(\"adjustment.tax_1\", pm.environment.get(\"adjustment_tax_1_update\"));",
-													"    pm.response.to.have.jsonBody(\"adjustment.tax_2\", pm.environment.get(\"adjustment_tax_2_update\"));",
-													"    pm.response.to.have.jsonBody(\"adjustment.use_pro_rate\", pm.environment.get(\"adjustment_update_pro_rate\"));",
+													"    pm.response.to.have.jsonBody(\"adjustment.tax1\", pm.environment.get(\"adjustment_tax1_update\"));",
+													"    pm.response.to.have.jsonBody(\"adjustment.tax2\", pm.environment.get(\"adjustment_tax2_update\"));",
+													"    pm.response.to.have.jsonBody(\"adjustment.useProRate\", pm.environment.get(\"adjustment_update_pro_rate\"));",
 													"}); ",
 													"",
 													"pm.test(\"Validate schema for composite_purchase_order.json\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validateOrderAgainstSchema(jsonData);",
 													"});",
 													"",
-													"pm.test(\"po_lines exist\", function () {",
+													"pm.test(\"PO Lines exist\", function () {",
 													"    utils.validatePoLines(jsonData, 1);",
 													"});",
 													""
@@ -3319,7 +3479,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3328,7 +3488,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200"
@@ -3364,7 +3524,7 @@
 							"name": "Update PO number",
 							"item": [
 								{
-									"name": "Update order with new po_number",
+									"name": "Update order with new poNumber",
 									"event": [
 										{
 											"listen": "prerequest",
@@ -3373,14 +3533,14 @@
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
 													"",
-													"// Get Order and update po_number only",
-													"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.complete_order_id, (err, res) => {",
+													"// Get Order and update poNumber only",
+													"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.completeOrderId, (err, res) => {",
 													"    let order  = res.json();",
-													"    order.po_number = \"newponumber\";",
-													"    pm.variables.set(\"updated_order\", JSON.stringify(order));",
+													"    order.poNumber = \"newponumber\";",
+													"    pm.variables.set(\"updatedOrder\", JSON.stringify(order));",
 													"});",
 													"",
-													"pm.globals.set(\"po_number\", \"newponumber\");"
+													"pm.globals.set(\"poNumber\", \"newponumber\");"
 												],
 												"type": "text/javascript"
 											}
@@ -3442,10 +3602,10 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{{updated_order}}"
+											"raw": "{{updatedOrder}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3454,7 +3614,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "PUT /orders/composite-orders/id requests that return 204"
@@ -3462,7 +3622,7 @@
 									"response": []
 								},
 								{
-									"name": "Get updated order and validate po_number",
+									"name": "Get updated order and validate poNumber",
 									"event": [
 										{
 											"listen": "prerequest",
@@ -3487,12 +3647,12 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema for composite_purchase_order.json\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validateOrderAgainstSchema(jsonData);",
 													"});",
 													"",
-													"pm.test(\"Validate po_number\", function() {",
-													"    pm.expect(jsonData.po_number).to.equal(pm.globals.get(\"po_number\"));",
+													"pm.test(\"Validate poNumber\", function() {",
+													"    pm.expect(jsonData.poNumber).to.equal(pm.globals.get(\"poNumber\"));",
 													"    utils.validatePoLinesNumber(jsonData);",
 													"});"
 												],
@@ -3521,7 +3681,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3530,7 +3690,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200"
@@ -3606,10 +3766,10 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"approved\": false,\n    \"assigned_to\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"po_number\": \"{{po_number}}\",\n    \"order_type\": \"Ongoing\",\n    \"re_encumber\": false,\n    \"total_estimated_price\": 99.99,\n    \"total_items\": 2,\n    \"vendor\": \"168f8a86-d26c-406e-813f-c7527f241ac3\",\n    \"workflow_status\": \"Pending\"\n}"
+											"raw": "{\n    \"approved\": false,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"{{poNumber}}\",\n    \"orderType\": \"Ongoing\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 99.99,\n    \"totalItems\": 2,\n    \"vendor\": \"168f8a86-d26c-406e-813f-c7527f241ac3\",\n    \"workflowStatus\": \"Pending\"\n}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3618,7 +3778,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "PUT /orders/composite-orders/id requests that return 204"
@@ -3651,7 +3811,7 @@
 													"});",
 													"",
 													"pm.test(\"Validate schema for composite_purchase_order.json\", function () {",
-													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"complete_order_id\"));",
+													"    pm.expect(jsonData.id).to.equal(pm.globals.get(\"completeOrderId\"));",
 													"    utils.validateOrderAgainstSchema(jsonData);",
 													"});",
 													"",
@@ -3659,7 +3819,7 @@
 													"    utils.validatePoLines(jsonData, 1);",
 													"});",
 													"",
-													"pm.test(\"Validate po_line_number\", function() {",
+													"pm.test(\"Validate poLineNumber\", function() {",
 													"    utils.validatePoLinesNumber(jsonData);",
 													"});"
 												],
@@ -3688,7 +3848,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3697,7 +3857,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200"
@@ -3773,10 +3933,10 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"po_number\": \"{{po_number}}\"\n}"
+											"raw": "{\n\t\"poNumber\": \"{{poNumber}}\"\n}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3785,7 +3945,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "PUT /orders/composite-orders/id requests that return 204"
@@ -3847,7 +4007,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -3856,7 +4016,7 @@
 											"path": [
 												"orders",
 												"composite-orders",
-												"{{complete_order_id}}"
+												"{{completeOrderId}}"
 											]
 										},
 										"description": "GET /orders/composite-orders/id requests that return 200"
@@ -3906,10 +4066,10 @@
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
 											"    let order  = res.json();",
-											"    order.workflow_status = \"Pending\";",
+											"    order.workflowStatus = \"Pending\";",
 											"    // Setting create inventory to false for PO Line with P/E Mix format",
-											"    order.compositePoLines[0].eresource.create_inventory = false;",
-											"    order = utils.deletePoNumber(order);",
+											"    order.compositePoLines[0].eresource.createInventory = false;",
+											"    order.poNumber = \"1MIX1EL1PHYS1OTH\";",
 											"",
 											"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(utils.prepareOrder(order)));",
 											"});"
@@ -3929,18 +4089,18 @@
 											"    pm.response.to.have.status(201);",
 											"});",
 											"",
-											"pm.test(\"po_lines exist\", function () {",
+											"pm.test(\"PO Lines exist\", function () {",
 											"    utils.validatePoLines(jsonData, 2);",
 											"});",
 											"",
 											"pm.test(\"Each order has these optional fields\", function() {",
 											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.globals.set(\"another_complete_order_id\", jsonData.id);",
+											"    pm.globals.set(\"anotherCompleteOrderId\", jsonData.id);",
 											"    pm.globals.set(\"another_complete_order_content\", jsonData);",
 											"    pm.expect(jsonData.approved).to.exist;",
-											"    pm.expect(jsonData.po_number).to.exist;",
+											"    pm.expect(jsonData.poNumber).to.exist;",
 											"    pm.expect(jsonData.notes).to.exist;",
-											"    pm.expect(jsonData.total_items).to.exist;",
+											"    pm.expect(jsonData.totalItems).to.exist;",
 											"    pm.expect(jsonData.vendor).to.exist;",
 											"});",
 											""
@@ -4003,30 +4163,30 @@
 											"",
 											"    let order  = utils.prepareOrder(res.json());",
 											"    // Few more cases for MODORDERS-117",
-											"    order.compositePoLines[0].order_format = \"Physical Resource\";",
+											"    order.compositePoLines[0].orderFormat = \"Physical Resource\";",
 											"    setPhysicalQuantity(order.compositePoLines[0]);",
-											"    order.compositePoLines[1].order_format = \"Other\";",
+											"    order.compositePoLines[1].orderFormat = \"Other\";",
 											"    setPhysicalQuantity(order.compositePoLines[1]);",
 											"",
 											"    // add 2 new PO lines",
 											"    pendingOrder.compositePoLines = pendingOrder.compositePoLines.concat(order.compositePoLines);",
 											"    // Set Open status",
-											"    pendingOrder.workflow_status = \"Open\";",
+											"    pendingOrder.workflowStatus = \"Open\";",
 											"",
 											"    pm.variables.set(\"request_body\", JSON.stringify(pendingOrder));",
 											"    pm.globals.unset(\"another_complete_order_content\");",
 											"});",
 											"",
 											"function setPhysicalQuantity(line) {",
-											"    delete line.cost.quantity_electronic;",
+											"    delete line.cost.quantityElectronic;",
 											"    var total = 0;",
 											"    for(var i = 0; i < line.locations.length; i++) {",
 											"        var location = line.locations[i];",
-											"        delete location.quantity_electronic;",
-											"        location.quantity_physical = i + 1;",
-											"        total += location.quantity_physical;",
+											"        delete location.quantityElectronic;",
+											"        location.quantityPhysical = i + 1;",
+											"        total += location.quantityPhysical;",
 											"    }",
-											"    line.cost.quantity_physical = total;",
+											"    line.cost.quantityPhysical = total;",
 											"}"
 										],
 										"type": "text/javascript"
@@ -4044,7 +4204,7 @@
 											"    pm.response.to.have.status(\"No Content\");",
 											"});   ",
 											"",
-											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.another_complete_order_id, function (err, res) {",
+											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.anotherCompleteOrderId, function (err, res) {",
 											"    pm.test(\"Verify PO Line updated with expected receipt status\", function () {",
 											"        let order  = res.json();",
 											"        utils.validatePoLines(order, 4, true);",
@@ -4098,7 +4258,7 @@
 									"raw": "{{request_body}}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{another_complete_order_id}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{anotherCompleteOrderId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -4107,7 +4267,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{another_complete_order_id}}"
+										"{{anotherCompleteOrderId}}"
 									]
 								},
 								"description": "Update a purchase order created a step before adding 2 more order lines and setting status to `Open`. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117)).\nThe two lines are added to order:\n- the first new line is of `Physical Resource` format, 3 locations, 6 physical items in total.\n- the second new line is of `Other` format, 2 location, 3 items."
@@ -4132,8 +4292,9 @@
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", (err, res) => {",
 											"    let order  = res.json();",
-											"    order.workflow_status = \"Open\";",
-											"    order = utils.deletePoNumber(order);",
+											"    order.workflowStatus = \"Open\";",
+											"    //order = utils.deletePoNumber(order);",
+											"    order.poNumber = \"1MIX1EL\";",
 											"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(utils.prepareOrder(order)));",
 											"});"
 										],
@@ -4152,7 +4313,7 @@
 											"    pm.response.to.have.status(201);",
 											"});",
 											"",
-											"pm.test(\"po_lines and corresponding Inventory entities exist\", function () {",
+											"pm.test(\"PO Lines and corresponding Inventory entities exist\", function () {",
 											"    utils.validatePoLines(jsonData, 2, true);",
 											"});",
 											"",
@@ -4160,11 +4321,11 @@
 											"",
 											"pm.test(\"Each order has these optional fields\", function() {",
 											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.globals.set(\"complete_open_order_id\", jsonData.id); ",
+											"    pm.globals.set(\"completeOpenOrderId\", jsonData.id); ",
 											"    pm.expect(jsonData.approved).to.exist;",
-											"    pm.expect(jsonData.po_number).to.exist;",
+											"    pm.expect(jsonData.poNumber).to.exist;",
 											"    pm.expect(jsonData.notes).to.exist;",
-											"    pm.expect(jsonData.total_items).to.exist;",
+											"    pm.expect(jsonData.totalItems).to.exist;",
 											"    pm.expect(jsonData.vendor).to.exist;",
 											"});",
 											""
@@ -4239,7 +4400,7 @@
 											"pm.test(\"Status code is 201\", function () {",
 											"    pm.response.to.have.status(201);",
 											"    pm.expect(order.id).to.exist;",
-											"    pm.globals.set(\"phys_el_open_order_id\", order.id); ",
+											"    pm.globals.set(\"physElecOpenOrderId\", order.id); ",
 											"});",
 											"",
 											"pm.test(\"2 PO Lines and corresponding Inventory entities exist\", function () {",
@@ -4305,10 +4466,10 @@
 											"    },",
 											"    function (err, res) {",
 											"        let order  = res.json();",
-											"        order.workflow_status = \"Open\";",
+											"        order.workflowStatus = \"Open\";",
 											"        order = utils.deletePoNumber(order);",
 											"        for(var i = 0; i < order.compositePoLines.length; i++) {",
-											"    \t  order.compositePoLines[i].receipt_status = \"Receipt Not Required\";",
+											"    \t  order.compositePoLines[i].receiptStatus = \"Receipt Not Required\";",
 											"        }",
 											"        ",
 											"        pm.globals.set(\"order_with_receipt_not_required_lines\", JSON.stringify(utils.prepareOrder(order)));",
@@ -4330,7 +4491,7 @@
 											"    pm.response.to.have.status(201);",
 											"});",
 											"",
-											"pm.test(\"Verify two po_lines exist\", function () {",
+											"pm.test(\"Verify two PO Lines exist\", function () {",
 											"    utils.validatePoLines(jsonData, 2, false);",
 											"});",
 											"",
@@ -4340,9 +4501,9 @@
 											"    pm.expect(jsonData.id).to.exist;",
 											"    pm.globals.set(\"order_without_inventory_records_id\", jsonData.id); ",
 											"    pm.expect(jsonData.approved).to.exist;",
-											"    pm.expect(jsonData.po_number).to.exist;",
+											"    pm.expect(jsonData.poNumber).to.exist;",
 											"    pm.expect(jsonData.notes).to.exist;",
-											"    pm.expect(jsonData.total_items).to.exist;",
+											"    pm.expect(jsonData.totalItems).to.exist;",
 											"    pm.expect(jsonData.vendor).to.exist;",
 											"});",
 											""
@@ -4404,7 +4565,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareReceivingRequestForPoLineOfFormat(globals.complete_open_order_id, \"P/E Mix\");"
+											"utils.prepareReceivingRequestForPoLineOfFormat(globals.completeOpenOrderId, \"P/E Mix\");"
 										],
 										"type": "text/javascript"
 									}
@@ -4488,7 +4649,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.complete_open_order_id, \"P/E Mix\");"
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.completeOpenOrderId, \"P/E Mix\");"
 										],
 										"type": "text/javascript"
 									}
@@ -4572,7 +4733,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareReceivingRequestForPoLineOfFormat(globals.phys_el_open_order_id, \"Physical Resource\", 10);"
+											"utils.prepareReceivingRequestForPoLineOfFormat(globals.physElecOpenOrderId, \"Physical Resource\", 10);"
 										],
 										"type": "text/javascript"
 									}
@@ -4656,7 +4817,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.phys_el_open_order_id, \"Physical Resource\");"
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.physElecOpenOrderId, \"Physical Resource\");"
 										],
 										"type": "text/javascript"
 									}
@@ -4740,7 +4901,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareReceivingRequestForPoLineOfFormat(globals.phys_el_open_order_id, \"Physical Resource\");"
+											"utils.prepareReceivingRequestForPoLineOfFormat(globals.physElecOpenOrderId, \"Physical Resource\");"
 										],
 										"type": "text/javascript"
 									}
@@ -4824,7 +4985,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareReceivingRequestForPoLineOfFormat(globals.phys_el_open_order_id, \"Electronic Resource\");"
+											"utils.prepareReceivingRequestForPoLineOfFormat(globals.physElecOpenOrderId, \"Electronic Resource\");"
 										],
 										"type": "text/javascript"
 									}
@@ -4908,7 +5069,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.phys_el_open_order_id, \"Electronic Resource\", 2);"
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.physElecOpenOrderId, \"Electronic Resource\", 2);"
 										],
 										"type": "text/javascript"
 									}
@@ -4993,7 +5154,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareReceivingRequestForPoLineOfFormat(globals.complete_open_order_id, \"Electronic Resource\");"
+											"utils.prepareReceivingRequestForPoLineOfFormat(globals.completeOpenOrderId, \"Electronic Resource\");"
 										],
 										"type": "text/javascript"
 									}
@@ -5077,7 +5238,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.complete_open_order_id, \"Electronic Resource\", 1);"
+											"utils.prepareRollBackReceivingRequestForPoLineOfFormat(globals.completeOpenOrderId, \"Electronic Resource\", 1);"
 										],
 										"type": "text/javascript"
 									}
@@ -5162,7 +5323,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.prepareReceivingRequestForOrder(globals.another_complete_order_id);"
+											"utils.prepareReceivingRequestForOrder(globals.anotherCompleteOrderId);"
 										],
 										"type": "text/javascript"
 									}
@@ -5187,7 +5348,7 @@
 											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
 											"});",
 											"",
-											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.another_complete_order_id, (err, res) => {",
+											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.anotherCompleteOrderId, (err, res) => {",
 											"    let order = res.json();",
 											"    order.compositePoLines.forEach(line => {",
 											"        utils.validateReceiptStatus(line, \"Fully Received\");",
@@ -5311,7 +5472,7 @@
 							"response": []
 						},
 						{
-							"name": "Get po_number",
+							"name": "Get poNumber",
 							"event": [
 								{
 									"listen": "test",
@@ -5328,7 +5489,7 @@
 											"});\r",
 											"\r",
 											"// 2. Validate PoNumber schema\r",
-											"var schema = JSON.parse(globals.schema_po_number_content);\r",
+											"var schema = JSON.parse(globals.schema_poNumber_content);\r",
 											"pm.test('PoNumber schema is valid', function() {\r",
 											"  pm.expect(tv4.validate(jsonData, schema)).to.be.true;\r",
 											"});\r",
@@ -5435,7 +5596,7 @@
 											"});",
 											"pm.test(\"At least 3 orders\", function () {",
 											"    var jsonData = pm.response.json();",
-											"    pm.expect(jsonData.purchase_orders).to.have.lengthOf.at.least(3);",
+											"    pm.expect(jsonData.purchaseOrders).to.have.lengthOf.at.least(3);",
 											"});"
 										],
 										"type": "text/javascript"
@@ -5503,8 +5664,8 @@
 											"});",
 											"",
 											"pm.test(\"Validate that response contains orders with proper workflow status\", function () {",
-											"    for(var i = 0; i < jsonData.purchase_orders.length; i++) {",
-											"    \tpm.expect(jsonData.purchase_orders[i].workflow_status).to.equal(\"Open\");",
+											"    for(var i = 0; i < jsonData.purchaseOrders.length; i++) {",
+											"    \tpm.expect(jsonData.purchaseOrders[i].workflowStatus).to.equal(\"Open\");",
 											"    }",
 											"});"
 										],
@@ -5533,7 +5694,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?limit=30&query=workflow_status==Open",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?limit=30&query=workflowStatus==Open",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -5550,7 +5711,7 @@
 										},
 										{
 											"key": "query",
-											"value": "workflow_status==Open"
+											"value": "workflowStatus==Open"
 										}
 									]
 								},
@@ -5587,7 +5748,7 @@
 											"});",
 											"pm.test(\"At least 4 orders\", function () {",
 											"    var jsonData = pm.response.json();",
-											"    pm.expect(jsonData.po_lines).to.have.lengthOf.above(4);",
+											"    pm.expect(jsonData.poLines).to.have.lengthOf.above(4);",
 											"});"
 										],
 										"type": "text/javascript"
@@ -5654,8 +5815,8 @@
 											"",
 											"pm.test(\"Validate that response contains orders with proper payment status\", function () {",
 											"    var jsonData = pm.response.json();",
-											"    for(var i = 0; i < jsonData.po_lines.length; i++) {",
-											"    \tpm.expect(jsonData.po_lines[i].payment_status).to.equal(\"Pending\");",
+											"    for(var i = 0; i < jsonData.poLines.length; i++) {",
+											"    \tpm.expect(jsonData.poLines[i].paymentStatus).to.equal(\"Pending\");",
 											"    }",
 											"});"
 										],
@@ -5684,7 +5845,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?limit=30&query=payment_status==Pending",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?limit=30&query=paymentStatus==Pending",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -5701,7 +5862,7 @@
 										},
 										{
 											"key": "query",
-											"value": "payment_status==Pending"
+											"value": "paymentStatus==Pending"
 										}
 									]
 								},
@@ -5762,7 +5923,7 @@
 											"});",
 											"",
 											"pm.test(\"History has pieces to receive\", function() {",
-											"    pm.expect(jsonData.total_records).to.be.above(0);",
+											"    pm.expect(jsonData.totalRecords).to.be.above(0);",
 											"});"
 										],
 										"type": "text/javascript"
@@ -5790,7 +5951,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=purchaseOrderId={{complete_open_order_id}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=purchaseOrderId={{completeOpenOrderId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -5803,7 +5964,7 @@
 									"query": [
 										{
 											"key": "query",
-											"value": "purchaseOrderId={{complete_open_order_id}}"
+											"value": "purchaseOrderId={{completeOpenOrderId}}"
 										}
 									]
 								},
@@ -5836,7 +5997,7 @@
 											"});",
 											"",
 											"pm.test(\"History has no pieces to receive\", function() {",
-											"    pm.expect(jsonData.total_records).to.equal(0);",
+											"    pm.expect(jsonData.totalRecords).to.equal(0);",
 											"});"
 										],
 										"type": "text/javascript"
@@ -5927,7 +6088,7 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"pm.variables.set(\"order_body\", JSON.stringify(utils.buildOrderWithMinContent()));"
+											"pm.variables.set(\"orderBody\", JSON.stringify(utils.buildOrderWithMinContent()));"
 										],
 										"type": "text/javascript"
 									}
@@ -5941,7 +6102,7 @@
 											"    pm.response.to.have.status(201);",
 											"",
 											"    var jsonData = pm.response.json();",
-											"    pm.globals.set(\"negative_tests_order_id\", jsonData.id); ",
+											"    pm.globals.set(\"negativeTestsOrderId\", jsonData.id); ",
 											"});"
 										],
 										"type": "text/javascript"
@@ -5966,7 +6127,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{{order_body}}"
+									"raw": "{{orderBody}}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -6009,9 +6170,9 @@
 											"",
 											"pm.test(\"Validate that response contains desired data\", function () {",
 											"    let line = pm.response.json();",
-											"    pm.expect(line.reporting_codes).to.have.lengthOf(2);",
+											"    pm.expect(line.reportingCodes).to.have.lengthOf(2);",
 											"    pm.expect(line.locations).to.have.lengthOf(1);",
-											"    pm.globals.set(\"po_line_for_negative_tests\", JSON.stringify(line));",
+											"    pm.globals.set(\"poLineForNegativeTests\", JSON.stringify(line));",
 											"});",
 											""
 										],
@@ -6037,7 +6198,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"locations\" : [{\n      \"quantity\" : 1,\n      \"quantity_electronic\" : 1,\n      \"quantity_physical\" : 0\n    }],\n\t\"source\": { \"code\": \"FOLIO\" },\n    \"purchase_order_id\" : \"{{negative_tests_order_id}}\",\n\t\"reporting_codes\": [\n\t\t{\n\t\t  \"code\": \"CODE1\",\n\t\t  \"description\": \"ABCDEF\"\n\t\t},\n\t\t{\n\t\t  \"code\": \"CODE2\",\n\t\t  \"description\": \"ABCDE\"\n\t\t}\n\t]\n}"
+									"raw": "{\n\t\"locations\" : [{\n      \"quantity\" : 1,\n      \"quantityElectronic\" : 1,\n      \"quantityPhysical\" : 0\n    }],\n\t\"source\": { \"code\": \"FOLIO\" },\n    \"purchaseOrderId\" : \"{{negativeTestsOrderId}}\",\n\t\"reportingCodes\": [\n\t\t{\n\t\t  \"code\": \"CODE1\",\n\t\t  \"description\": \"ABCDEF\"\n\t\t},\n\t\t{\n\t\t  \"code\": \"CODE2\",\n\t\t  \"description\": \"ABCDE\"\n\t\t}\n\t]\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
@@ -6581,14 +6742,14 @@
 							"response": []
 						},
 						{
-							"name": "Update order - empty po_number - 422",
+							"name": "Update order - empty poNumber - 422",
 							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
 										"id": "570809ac-8aba-4c7c-b384-8ee934d027c0",
 										"exec": [
-											"pm.variables.set(\"poline_id\", eval(globals.loadUtils).getLastPoLineId());"
+											"pm.variables.set(\"poLineId\", eval(globals.loadUtils).getLastPoLineId());"
 										],
 										"type": "text/javascript"
 									}
@@ -6627,7 +6788,7 @@
 									"raw": "{\n\n}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negative_tests_order_id}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsOrderId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -6636,7 +6797,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{negative_tests_order_id}}"
+										"{{negativeTestsOrderId}}"
 									]
 								}
 							},
@@ -6660,7 +6821,7 @@
 												"id": "570809ac-8aba-4c7c-b384-8ee934d027c0",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"let line = utils.buildPoLineWithMinContent(globals.negative_tests_order_id);",
+													"let line = utils.buildPoLineWithMinContent(globals.negativeTestsOrderId);",
 													"delete line.source;",
 													"pm.variables.set(\"line_body\", JSON.stringify(line));"
 												],
@@ -6737,15 +6898,15 @@
 													"    },",
 													"    function (err, res) {",
 													"        let line = res.json().compositePoLines[0];",
-													"        line.purchase_order_id = globals.negative_tests_order_id;",
+													"        line.purchaseOrderId = globals.negativeTestsOrderId;",
 													"",
-													"        line.order_format = \"Physical Resource\";",
-													"        line.cost.quantity_electronic = 5;",
-													"        line.cost.quantity_physical = 0;",
+													"        line.orderFormat = \"Physical Resource\";",
+													"        line.cost.quantityElectronic = 5;",
+													"        line.cost.quantityPhysical = 0;",
 													"        for(var i = 0; i < line.locations.length; i++) {",
 													"            var location = line.locations[i];",
-													"            location.quantity_electronic = 10;",
-													"            location.quantity_physical = 10;",
+													"            location.quantityElectronic = 10;",
+													"            location.quantityPhysical = 10;",
 													"        }",
 													"",
 													"        pm.variables.set(\"line_body\", JSON.stringify(line));",
@@ -6821,15 +6982,15 @@
 													"    },",
 													"    function (err, res) {",
 													"        let line = res.json().compositePoLines[0];",
-													"        line.purchase_order_id = globals.negative_tests_order_id;",
+													"        line.purchaseOrderId = globals.negativeTestsOrderId;",
 													"",
-													"        line.order_format = \"Electronic Resource\";",
-													"        line.cost.quantity_electronic = 0;",
-													"        line.cost.quantity_physical = 5;",
+													"        line.orderFormat = \"Electronic Resource\";",
+													"        line.cost.quantityElectronic = 0;",
+													"        line.cost.quantityPhysical = 5;",
 													"        for(var i = 0; i < line.locations.length; i++) {",
 													"            var location = line.locations[i];",
-													"            location.quantity_electronic = 10;",
-													"            location.quantity_physical = 10;",
+													"            location.quantityElectronic = 10;",
+													"            location.quantityPhysical = 10;",
 													"        }",
 													"",
 													"        pm.variables.set(\"line_body\", JSON.stringify(line));",
@@ -6905,16 +7066,16 @@
 													"    },",
 													"    function (err, res) {",
 													"        let line = res.json().compositePoLines[0];",
-													"        line.id = JSON.parse(globals.po_line_for_negative_tests).id;",
-													"        line.purchase_order_id = globals.negative_tests_order_id;",
+													"        line.id = JSON.parse(globals.poLineForNegativeTests).id;",
+													"        line.purchaseOrderId = globals.negativeTestsOrderId;",
 													"",
-													"        line.order_format = \"P/E Mix\";",
-													"        line.cost.quantity_electronic = 0;",
-													"        line.cost.quantity_physical = 5;",
+													"        line.orderFormat = \"P/E Mix\";",
+													"        line.cost.quantityElectronic = 0;",
+													"        line.cost.quantityPhysical = 5;",
 													"        for(var i = 0; i < line.locations.length; i++) {",
 													"            var location = line.locations[i];",
-													"            location.quantity_electronic = 10;",
-													"            location.quantity_physical = 10;",
+													"            location.quantityElectronic = 10;",
+													"            location.quantityPhysical = 10;",
 													"        }",
 													"",
 													"        pm.variables.set(\"line_body\", JSON.stringify(line));",
@@ -7190,7 +7351,7 @@
 										"id": "570809ac-8aba-4c7c-b384-8ee934d027c0",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"let line = utils.buildPoLineWithMinContent(globals.negative_tests_order_id);",
+											"let line = utils.buildPoLineWithMinContent(globals.negativeTestsOrderId);",
 											"line.id = \"bad-id\";",
 											"pm.variables.set(\"line_body\", JSON.stringify(line));"
 										],
@@ -7255,8 +7416,8 @@
 										"id": "570809ac-8aba-4c7c-b384-8ee934d027c0",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"let line = utils.buildPoLineWithMinContent(globals.negative_tests_order_id);",
-											"line.nonexistent_property = \"nonexistent_property_value\";",
+											"let line = utils.buildPoLineWithMinContent(globals.negativeTestsOrderId);",
+											"line.nonexistentProperty = \"nonexistent_property_value\";",
 											"pm.variables.set(\"line_body\", JSON.stringify(line));"
 										],
 										"type": "text/javascript"
@@ -7320,8 +7481,8 @@
 										"id": "570809ac-8aba-4c7c-b384-8ee934d027c0",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"let line = utils.buildPoLineWithMinContent(globals.negative_tests_order_id);",
-											"line.nonexistent_property = \"nonexistent_property_value\";",
+											"let line = utils.buildPoLineWithMinContent(globals.negativeTestsOrderId);",
+											"line.nonexistentProperty = \"nonexistent_property_value\";",
 											"pm.variables.set(\"line_body\", JSON.stringify(line));"
 										],
 										"type": "text/javascript"
@@ -7452,7 +7613,7 @@
 										"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"let line = utils.buildPoLineWithMinContent(globals.negative_tests_order_id);",
+											"let line = utils.buildPoLineWithMinContent(globals.negativeTestsOrderId);",
 											"pm.variables.set(\"line_body\", JSON.stringify(line));"
 										],
 										"type": "text/javascript"
@@ -7578,7 +7739,7 @@
 										"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
 										"exec": [
 											"let line = JSON.parse(pm.globals.get(\"po_listed_print_monograph\")).compositePoLines[0];",
-											"line.purchase_order_id = \"\";",
+											"line.purchaseOrderId = \"\";",
 											"pm.variables.set(\"po_line_listed_print_monograph\", JSON.stringify(line));"
 										],
 										"type": "text/javascript"
@@ -7634,92 +7795,6 @@
 								"description": "GET /orders/order-lines/id requests that return 422"
 							},
 							"response": []
-						},
-						{
-							"name": "Update line - update removed sub-object - 500",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "570809ac-8aba-4c7c-b384-8ee934d027c0",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let line = JSON.parse(globals.po_line_for_negative_tests);",
-											"line.po_line_description =\"Description\";",
-											"pm.variables.set(\"po_line_for_negative_tests\", JSON.stringify(line));",
-											"pm.variables.set(\"poline_id\", line.id);",
-											"",
-											"// Delete one reporting code from storage",
-											"utils.processDeleteRequest(\"/orders-storage/reporting_codes/\" + line.reporting_codes[0].id);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "b95ac933-05d2-4876-aab0-13142296fb9e",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"pm.test(\"Status code is 500\", function () {",
-											"    pm.response.to.have.status(500);",
-											"",
-											"    // Further tests can be done only if Server Error happened",
-											"    pm.test(\"Error in body as json\", function () {",
-											"        pm.expect(pm.response.json().errors).to.have.lengthOf(2);",
-											"    });",
-											"",
-											"    utils.sendGetRequest(\"/orders/order-lines/\" + pm.variables.get(\"poline_id\"), function (err, res) {",
-											"        pm.test(\"po_line has updates\", function () {",
-											"            let line = res.json();",
-											"            pm.expect(line.locations).to.have.lengthOf(1);",
-											"            pm.expect(line.po_line_description).to.exist;",
-											"            pm.expect(line.reporting_codes).to.have.lengthOf(1);",
-											"        });",
-											"    });",
-											"",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{po_line_for_negative_tests}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poline_id}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"order-lines",
-										"{{poline_id}}"
-									]
-								},
-								"description": "The test verifies that PO Line is partially updated even if errors happened on sub-object operations\n1. Remove one of reporting codes in the Pre-request script\n2. Submit PUT PO Line request\n3. Verify expected behavior in Tests"
-							},
-							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -7736,8 +7811,8 @@
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.negative_tests_order_id, function (err, res) {",
-											"    pm.variables.set(\"existing_number\", res.json().po_number);",
+											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.negativeTestsOrderId, function (err, res) {",
+											"    pm.variables.set(\"existing_number\", res.json().poNumber);",
 											"});"
 										],
 										"type": "text/javascript"
@@ -7877,7 +7952,7 @@
 											"let utils = eval(globals.loadUtils);",
 											"",
 											"pm.sendRequest({",
-											"    url: utils.buildOkapiUrl(\"/orders/receiving-history?limit=10&query=receivingStatus==Received and purchaseOrderId=\" + globals.phys_el_open_order_id),",
+											"    url: utils.buildOkapiUrl(\"/orders/receiving-history?limit=10&query=receivingStatus==Received and purchaseOrderId=\" + globals.physElecOpenOrderId),",
 											"        method: \"GET\",",
 											"        header: {",
 											"            \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
@@ -7885,7 +7960,7 @@
 											"        }",
 											"},",
 											"function (err, res) {",
-											"    let receivingRq = utils.prepareReceivingRequest(res.json().receiving_history);",
+											"    let receivingRq = utils.prepareReceivingRequest(res.json().receivingHistory);",
 											"    pm.variables.set(\"receivingRqBody\", JSON.stringify(receivingRq));",
 											"});",
 											""
@@ -8106,7 +8181,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_order_id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -8115,7 +8190,7 @@
 							"path": [
 								"orders",
 								"composite-orders",
-								"{{complete_order_id}}"
+								"{{completeOrderId}}"
 							]
 						},
 						"description": "GET /orders/composite-orders/id requests that return 204"
@@ -8132,7 +8207,7 @@
 								"exec": [
 									"let utils = eval(globals.loadUtils);",
 									"",
-									"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.another_complete_order_id, (err, res) => {",
+									"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.anotherCompleteOrderId, (err, res) => {",
 									"    // The po_listed_print_monograph.json was used to create this order and one more Open order. Some instances will not be deleted now but with deletion of the next order",
 									"    utils.deleteInventoryRecords(res.json(), false);",
 									"});"
@@ -8174,7 +8249,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{another_complete_order_id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{anotherCompleteOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -8183,7 +8258,7 @@
 							"path": [
 								"orders",
 								"composite-orders",
-								"{{another_complete_order_id}}"
+								"{{anotherCompleteOrderId}}"
 							]
 						},
 						"description": "GET /orders/composite-orders/id requests that return 204"
@@ -8200,7 +8275,7 @@
 								"exec": [
 									"let utils = eval(globals.loadUtils);",
 									"",
-									"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.complete_open_order_id, (err, res) => {",
+									"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.completeOpenOrderId, (err, res) => {",
 									"    // The instances should be deleted at this point for all orders created based on po_listed_print_monograph.json",
 									"    utils.deleteInventoryRecords(res.json(), true);",
 									"});"
@@ -8242,7 +8317,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{complete_open_order_id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOpenOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -8251,7 +8326,7 @@
 							"path": [
 								"orders",
 								"composite-orders",
-								"{{complete_open_order_id}}"
+								"{{completeOpenOrderId}}"
 							]
 						},
 						"description": "GET /orders/composite-orders/id requests that return 204"
@@ -8268,7 +8343,7 @@
 								"exec": [
 									"let utils = eval(globals.loadUtils);",
 									"",
-									"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.phys_el_open_order_id, (err, res) => {",
+									"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.physElecOpenOrderId, (err, res) => {",
 									"    utils.deleteInventoryRecords(res.json(), true);",
 									"});"
 								],
@@ -8309,7 +8384,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{phys_el_open_order_id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{physElecOpenOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -8318,7 +8393,7 @@
 							"path": [
 								"orders",
 								"composite-orders",
-								"{{phys_el_open_order_id}}"
+								"{{physElecOpenOrderId}}"
 							]
 						},
 						"description": "GET /orders/composite-orders/id requests that return 204"
@@ -8372,7 +8447,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negative_tests_order_id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -8381,7 +8456,7 @@
 							"path": [
 								"orders",
 								"composite-orders",
-								"{{negative_tests_order_id}}"
+								"{{negativeTestsOrderId}}"
 							]
 						},
 						"description": "GET /orders/composite-orders/id requests that return 204"
@@ -8462,7 +8537,7 @@
 									"let utils = eval(globals.loadUtils);",
 									"let lineId = utils.getLastPoLineId();",
 									"if (lineId) {",
-									"    pm.variables.set(\"complete_poline_id\", lineId);",
+									"    pm.variables.set(\"complete_poLineId\", lineId);",
 									"}"
 								],
 								"type": "text/javascript"
@@ -8474,7 +8549,7 @@
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
 									"pm.test(\"Verify that no lines found\", function () {",
-									"    pm.expect(pm.response.json().total_records).to.equal(0);",
+									"    pm.expect(pm.response.json().totalRecords).to.equal(0);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -8502,7 +8577,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/po_lines?query=purchase_order_id=={{complete_order_id}} or purchase_order_id=={{another_complete_order_id}} or purchase_order_id=={{complete_open_order_id}} or purchase_order_id=={{negative_tests_order_id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/po-lines?query=purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{negativeTestsOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -8510,12 +8585,12 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"orders-storage",
-								"po_lines"
+								"po-lines"
 							],
 							"query": [
 								{
 									"key": "query",
-									"value": "purchase_order_id=={{complete_order_id}} or purchase_order_id=={{another_complete_order_id}} or purchase_order_id=={{complete_open_order_id}} or purchase_order_id=={{negative_tests_order_id}}"
+									"value": "purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{negativeTestsOrderId}}"
 								}
 							]
 						},
@@ -8542,7 +8617,7 @@
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
 									"pm.test(\"Verify that no orders found\", function () {",
-									"    pm.expect(pm.response.json().total_records).to.equal(0);",
+									"    pm.expect(pm.response.json().totalRecords).to.equal(0);",
 									"});",
 									"",
 									"// Remove all created variables",
@@ -8573,7 +8648,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/purchase_orders?query=id=={{complete_order_id}} or id=={{another_complete_order_id}} or id=={{complete_open_order_id}} or id=={{negative_tests_order_id}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/purchase-orders?query=id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or id=={{negativeTestsOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -8581,16 +8656,16 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"orders-storage",
-								"purchase_orders"
+								"purchase-orders"
 							],
 							"query": [
 								{
 									"key": "query",
-									"value": "id=={{complete_order_id}} or id=={{another_complete_order_id}} or id=={{complete_open_order_id}} or id=={{negative_tests_order_id}}"
+									"value": "id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or id=={{negativeTestsOrderId}}"
 								}
 							]
 						},
-						"description": "GET /orders-storage/purchase_orders returns a 404 after delete"
+						"description": "GET /orders-storage/purchaseOrders returns a 404 after delete"
 					},
 					"response": []
 				}
@@ -8652,6 +8727,7 @@
 					"     */",
 					"    utils.prepareOrder = function (order) {",
 					"        delete order.id;",
+					"        order.vendor = pm.environment.get(\"activeVendorId\");",
 					"        console.log(\"Preparing order. Number of PO lines: %d\", order.compositePoLines.length);",
 					"",
 					"        for (var i = 0; i < order.compositePoLines.length; i++) {",
@@ -8665,21 +8741,14 @@
 					"     * Updates sub-objects of the PO Line removing ids and adding missing data.",
 					"     */",
 					"    utils.preparePoLine = function (poLine) {",
+					"        if (poLine.eresource) {",
+					"            poLine.eresource.accessProvider = pm.environment.get(\"activeVendorId\");",
+					"        }",
 					"        delete poLine.id;",
-					"        delete poLine.purchase_order_id;",
-					"        delete poLine.receipt_date;",
-					"        utils._deleteSubObjectIds(poLine.adjustment);",
-					"        utils._deleteSubObjectIds(poLine.cost);",
-					"        utils._deleteSubObjectIds(poLine.details);",
-					"        utils._deleteSubObjectIds(poLine.eresource);",
-					"        utils._deleteSubObjectsIds(poLine.locations);",
-					"        utils._deleteSubObjectIds(poLine.physical);",
-					"        utils._deleteSubObjectIds(poLine.source);",
-					"        utils._deleteSubObjectIds(poLine.vendor_detail);",
+					"        delete poLine.purchaseOrderId;",
+					"        delete poLine.receiptDate;",
 					"        utils._deleteSubObjectsIds(poLine.alerts);",
-					"        utils._deleteSubObjectsIds(poLine.claims);",
-					"        utils._deleteSubObjectsIds(poLine.fund_distribution);",
-					"        utils._deleteSubObjectsIds(poLine.reporting_codes);",
+					"        utils._deleteSubObjectsIds(poLine.reportingCodes);",
 					"        return poLine;",
 					"    };",
 					"",
@@ -8695,8 +8764,8 @@
 					"     */",
 					"    utils.buildPoLineWithMinContent = function (orderId) {",
 					"        return {",
-					"            \"po_line_number\": \"tempnumber-123\",",
-					"            \"purchase_order_id\": orderId,",
+					"            \"poLineNumber\": \"tempnumber-123\",",
+					"            \"purchaseOrderId\": orderId,",
 					"            \"source\": {",
 					"                \"code\": \"FOLIO\"",
 					"            }",
@@ -8715,19 +8784,19 @@
 					"     * Validates presence of the PO lines of expected quantity and its sub-object elements",
 					"     */",
 					"    utils.validatePoLines = function (order, expectedCount, checkInventory) {",
-					"        console.log(\"Validating PO Lines for order with PO number=%s. Expected lines count=%d. Inventory check required: %s\", order.po_number, expectedCount, checkInventory);",
+					"        console.log(\"Validating PO Lines for order with PO number=%s. Expected lines count=%d. Inventory check required: %s\", order.poNumber, expectedCount, checkInventory);",
 					"        pm.expect(order.compositePoLines).to.have.lengthOf(expectedCount);",
 					"        order.compositePoLines.forEach(poLine => {",
-					"            pm.test(\"Validating PO Line with number=\" + poLine.po_line_number, function () {",
+					"            pm.test(\"Validating PO Line with number=\" + poLine.poLineNumber, function () {",
 					"                utils.rememberPoLineId(poLine);",
-					"                pm.expect(poLine.purchase_order_id, \"Line has to have order id\").to.equal(order.id);",
+					"                pm.expect(poLine.purchaseOrderId, \"Line has to have order id\").to.equal(order.id);",
 					"                utils.validatePoLineAgainstSchema(poLine);",
 					"",
 					"                if (checkInventory) {",
 					"                    utils.validatePoLinesInventoryLinks(poLine);",
 					"                } else {",
 					"                    utils.verifyNoInventoryItemsExist(poLine);",
-					"                    pm.expect(poLine.instance_id).to.not.exist;",
+					"                    pm.expect(poLine.instanceId).to.not.exist;",
 					"                }",
 					"            });",
 					"        });",
@@ -8739,11 +8808,11 @@
 					"    utils.validatePoLinesInventoryLinks = function (poLine) {",
 					"        // Instance should created only",
 					"        if (utils.calculateExpectedItemsQuantity(poLine) > 0) {",
-					"            pm.expect(poLine.instance_id, \"Instance id is expected\").to.exist;",
-					"            utils.sendGetRequest(\"/instance-storage/instances/\" + poLine.instance_id, (err, res) => {",
-					"                pm.test(\"Instance Record exist for PO Line with number=\" + poLine.po_line_number, function () {",
+					"            pm.expect(poLine.instanceId, \"Instance id is expected\").to.exist;",
+					"            utils.sendGetRequest(\"/instance-storage/instances/\" + poLine.instanceId, (err, res) => {",
+					"                pm.test(\"Instance Record exist for PO Line with number=\" + poLine.poLineNumber, function () {",
 					"                    pm.expect(res.json()).to.exist;",
-					"                    pm.expect(res.json().id).to.equal(poLine.instance_id);",
+					"                    pm.expect(res.json().id).to.equal(poLine.instanceId);",
 					"                    //Check if holdings record is created",
 					"                    utils.validateHoldingsRecord(poLine);",
 					"                    // Now check items",
@@ -8752,7 +8821,7 @@
 					"            });",
 					"        } else {",
 					"            utils.verifyNoInventoryItemsExist(poLine);",
-					"            pm.expect(poLine.instance_id).to.not.exist;",
+					"            pm.expect(poLine.instanceId).to.not.exist;",
 					"        }",
 					"    };",
 					"",
@@ -8762,7 +8831,7 @@
 					"    utils.validateInventoryItems = function (line) {",
 					"        let expectedCount = utils.calculateExpectedItemsQuantity(line);",
 					"        utils.getItemsByPoLineId(line.id, 0, (err, res) => {",
-					"            pm.test(expectedCount + \" Item Records exist for PO Line with number=\" + line.po_line_number, function () {",
+					"            pm.test(expectedCount + \" Item Records exist for PO Line with number=\" + line.poLineNumber, function () {",
 					"                let body = res.json();",
 					"                pm.expect(body, \"GET Items response is not in json format\").to.exist;",
 					"                pm.expect(body.totalRecords, \"Quantity of items created for PO Line should be \" + expectedCount).to.equal(expectedCount);",
@@ -8781,7 +8850,7 @@
 					"     * Validates that Holdings Record was created  in the inventory",
 					"     */",
 					"    utils.validateHoldingsRecord = function (poLine) {",
-					"        let instanceId = poLine.instance_id;",
+					"        let instanceId = poLine.instanceId;",
 					"        pm.expect(instanceId).to.exist;",
 					"        utils.sendGetRequest(\"/holdings-storage/holdings?limit=0&query=instanceId==\" + instanceId, (err, res) => {",
 					"            pm.test(\"Holding Records exist for Created Instance=\" + instanceId, function () {",
@@ -8798,7 +8867,7 @@
 					"        return new Promise((resolve) => {",
 					"            utils.getItemsByPoLineId(line.id, 0, (err, res) => {",
 					"                resolve();",
-					"                pm.test(\"No Item Records found for PO Line with number=\" + line.po_line_number, function () {",
+					"                pm.test(\"No Item Records found for PO Line with number=\" + line.poLineNumber, function () {",
 					"                    pm.expect(res.code).to.eql(200);",
 					"                    pm.expect(res.json().totalRecords).to.eql(0);",
 					"                });",
@@ -8810,12 +8879,12 @@
 					"     * Validates that PO Line's receipt status updated to expected",
 					"     */",
 					"    utils.validateReceiptStatus = function(poLine, receiptStatus) {",
-					"        pm.test(poLine.po_line_number + \" PO Line should have \" + receiptStatus + \" receipt status\", function () {",
-					"            pm.expect(poLine.receipt_status, \"Receipt status should be \" + receiptStatus).to.equal(receiptStatus);",
+					"        pm.test(poLine.poLineNumber + \" PO Line should have \" + receiptStatus + \" receipt status\", function () {",
+					"            pm.expect(poLine.receiptStatus, \"Receipt status should be \" + receiptStatus).to.equal(receiptStatus);",
 					"            if (\"Fully Received\" === receiptStatus) {",
-					"                pm.expect(poLine.receipt_date, \"Receipt date should be set\").to.not.be.empty;",
+					"                pm.expect(poLine.receiptDate, \"Receipt date should be set\").to.not.be.empty;",
 					"            } else {",
-					"                pm.expect(poLine.receipt_date, \"Receipt date should be empty\").to.not.exist;",
+					"                pm.expect(poLine.receiptDate, \"Receipt date should be empty\").to.not.exist;",
 					"            }",
 					"        });",
 					"    };",
@@ -8826,7 +8895,7 @@
 					"    utils.validateInventoryItemsReceived = function(poLine, expectedQuantity) {",
 					"        let expectedCount = typeof expectedQuantity === \"undefined\" ? utils.calculateExpectedItemsQuantity(poLine) : expectedQuantity;",
 					"        utils.sendGetRequest(\"/item-storage/items?limit=100&query=status.name==Received and purchaseOrderLineIdentifier==\" + poLine.id, (err, res) => {",
-					"            pm.test(expectedCount + \" Item Records marked as received for PO Line with number=\" + poLine.po_line_number, function () {",
+					"            pm.test(expectedCount + \" Item Records marked as received for PO Line with number=\" + poLine.poLineNumber, function () {",
 					"                let body = res.json();",
 					"                pm.expect(body, \"GET Items response is not in json format\").to.exist;",
 					"                pm.expect(body.totalRecords, \"Quantity of items received for PO Line should be \" + expectedCount).to.equal(expectedCount);",
@@ -8843,8 +8912,8 @@
 					"    utils.validateReceivingHistoryNumberOfPiecesByStatus = function(poLine, expectedQuantity, receivingStatus) {",
 					"        receivingStatus = typeof receivingStatus === \"undefined\" ? \"Expected\" : receivingStatus;",
 					"        utils.sendGetRequest(\"/orders/receiving-history?limit=0&query=receivingStatus==\" + receivingStatus + \" and poLineId=\" + poLine.id, (err, res) => {",
-					"            pm.test(expectedQuantity + \" \" + receivingStatus + \" pieces for PO Line with number=\" + poLine.po_line_number, function () {",
-					"                pm.expect(res.json().total_records).to.equal(expectedQuantity);",
+					"            pm.test(expectedQuantity + \" \" + receivingStatus + \" pieces for PO Line with number=\" + poLine.poLineNumber, function () {",
+					"                pm.expect(res.json().totalRecords).to.equal(expectedQuantity);",
 					"            });",
 					"        });",
 					"    };",
@@ -8872,8 +8941,8 @@
 					"                quantityToReceive = 1000;",
 					"            }",
 					"            utils.sendGetRequest(\"/orders/receiving-history?limit=\" + quantityToReceive + \"&query=receivingStatus==\" + pieceStatus + \" and purchaseOrderId=\" + orderId, (err, res) => {",
-					"                let receivingRq = utils.prepareReceivingRequest(res.json().receiving_history, itemStatus);",
-					"                pm.variables.set(\"receivingHistoryTotalRecords\", res.json().total_records);",
+					"                let receivingRq = utils.prepareReceivingRequest(res.json().receivingHistory, itemStatus);",
+					"                pm.variables.set(\"receivingHistoryTotalRecords\", res.json().totalRecords);",
 					"                pm.variables.set(\"receivingRqBody\", JSON.stringify(receivingRq));",
 					"            });",
 					"        });",
@@ -8907,7 +8976,7 @@
 					"            let poLine;",
 					"            pm.test(\"One PO Line with \" + orderFormat + \" order format expected\", function () {",
 					"                pm.expect(res).to.have.property('code', 200);",
-					"                let lines = res.json().compositePoLines.filter(line => line.order_format === orderFormat);",
+					"                let lines = res.json().compositePoLines.filter(line => line.orderFormat === orderFormat);",
 					"                pm.expect(lines.length).to.equal(1);",
 					"                poLine = lines[0];",
 					"            });",
@@ -8918,8 +8987,8 @@
 					"                quantityToReceive = piecesQuantity;",
 					"            }",
 					"            utils.sendGetRequest(\"/orders/receiving-history?limit=\" + quantityToReceive + \"&query=receivingStatus==\" + pieceStatus + \" and poLineId=\" + poLine.id, (err, res) => {",
-					"                let receivingRq = utils.prepareReceivingRequest(res.json().receiving_history, itemStatus);",
-					"                pm.variables.set(\"receivingHistoryTotalRecords\", res.json().total_records);",
+					"                let receivingRq = utils.prepareReceivingRequest(res.json().receivingHistory, itemStatus);",
+					"                pm.variables.set(\"receivingHistoryTotalRecords\", res.json().totalRecords);",
 					"                pm.variables.set(\"receivingRqBody\", JSON.stringify(receivingRq));",
 					"            });",
 					"        });",
@@ -9024,7 +9093,7 @@
 					"     * The logic is based on MODORDERS-117",
 					"     */",
 					"    utils.calculateExpectedItemsQuantity = function(poLine) {",
-					"        switch (poLine.order_format) {",
+					"        switch (poLine.orderFormat) {",
 					"            case \"P/E Mix\":",
 					"                return utils.getPhysicalQuantity(poLine) + utils.getElectronicQuantity(poLine);",
 					"            case \"Physical Resource\":",
@@ -9042,14 +9111,14 @@
 					"     * The logic is based on MODORDERS-100",
 					"     */",
 					"    utils.calculateExpectedPiecesQuantity = function(poLine) {",
-					"        switch (poLine.order_format) {",
+					"        switch (poLine.orderFormat) {",
 					"            case \"P/E Mix\":",
 					"            case \"Other\":",
-					"                return poLine.cost.quantity_physical + poLine.cost.quantity_electronic;",
+					"                return poLine.cost.quantityPhysical + poLine.cost.quantityElectronic;",
 					"            case \"Physical Resource\":",
-					"                return poLine.cost.quantity_physical;",
+					"                return poLine.cost.quantityPhysical;",
 					"            case \"Electronic Resource\":",
-					"                return poLine.cost.quantity_electronic;",
+					"                return poLine.cost.quantityElectronic;",
 					"            default:",
 					"                return 0;",
 					"        }",
@@ -9063,7 +9132,7 @@
 					"        let locations = poLine.locations;",
 					"        if (locations) {",
 					"            for(let i = 0; i < locations.length; i++) {",
-					"                var qty = locations[i].quantity_physical;",
+					"                var qty = locations[i].quantityPhysical;",
 					"                if (qty > 0) {",
 					"                    total += qty;",
 					"                }",
@@ -9077,10 +9146,10 @@
 					"     */",
 					"    utils.getElectronicQuantity = function(poLine) {",
 					"        let total = 0;",
-					"        if (poLine.eresource && poLine.eresource.create_inventory && poLine.locations) {",
+					"        if (poLine.eresource && poLine.eresource.createInventory && poLine.locations) {",
 					"            let locations = poLine.locations;",
 					"            for(let i = 0; i < locations.length; i++) {",
-					"                var qty = locations[i].quantity_electronic;",
+					"                var qty = locations[i].quantityElectronic;",
 					"                if (qty > 0) {",
 					"                    total += qty;",
 					"                }",
@@ -9094,35 +9163,35 @@
 					"     */",
 					"    utils.validatePoLineSubObjetcsPresence = function(poLine) {",
 					"        pm.expect(poLine.id, \"PO line id expected\").to.exist;",
-					"        pm.expect(poLine.acquisition_method, \"acquisition_method expected\").to.exist;",
+					"        pm.expect(poLine.acquisitionMethod, \"acquisitionMethod expected\").to.exist;",
 					"        pm.expect(poLine.adjustment, \"adjustment expected\").to.exist;",
 					"        pm.expect(poLine.alerts, \"alerts expected\").to.exist;",
-					"        pm.expect(poLine.cancellation_restriction, \"cancellation_restriction expected\").to.exist;",
-					"        pm.expect(poLine.cancellation_restriction_note, \"cancellation_restriction_note expected\").to.exist;",
+					"        pm.expect(poLine.cancellationRestriction, \"cancellationRestriction expected\").to.exist;",
+					"        pm.expect(poLine.cancellationRestrictionNote, \"cancellationRestrictionNote expected\").to.exist;",
 					"        pm.expect(poLine.claims, \"claims expected\").to.exist;",
 					"        pm.expect(poLine.contributors, \"contributors expected\").to.exist;",
 					"        pm.expect(poLine.cost, \"cost expected\").to.exist;",
 					"        pm.expect(poLine.description, \"description expected\").to.exist;",
 					"        pm.expect(poLine.donor, \"donor expected\").to.exist;",
-					"        pm.expect(poLine.fund_distribution, \"fund_distribution expected\").to.exist;",
+					"        pm.expect(poLine.fundDistribution, \"fundDistribution expected\").to.exist;",
 					"        pm.expect(poLine.locations, \"locations expected\").to.exist;",
-					"        pm.expect(poLine.order_format, \"order_format expected\").to.exist;",
+					"        pm.expect(poLine.orderFormat, \"orderFormat expected\").to.exist;",
 					"        pm.expect(poLine.owner, \"owner expected\").to.exist;",
-					"        pm.expect(poLine.payment_status, \"payment_status expected\").to.exist;",
+					"        pm.expect(poLine.paymentStatus, \"paymentStatus expected\").to.exist;",
 					"        pm.expect(poLine.physical, \"physical expected\").to.exist;",
-					"        pm.expect(poLine.po_line_description, \"po_line_description expected\").to.exist;",
-					"        pm.expect(poLine.po_line_number, \"po_line_number expected\").to.exist;",
-					"        pm.expect(poLine.publication_date, \"publication_date expected\").to.exist;",
+					"        pm.expect(poLine.poLineDescription, \"poLineDescription expected\").to.exist;",
+					"        pm.expect(poLine.poLineNumber, \"poLineNumber expected\").to.exist;",
+					"        pm.expect(poLine.publicationDate, \"publicationDate expected\").to.exist;",
 					"        pm.expect(poLine.publisher, \"publisher expected\").to.exist;",
-					"        pm.expect(poLine.receipt_status, \"receipt_status expected\").to.exist;",
-					"        pm.expect(poLine.reporting_codes, \"reporting_codes expected\").to.exist;",
+					"        pm.expect(poLine.receiptStatus, \"receiptStatus expected\").to.exist;",
+					"        pm.expect(poLine.reportingCodes, \"reportingCodes expected\").to.exist;",
 					"        pm.expect(poLine.requester, \"requester expected\").to.exist;",
 					"        pm.expect(poLine.rush, \"rush expected\").to.exist;",
 					"        pm.expect(poLine.selector, \"selector expected\").to.exist;",
 					"        pm.expect(poLine.source, \"source expected\").to.exist;",
 					"        pm.expect(poLine.tags, \"tags expected\").to.exist;",
 					"        pm.expect(poLine.title, \"title expected\").to.exist;",
-					"        pm.expect(poLine.vendor_detail, \"vendor_detail expected\").to.exist;",
+					"        pm.expect(poLine.vendorDetail, \"vendorDetail expected\").to.exist;",
 					"    };",
 					"",
 					"    /**",
@@ -9130,61 +9199,61 @@
 					"     */",
 					"    utils.validatePoLineWithMinimalContent = function(poLine) {",
 					"        pm.expect(poLine.id, \"PO line id expected\").to.exist;",
-					"        pm.expect(poLine.purchase_order_id, \"PO id expected\").to.exist;",
+					"        pm.expect(poLine.purchaseOrderId, \"PO id expected\").to.exist;",
 					"        pm.expect(poLine.source, \"source not expected\").to.exist;",
-					"        pm.expect(poLine.acquisition_method, \"acquisition_method not expected\").to.not.exist;",
+					"        pm.expect(poLine.acquisitionMethod, \"acquisitionMethod not expected\").to.not.exist;",
 					"        pm.expect(poLine.adjustment, \"adjustment not expected\").to.not.exist;",
 					"        pm.expect(poLine.alerts, \"alerts should be empty\").to.be.an('array').that.is.empty;",
-					"        pm.expect(poLine.cancellation_restriction, \"cancellation_restriction not expected\").to.not.exist;",
-					"        pm.expect(poLine.cancellation_restriction_note, \"cancellation_restriction_note not expected\").to.not.exist;",
+					"        pm.expect(poLine.cancellationRestriction, \"cancellationRestriction not expected\").to.not.exist;",
+					"        pm.expect(poLine.cancellationRestrictionNote, \"cancellationRestrictionNote not expected\").to.not.exist;",
 					"        pm.expect(poLine.claims, \"claims should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.contributors, \"contributors should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.cost, \"cost not expected\").to.not.exist;",
 					"        pm.expect(poLine.description, \"description not expected\").to.not.exist;",
 					"        pm.expect(poLine.donor, \"donor not expected\").to.not.exist;",
-					"        pm.expect(poLine.fund_distribution, \"fund_distribution should be empty\").to.be.an('array').that.is.empty;",
+					"        pm.expect(poLine.fundDistribution, \"fundDistribution should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.locations, \"locations should be empty\").to.be.an('array').that.is.empty;",
-					"        pm.expect(poLine.order_format, \"order_format not expected\").to.not.exist;",
+					"        pm.expect(poLine.orderFormat, \"orderFormat not expected\").to.not.exist;",
 					"        pm.expect(poLine.owner, \"owner not expected\").to.not.exist;",
-					"        pm.expect(poLine.payment_status, \"payment_status not expected\").to.not.exist;",
+					"        pm.expect(poLine.paymentStatus, \"paymentStatus not expected\").to.not.exist;",
 					"        pm.expect(poLine.physical, \"physical not expected\").to.not.exist;",
-					"        pm.expect(poLine.po_line_description, \"po_line_description not expected\").to.not.exist;",
-					"        pm.expect(poLine.po_line_number, \"po_line_number is expected\").to.exist;",
-					"        pm.expect(poLine.publication_date, \"publication_date not expected\").to.not.exist;",
+					"        pm.expect(poLine.poLineDescription, \"poLineDescription not expected\").to.not.exist;",
+					"        pm.expect(poLine.poLineNumber, \"poLineNumber is expected\").to.exist;",
+					"        pm.expect(poLine.publicationDate, \"publicationDate not expected\").to.not.exist;",
 					"        pm.expect(poLine.publisher, \"publisher not expected\").to.not.exist;",
-					"        pm.expect(poLine.receipt_date, \"receipt_date not expected\").to.not.exist;",
-					"        pm.expect(poLine.receipt_status, \"receipt_status must be Pending\").to.equal(\"Pending\");",
-					"        pm.expect(poLine.reporting_codes, \"reporting_codes should be empty\").to.be.an('array').that.is.empty;",
+					"        pm.expect(poLine.receiptDate, \"receiptDate not expected\").to.not.exist;",
+					"        pm.expect(poLine.receiptStatus, \"receiptStatus must be Pending\").to.equal(\"Pending\");",
+					"        pm.expect(poLine.reportingCodes, \"reportingCodes should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.requester, \"requester not expected\").to.not.exist;",
 					"        pm.expect(poLine.rush, \"rush not expected\").to.not.exist;",
 					"        pm.expect(poLine.selector, \"selector not expected\").to.not.exist;",
 					"        pm.expect(poLine.tags, \"tags should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.title, \"title not expected\").to.not.exist;",
-					"        pm.expect(poLine.vendor_detail, \"vendor_detail not expected\").to.not.exist;",
+					"        pm.expect(poLine.vendorDetail, \"vendorDetail not expected\").to.not.exist;",
 					"    };",
 					"",
 					"    /**",
-					"     * Adds PO line id to `complete_poline_ids` array and stores as global variable.",
+					"     * Adds PO line id to `completePolineIds` array and stores as global variable.",
 					"     */",
 					"    utils.rememberPoLineId = function(poLine) {",
 					"        if (poLine && poLine.id) {",
-					"            let complete_poline_ids = pm.globals.get(\"complete_poline_ids\") ? JSON.parse(pm.globals.get(\"complete_poline_ids\")) : [];",
-					"            complete_poline_ids.push(poLine.id);",
-					"            pm.globals.set(\"complete_poline_ids\", JSON.stringify(complete_poline_ids));",
+					"            let completePolineIds = pm.globals.get(\"completePolineIds\") ? JSON.parse(pm.globals.get(\"completePolineIds\")) : [];",
+					"            completePolineIds.push(poLine.id);",
+					"            pm.globals.set(\"completePolineIds\", JSON.stringify(completePolineIds));",
 					"        }",
 					"    };",
 					"",
 					"    /**",
-					"     * Gets last id from `complete_poline_ids` array (global variable).",
+					"     * Gets last id from `completePolineIds` array (global variable).",
 					"     * In case the `withRemoval==true`, the last id is removed from array.",
 					"     * In case the array is empty, `null` is returned",
 					"     */",
 					"    utils.getLastPoLineId = function(withRemoval) {",
-					"        let complete_poline_ids = globals.complete_poline_ids ? JSON.parse(globals.complete_poline_ids) : [];",
-					"        if (complete_poline_ids.length > 0) {",
-					"            let lineId = complete_poline_ids.pop();",
+					"        let completePolineIds = globals.completePolineIds ? JSON.parse(globals.completePolineIds) : [];",
+					"        if (completePolineIds.length > 0) {",
+					"            let lineId = completePolineIds.pop();",
 					"            if (withRemoval) {",
-					"                pm.globals.set(\"complete_poline_ids\", JSON.stringify(complete_poline_ids));",
+					"                pm.globals.set(\"completePolineIds\", JSON.stringify(completePolineIds));",
 					"            }",
 					"            return lineId;",
 					"        }",
@@ -9212,9 +9281,9 @@
 					"     */",
 					"    utils.validatePoLinesNumber = function(order) {",
 					"        let poLineSuffix = \"(-[0-9]{1,3})\";",
-					"        let regex = new RegExp(order.po_number + poLineSuffix);",
+					"        let regex = new RegExp(order.poNumber + poLineSuffix);",
 					"        for(let i = 0; i < order.compositePoLines.length; i++) {",
-					"            let poLineNumber = order.compositePoLines[i].po_line_number;",
+					"            let poLineNumber = order.compositePoLines[i].poLineNumber;",
 					"            let match = regex.exec(poLineNumber);",
 					"            pm.expect(match).not.equal(null);",
 					"        }",
@@ -9367,13 +9436,13 @@
 					"                    })",
 					"                    .then(holdingsDelResult => {",
 					"                        // delete instance if there is an instance id and there is no holdings linked to any item",
-					"                        if (line.instance_id) {",
+					"                        if (line.instanceId) {",
 					"                            // see utils.deleteHoldingsRecords()",
 					"                            let holdingsQty = holdingsDelResult.filter(code => code === -1).length;",
 					"                            if (holdingsQty === 0) {",
-					"                                return utils.deleteInventoryInstance(line.instance_id);",
+					"                                return utils.deleteInventoryInstance(line.instanceId);",
 					"                            } else {",
-					"                                pm.test(holdingsQty + \" holdings record(s) referenced by instance id=\" + line.instance_id + \". The instance deletion is skipped!\", () => {});",
+					"                                pm.test(holdingsQty + \" holdings record(s) referenced by instance id=\" + line.instanceId + \". The instance deletion is skipped!\", () => {});",
 					"                            }",
 					"                        }",
 					"                        return -1;",
@@ -9410,8 +9479,8 @@
 					"     */",
 					"    utils.verifyInventoryInstanceDeleted = function(line) {",
 					"        return new Promise((resolve) => {",
-					"            if (line.instance_id) {",
-					"                utils.sendGetRequest(\"/instance-storage/instances/\" + line.instance_id, (err, res) => {",
+					"            if (line.instanceId) {",
+					"                utils.sendGetRequest(\"/instance-storage/instances/\" + line.instanceId, (err, res) => {",
 					"                    resolve();",
 					"                    pm.test(\"No Instance Record found for PO Line with id=\" + line.id, function () {",
 					"                        pm.expect(res.code).to.eql(404);",
@@ -9428,8 +9497,8 @@
 					"     */",
 					"    utils.verifyInventoryHoldingsDeleted = function(line) {",
 					"        return new Promise((resolve) => {",
-					"            if (line.instance_id) {",
-					"                utils.sendGetRequest(\"/holdings-storage/holdings?limit=0&query=instanceId==\" + line.instance_id, (err, res) => {",
+					"            if (line.instanceId) {",
+					"                utils.sendGetRequest(\"/holdings-storage/holdings?limit=0&query=instanceId==\" + line.instanceId, (err, res) => {",
 					"                    resolve();",
 					"                    pm.test(\"No Holding Records found for PO Line with id=\" + line.id, function () {",
 					"                        pm.expect(res.code).to.eql(200);",
@@ -9553,33 +9622,35 @@
 					"        pm.globals.unset(\"schema_alert_content\");",
 					"        pm.globals.unset(\"schema_composite_po_line_content\");",
 					"        pm.globals.unset(\"schema_cost_content\");",
+					"        pm.globals.unset(\"schema_contributor_content\");",
 					"        pm.globals.unset(\"schema_claim_content\");",
 					"        pm.globals.unset(\"schema_details_content\");",
 					"        pm.globals.unset(\"schema_eresource_content\");",
-					"        pm.globals.unset(\"schema_fund_distribution_content\");",
+					"        pm.globals.unset(\"schema_fundDistribution_content\");",
+					"        pm.globals.unset(\"schema_license_content\");",
 					"        pm.globals.unset(\"schema_location_content\");",
 					"        pm.globals.unset(\"schema_physical_content\");",
 					"        pm.globals.unset(\"schema_renewal_content\");",
 					"        pm.globals.unset(\"schema_reporting_code_content\");",
 					"        pm.globals.unset(\"schema_source_content\");",
-					"        pm.globals.unset(\"schema_vendor_detail_content\");",
+					"        pm.globals.unset(\"schema_vendorDetail_content\");",
 					"        pm.globals.unset(\"schema_metadata_content\");",
-					"        pm.globals.unset(\"schema_po_number_content\");",
-					"        pm.globals.unset(\"schema_order_format_content\");",
-					"        pm.globals.unset(\"schema_receipt_status_content\");",
-					"        pm.globals.unset(\"schema_product_id_type_content\");",
-					"        pm.globals.unset(\"empty_order_id\");",
+					"        pm.globals.unset(\"schema_poNumber_content\");",
+					"        pm.globals.unset(\"schema_orderFormat_content\");",
+					"        pm.globals.unset(\"schema_receiptStatus_content\");",
+					"        pm.globals.unset(\"schema_productIdType_content\");",
+					"        pm.globals.unset(\"emptyOrderId\");",
 					"        pm.globals.unset(\"po_listed_print_monograph\");",
-					"        pm.globals.unset(\"complete_poline_ids\");",
-					"        pm.globals.unset(\"complete_order_id\");",
-					"        pm.globals.unset(\"phys_el_open_order_id\");",
-					"        pm.globals.unset(\"negative_tests_order_id\");",
-					"        pm.globals.unset(\"another_complete_order_id\");",
-					"        pm.globals.unset(\"complete_open_order_id\");",
-					"        pm.globals.unset(\"po_line_for_negative_tests\");",
-					"        pm.globals.unset(\"complete_order_po_number\");",
-					"        pm.globals.unset(\"new_empty_po_line\");",
-					"        pm.globals.unset(\"po_number\");",
+					"        pm.globals.unset(\"completePolineIds\");",
+					"        pm.globals.unset(\"completeOrderId\");",
+					"        pm.globals.unset(\"physElecOpenOrderId\");",
+					"        pm.globals.unset(\"negativeTestsOrderId\");",
+					"        pm.globals.unset(\"anotherCompleteOrderId\");",
+					"        pm.globals.unset(\"completeOpenOrderId\");",
+					"        pm.globals.unset(\"poLineForNegativeTests\");",
+					"        pm.globals.unset(\"completeOrderPoNumber\");",
+					"        pm.globals.unset(\"newEmptyPoLine\");",
+					"        pm.globals.unset(\"poNumber\");",
 					"",
 					"        pm.environment.unset(\"xokapitoken\");",
 					"        pm.environment.unset(\"adjustment_credit_update\");",
@@ -9587,8 +9658,8 @@
 					"        pm.environment.unset(\"adjustment_insurance_update\");",
 					"        pm.environment.unset(\"adjustment_overhead_update\");",
 					"        pm.environment.unset(\"adjustment_shipment_update\");",
-					"        pm.environment.unset(\"adjustment_tax_1_update\");",
-					"        pm.environment.unset(\"adjustment_tax_2_update\");",
+					"        pm.environment.unset(\"adjustment_tax1_update\");",
+					"        pm.environment.unset(\"adjustment_tax2_update\");",
 					"        pm.environment.unset(\"adjustment_update_pro_rate\");",
 					"        pm.environment.unset(\"mod-orders-configs\");",
 					"        pm.environment.unset(\"receivingItemBarcode\");",
@@ -9598,6 +9669,7 @@
 					"     * Internal function to validate object against specified schema",
 					"     */",
 					"    utils._validateAgainstSchema = function(jsonData, schema) {",
+					"        console.log(\"Starting validating against schemas\");",
 					"        utils._addSchemas();",
 					"        var result = tv4.validateMultiple(jsonData, schema);",
 					"        pm.expect(result.valid).to.equal(true, \"Schema validation error: \" + JSON.stringify(result.errors));",
@@ -9617,29 +9689,21 @@
 					"        tv4.addSchema(\"mod-orders-storage/schemas/alert.json\", JSON.parse(globals.schema_alert_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/claim.json\", JSON.parse(globals.schema_claim_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/cost.json\", JSON.parse(globals.schema_cost_content));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/contributor.json\", JSON.parse(globals.schema_contributor_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/details.json\", JSON.parse(globals.schema_details_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/eresource.json\", JSON.parse(globals.schema_eresource_content));",
-					"        tv4.addSchema(\"mod-orders-storage/schemas/fund_distribution.json\", JSON.parse(globals.schema_fund_distribution_content));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/fund_distribution.json\", JSON.parse(globals.schema_fundDistribution_content));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/license.json\", JSON.parse(globals.schema_license_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/location.json\", JSON.parse(globals.schema_location_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/physical.json\", JSON.parse(globals.schema_physical_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/renewal.json\", JSON.parse(globals.schema_renewal_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/reporting_code.json\", JSON.parse(globals.schema_reporting_code_content));",
 					"        tv4.addSchema(\"mod-orders-storage/schemas/source.json\", JSON.parse(globals.schema_source_content));",
-					"        tv4.addSchema(\"mod-orders-storage/schemas/vendor_detail.json\", JSON.parse(globals.schema_vendor_detail_content));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/vendor_detail.json\", JSON.parse(globals.schema_vendorDetail_content));",
 					"        tv4.addSchema(\"raml-util/schemas/metadata.schema\", JSON.parse(globals.schema_metadata_content));",
-					"        tv4.addSchema(\"mod-orders-storage/schemas/order_format.json\", JSON.parse(globals.schema_order_format_content));",
-					"        tv4.addSchema(\"mod-orders-storage/schemas/receipt_status.json\", JSON.parse(globals.schema_receipt_status_content));",
-					"        tv4.addSchema(\"common/schemas/product_id_type.json\", JSON.parse(globals.schema_product_id_type_content));",
-					"    };",
-					"",
-					"    /**",
-					"     * Internal function to delete 'id' and 'po_line_id' in sub-object",
-					"     */",
-					"    utils._deleteSubObjectIds = function(data) {",
-					"        if (data) {",
-					"            delete data.id;",
-					"            delete data.po_line_id;",
-					"        }",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/order_format.json\", JSON.parse(globals.schema_orderFormat_content));",
+					"        tv4.addSchema(\"mod-orders-storage/schemas/receipt_status.json\", JSON.parse(globals.schema_receiptStatus_content));",
+					"        tv4.addSchema(\"common/schemas/product_id_type.json\", JSON.parse(globals.schema_productIdType_content));",
 					"    };",
 					"",
 					"    /**",
@@ -9647,14 +9711,12 @@
 					"     */",
 					"    utils._deleteSubObjectsIds = function(data) {",
 					"        if (data) {",
-					"            for(let i = 0; i < data.length; i++) {",
-					"                utils._deleteSubObjectIds(data[i]);",
-					"            }",
+					"            data.forEach(obj => delete obj.id);",
 					"        }",
 					"    };",
 					"",
 					"    utils.deletePoNumber = function(order) {",
-					"        delete order.po_number;",
+					"        delete order.poNumber;",
 					"",
 					"        return order;",
 					"    };",
@@ -9738,8 +9800,8 @@
 			"type": "string"
 		},
 		{
-			"id": "65885c7c-af3c-4e3c-a59c-f644c19146f7",
-			"key": "schema_fund_distribution",
+			"id": "86bc8fa4-7a5a-4390-a044-600b02f33a5d",
+			"key": "schema_fundDistribution",
 			"value": "fund_distribution.json",
 			"type": "string"
 		},
@@ -9774,20 +9836,20 @@
 			"type": "string"
 		},
 		{
-			"id": "28fe1d0e-890d-4bbb-ae5f-3225f7424309",
-			"key": "schema_vendor_detail",
+			"id": "5224357c-e3d8-4423-85cb-1eee5461a7ef",
+			"key": "schema_vendorDetail",
 			"value": "vendor_detail.json",
 			"type": "string"
 		},
 		{
-			"id": "fc845e50-429c-44e6-abf5-56a256a32257",
-			"key": "schema_order_format",
+			"id": "94aae42d-bc49-4b21-b005-fe64248b9e42",
+			"key": "schema_orderFormat",
 			"value": "order_format.json",
 			"type": "string"
 		},
 		{
-			"id": "486aca6b-4f3c-43d6-baaf-4bb577f755c1",
-			"key": "schema_receipt_status",
+			"id": "0756fadf-70c6-4d4a-919c-18e9f1dd23a4",
+			"key": "schema_receiptStatus",
 			"value": "receipt_status.json",
 			"type": "string"
 		},
@@ -9810,8 +9872,8 @@
 			"type": "string"
 		},
 		{
-			"id": "cc32d61d-bd8f-4ab5-86ad-bedcbd1eed44",
-			"key": "schema_po_number",
+			"id": "7e2ca12b-6e4d-4934-98aa-f714b858dd46",
+			"key": "schema_poNumber",
 			"value": "po_number.json",
 			"type": "string"
 		},
@@ -9835,7 +9897,7 @@
 		},
 		{
 			"id": "33142d57-2ac3-460b-a153-8cbf81fb0922",
-			"key": "schema_product_id_type",
+			"key": "schema_productIdType",
 			"value": "product_id_type.json",
 			"type": "string"
 		},


### PR DESCRIPTION
- MODORDERS-168 Update tests to support schema changes
- MODORDERS-170 Get active vendor to use in tests
  New request added to get active vendor's `id` to use in further requests: Setup/Prepare vendors/Get active vendor

![image](https://user-images.githubusercontent.com/43410167/54203232-e104da00-44e2-11e9-8377-6b75ca98dedd.png)
