### PR TITLE
MODKBEKBJ-202: Update api tests to avoid failures in FSE

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1dd5a0ca-daf9-4f12-b5e8-866f3cbeefc7",
+		"_postman_id": "6279fdc5-cf50-4e08-a44e-7890916e44a1",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1088,7 +1088,7 @@
 									"    ",
 									"    //Test that name matches value passed in",
 									"    pm.test('name matches value passed in', function() {",
-									"        pm.expect(response.data.attributes.name).to.eq('custom packages api test one');",
+									"        pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.variables.get(\"custom-package-one-uuid\"));",
 									"    });",
 									"    ",
 									"    //Test that package type is custom",
@@ -1104,6 +1104,17 @@
 									"    console.log('Custom package not created');",
 									"}",
 									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "e1884122-c31a-406d-a50f-acfac0fb3298",
+								"exec": [
+									"var uuid = require('uuid');",
+									"pm.variables.set(\"custom-package-one-uuid\", uuid.v4());"
 								],
 								"type": "text/javascript"
 							}
@@ -1127,7 +1138,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test one\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t},\n\t\t\t \"tags\": {\n    \t\t\t\"tagList\": [\n    \t\t\t\"foo-tag\"\n\t\t\t\t]\n\t\t\t}\n\t\t}\n\t}\n}"
+							"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t},\n\t\t\t \"tags\": {\n    \t\t\t\"tagList\": [\n    \t\t\t\"foo-tag\"\n\t\t\t\t]\n\t\t\t}\n\t\t}\n\t}\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",
@@ -1182,7 +1193,7 @@
 									"",
 									"    //Test that name matches value passed in",
 									"    pm.test('name matches value passed in', function() {",
-									"        pm.expect(response.data.attributes.name).to.eq('custom packages api test two');",
+									"        pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.variables.get(\"custom-package-two-uuid\"));",
 									"    });",
 									"    ",
 									"    //Test that package type is custom",
@@ -1210,6 +1221,17 @@
 								],
 								"type": "text/javascript"
 							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "cf165d11-165f-4f3b-8ffd-11c238778635",
+								"exec": [
+									"var uuid = require('uuid');",
+									"pm.variables.set(\"custom-package-two-uuid\", uuid.v4());"
+								],
+								"type": "text/javascript"
+							}
 						}
 					],
 					"request": {
@@ -1230,7 +1252,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom packages api test two\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t},\n\t\t\t\"tags\": {\n    \t\t\t\"tagList\": [\n    \t\t\t\"foo-tag\"\n\t\t\t\t]\n\t\t\t}\n\t\t}\n\t}\n}"
+							"raw": "{\n\t\"data\": {\n\t\t\"type\": \"packages\",\n\t\t\"attributes\": {\n\t\t\t\"name\": \"custom-packages-{{custom-package-two-uuid}}\",\n\t\t\t\"contentType\": \"E-Journal\",\n\t\t\t\"customCoverage\": {\n\t\t\t\t\"beginCoverage\": \"2003-01-01\",\n\t\t\t\t\"endCoverage\": \"2003-12-01\"\n\t\t\t},\n\t\t\t\"tags\": {\n    \t\t\t\"tagList\": [\n    \t\t\t\"foo-tag\"\n\t\t\t\t]\n\t\t\t}\n\t\t}\n\t}\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages",


### PR DESCRIPTION
Per https://issues.folio.org/browse/MODKBEKBJ-202, we were seeing various API test failures in mod-kb-ebsco-java when run in Ebsco's CI/CD pipeline. While most of the failures have been addressed in this https://github.com/folio-org/folio-api-tests/pull/118, there were still a few assertions failing. 

Fix those in this PR. 
 
Newman output when run against FSE env:
[output.txt](https://github.com/folio-org/folio-api-tests/files/2989708/output.txt)
