### PR TITLE
MODGOBI-58 Release 1.3.0 - correcting clean up requests

### DIFF
--- a/mod-gobi/mod-gobi.postman_collection.json
+++ b/mod-gobi/mod-gobi.postman_collection.json
@@ -1640,7 +1640,7 @@
 							"script": {
 								"id": "ffb3bd27-ba00-40e0-90ac-7a1558cf2552",
 								"exec": [
-									"pm.globals.set(\"vendorId\", pm.globals.get(\"vendor\").id);"
+									""
 								],
 								"type": "text/javascript"
 							}
@@ -1869,7 +1869,7 @@
 							"script": {
 								"id": "ffb3bd27-ba00-40e0-90ac-7a1558cf2552",
 								"exec": [
-									"pm.globals.set(\"vendorId\", pm.globals.get(\"vendor\").id);"
+									""
 								],
 								"type": "text/javascript"
 							}


### PR DESCRIPTION
## Purpose
Fixing clean up requests
At the moment cleanup requests fail with following error:
![image](https://user-images.githubusercontent.com/43410167/54984190-64342e80-4fbf-11e9-90df-10f6db632573.png)

## Approach
`vendorId` is set as environment variable after vendor is created by `/vendor-storage/vendors  - POST GOBI Vendor` request from `Test Setup` folder

To fix clean up requests the content of `Pre-request Script` section is removed for `/vendor-storage/vendors - Delete created Vendor` and `Order with overrides` requests from `Cleanup` folder

![image](https://user-images.githubusercontent.com/43410167/54984603-3dc2c300-4fc0-11e9-9d62-123e6a1c95c3.png)
