### PR TITLE
Adding vendor_status while creating a GOBI vendor

### DIFF
--- a/mod-gobi/mod-gobi.postman_collection.json
+++ b/mod-gobi/mod-gobi.postman_collection.json
@@ -106,7 +106,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"GOBI Library Systems\",\n  \"code\": \"GOBI\"\n}"
+							"raw": "{\n  \"name\": \"GOBI Library Systems\",\n  \"code\": \"GOBI\"\n, \n  \"vendor_status\": \"Active\"}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/vendor-storage/vendors",


### PR DESCRIPTION
## PURPOSE
While testing the GOBI API tests it was observed that mod-orders is timing out with 504, if a vendor_status field is not present while placing an order. 

## APPROACH
Though https://issues.folio.org/browse/MODORDERS-203 was created to address the issue. 
Adding the field in order to get the API tests working

##TODO
- [x] To add this fix the ACQ-Q1-2019 branch that was created for Q1
