### PR TITLE
MODORDERS-195- Add material types to each resource

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "88e3761d-94c2-4b21-b5f0-57e4777b92f4",
-		"name": "mod-orders",
+		"_postman_id": "27da0d38-8063-4fdc-87be-a7579953747c",
+		"name": "mod-orders copy",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1495,6 +1495,73 @@
 										"vendors"
 									]
 								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Get Prerequisite Data",
+					"item": [
+						{
+							"name": "Get Material Types",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Successfully retrieved Material types\", function () {",
+											"    pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    jsonData = pm.response.json();",
+											"});",
+											"});  ",
+											"",
+											"pm.test(\"PO Lines and corresponding Inventory entities exist\", function () {",
+											"    pm.globals.set(\"materialType\", jsonData.mtypes[0].id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/material-types",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"material-types"
+									]
+								},
+								"description": "Get material types to be used accross the orders while interaction with inventory"
 							},
 							"response": []
 						}
@@ -3262,7 +3329,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": \"268758test2\",\n  \"reEncumber\": false,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poLineId}}\",\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"{{currencyUpdate}}\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"ISBN\"\n          }\n        ],\n        \"materialTypes\": [\n          \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityElectronic\": 0,\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": \"268758test2\",\n  \"reEncumber\": false,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poLineId}}\",\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"{{currencyUpdate}}\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"ISBN\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityElectronic\": 0,\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
@@ -3371,7 +3438,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": {{completeOrderPoNumber}},\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"additionalCost\": {{additionalCostUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"USD\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"ISBN\"\n          }\n        ],\n        \"materialTypes\": [\n          \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": {{completeOrderPoNumber}},\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"additionalCost\": {{additionalCostUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"USD\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"ISBN\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
@@ -4050,6 +4117,7 @@
 											"    order.compositePoLines[1].orderFormat = \"Other\";",
 											"    setPhysicalInfo(order.compositePoLines[1]);",
 											"    ",
+											"    pendingOrder.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
 											"    // add 2 new PO lines",
 											"    pendingOrder.compositePoLines = pendingOrder.compositePoLines.concat(order.compositePoLines);",
 											"    // Set Open status",
@@ -4072,7 +4140,11 @@
 											"    line.cost.quantityPhysical = total;",
 											"    line.cost.listUnitPrice = 10.5;",
 											"    if (!line.hasOwnProperty(\"physical\")) {",
-											"        line.physical = {};",
+											"        line.physical = {",
+											"            \"materialType\": pm.globals.get(\"materialType\")",
+											"        };",
+											"    }else{",
+											"         line.physical.materialType=pm.globals.get(\"materialType\");",
 											"    }",
 											"}"
 										],
@@ -4347,6 +4419,9 @@
 											"    // Set new product ids to be sure that new instances will be created",
 											"    order.compositePoLines[0].details.productIds[0].productId = \"97807643541133\";",
 											"    order.compositePoLines[1].details.productIds[0].productId = \"97807643541134\";",
+											"    ",
+											"    //set proper material Type",
+											"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
 											"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(order));",
 											"});"
 										],
@@ -4523,8 +4598,13 @@
 											"let utils = eval(globals.loadUtils);",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_one_physical_one_electronic_lines.json\", (err, res) => {",
-											"    pm.variables.set(\"po_one_physical_one_electronic_lines\", JSON.stringify(utils.prepareOrder(res.json())));",
-											"});"
+											"    let order = utils.prepareOrder(res.json());",
+											"     order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
+											"     order.compositePoLines[1].eresource.materialType=pm.globals.get(\"materialType\");",
+											"    pm.variables.set(\"po_one_physical_one_electronic_lines\", JSON.stringify(order));",
+											"});",
+											"",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -4875,6 +4955,8 @@
 											"    order.compositePoLines[0].checkinItems = false;",
 											"    order.compositePoLines[1].checkinItems = false;",
 											"    order = utils.deletePoNumber(order);",
+											"    //set proper material Type ",
+											"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
 											"    pm.globals.set(\"po_listed_print_monograph_receiving_history\", JSON.stringify(utils.prepareOrder(order)));",
 											"});"
 										],
@@ -5048,6 +5130,8 @@
 											"    order.compositePoLines[0].details.productIds[0].productId = \"97807643541131\";",
 											"    order.compositePoLines[1].details.productIds[0].productId = \"97807643541132\";",
 											"    ",
+											"    //set proper material Type",
+											"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
 											"    ",
 											"    pm.globals.set(\"po_listed_print_monograph_with_checking_items_true\", JSON.stringify(utils.prepareOrder(order)));",
 											"});"
@@ -6575,6 +6659,12 @@
 													"    let order  = res.json();",
 													"    order.workflowStatus = \"Pending\";",
 													"    order.compositePoLines[0].orderFormat = \"P/E Mix\";",
+													"    ",
+													"    //put proper material type",
+													"    order.compositePoLines[0].eresource.materialType=pm.globals.get(\"materialType\");",
+													"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
+													"    order.compositePoLines[1].eresource.materialType=pm.globals.get(\"materialType\");",
+													"    ",
 													"    order = utils.deletePoNumber(order);",
 													"    // Set retrieved content for further requests",
 													"    pm.variables.set(\"poListedPrintMonographPiece\", JSON.stringify(utils.prepareOrder(order)));",
@@ -7441,7 +7531,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"ISBN\"\n                    }\n                ],\n                \"materialTypes\": [\n                    \"1a54b431-2e4f-452d-9cae-9cee66c9a892\"\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"eresource\": {\n                \"createInventory\": \"Instance, Holding, Item\"\n            },\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"f34d27c6-a8eb-461b-acd6-5dea81771e70\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ]\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"poLineNumber\": \"10011-2\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": {\n                \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n                \"description\": \"ABCDEFGHIJKLMNO\"\n            },\n            \"tags\": [\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFG\",\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFGHIJKLMNO\"\n            ],\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ],\n    \"metadata\": {\n        \"createdDate\": \"2019-03-26T20:17:56.245+0000\",\n        \"createdByUserId\": \"a867202f-4045-576c-8152-cb02220c6393\",\n        \"updatedDate\": \"2019-03-26T20:17:56.245+0000\",\n        \"updatedByUserId\": \"a867202f-4045-576c-8152-cb02220c6393\"\n    }\n}"
+											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"ISBN\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"f34d27c6-a8eb-461b-acd6-5dea81771e70\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialType}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": {\n                \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n                \"description\": \"ABCDEFGHIJKLMNO\"\n            },\n            \"tags\": [\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFG\",\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFGHIJKLMNO\"\n            ],\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -8307,6 +8397,8 @@
 													"    //remove createInventory value",
 													"    delete order.compositePoLines[0].eresource.createInventory;",
 													"    delete order.compositePoLines[0].physical.createInventory;",
+													"    ",
+													"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
 													"",
 													"    pm.variables.set(\"orderWithCreateInventoryNull1\", JSON.stringify(utils.prepareOrder(order)));",
 													"});"
@@ -8774,6 +8866,10 @@
 											"    //set createInventory value",
 											"    order.compositePoLines[0].eresource.createInventory = \"Instance, Holding, Item\";",
 											"    order.compositePoLines[0].physical.createInventory = \"Instance, Holding, Item\";",
+											"    ",
+											"    //put proper material type",
+											"    order.compositePoLines[0].eresource.materialType = pm.globals.get(\"materialType\");",
+											"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
 											"    ",
 											"    pm.globals.set(\"orderWithCreateInventoryInstanceHoldingItem\", JSON.stringify(utils.prepareOrder(order)));",
 											"});"
@@ -14075,7 +14171,21 @@
 					"            \"purchaseOrderId\": orderId,",
 					"            \"source\": {",
 					"                \"code\": \"FOLIO\"",
-					"            }",
+					"            },",
+					"            \"orderFormat\": \"Physical Resource\",",
+					"            \"physical\":{",
+					"\t             \"createInventory\": \"None\"",
+					"\t        },",
+					"\t        \"cost\":{",
+					"\t            \"currency\":\"USD\",",
+					"\t            \"listUnitPrice\": 1,",
+					"\t            \"quantityPhysical\":1",
+					"\t        },",
+					"\t        \"locations\":[{",
+					"\t            \"locationId\": \"00e761ce-68a6-44ac-8a1f-3257a847b027\",",
+					"\t            \"quantityPhysical\":1",
+					"\t        }",
+					"\t        ]",
 					"        };",
 					"    };",
 					"",
@@ -14486,7 +14596,7 @@
 					"                quantity += utils.isItemsUpdateRequiredForEresource(poLine) ? utils.getElectronicItemsQuantity(poLine) : 0;",
 					"                return quantity;",
 					"            case \"Other\":",
-					"                quantity += utils.isItemsUpdateRequiredForPhysical(poLine) ? utils.getElectronicItemsQuantity(poLine) : 0;",
+					"                quantity += utils.isItemsUpdateRequiredForPhysical(poLine) ? utils.getPhysicalItemsQuantity(poLine) : 0;",
 					"                return quantity;",
 					"            default:",
 					"                return 0;",
@@ -14636,22 +14746,21 @@
 					"    utils.validatePoLineWithMinimalContent = function(poLine) {",
 					"        pm.expect(poLine.id, \"PO line id expected\").to.exist;",
 					"        pm.expect(poLine.purchaseOrderId, \"PO id expected\").to.exist;",
-					"        pm.expect(poLine.source, \"source not expected\").to.exist;",
+					"        pm.expect(poLine.source, \"source expected\").to.exist;",
 					"        pm.expect(poLine.acquisitionMethod, \"acquisitionMethod not expected\").to.not.exist;",
 					"        pm.expect(poLine.alerts, \"alerts should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.cancellationRestriction, \"cancellationRestriction not expected\").to.not.exist;",
 					"        pm.expect(poLine.cancellationRestrictionNote, \"cancellationRestrictionNote not expected\").to.not.exist;",
 					"        pm.expect(poLine.claims, \"claims should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.contributors, \"contributors should be empty\").to.be.an('array').that.is.empty;",
-					"        pm.expect(poLine.cost, \"cost not expected\").to.not.exist;",
+					"        pm.expect(poLine.cost, \"cost expected\").to.exist;",
 					"        pm.expect(poLine.description, \"description not expected\").to.not.exist;",
 					"        pm.expect(poLine.donor, \"donor not expected\").to.not.exist;",
 					"        pm.expect(poLine.fundDistribution, \"fundDistribution should be empty\").to.be.an('array').that.is.empty;",
-					"        pm.expect(poLine.locations, \"locations should be empty\").to.be.an('array').that.is.empty;",
-					"        pm.expect(poLine.orderFormat, \"orderFormat not expected\").to.not.exist;",
+					"        pm.expect(poLine.locations, \"locations should be present\").to.be.an('array').that.is.not.empty;",
+					"        pm.expect(poLine.orderFormat, \"orderFormat expected\").to.exist;",
 					"        pm.expect(poLine.owner, \"owner not expected\").to.not.exist;",
 					"        pm.expect(poLine.paymentStatus, \"paymentStatus not expected\").to.not.exist;",
-					"        pm.expect(poLine.physical, \"physical not expected\").to.not.exist;",
 					"        pm.expect(poLine.poLineDescription, \"poLineDescription not expected\").to.not.exist;",
 					"        pm.expect(poLine.poLineNumber, \"poLineNumber is expected\").to.exist;",
 					"        pm.expect(poLine.publicationDate, \"publicationDate not expected\").to.not.exist;",
@@ -14972,7 +15081,7 @@
 					"            if (line.instanceId) {",
 					"                utils.sendGetRequest(\"/instance-storage/instances/\" + line.instanceId, (err, res) => {",
 					"                    resolve();",
-					"                    pm.test(\"No Instance Record found for PO Line with id=\" + line.id, function() {",
+					"                    pm.test(\"No Instance Record found for PO Line with id=\" + line.id + \" and instance id=\"+line.instanceId, function() {",
 					"                        pm.expect(res.code).to.eql(404);",
 					"                    });",
 					"                });",

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "27da0d38-8063-4fdc-87be-a7579953747c",
-		"name": "mod-orders copy",
+		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -4117,7 +4117,7 @@
 											"    order.compositePoLines[1].orderFormat = \"Other\";",
 											"    setPhysicalInfo(order.compositePoLines[1]);",
 											"    ",
-											"    pendingOrder.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
+											"    pendingOrder.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
 											"    // add 2 new PO lines",
 											"    pendingOrder.compositePoLines = pendingOrder.compositePoLines.concat(order.compositePoLines);",
 											"    // Set Open status",
@@ -4144,7 +4144,7 @@
 											"            \"materialType\": pm.globals.get(\"materialType\")",
 											"        };",
 											"    }else{",
-											"         line.physical.materialType=pm.globals.get(\"materialType\");",
+											"         line.physical.materialType = pm.globals.get(\"materialType\");",
 											"    }",
 											"}"
 										],
@@ -4421,7 +4421,7 @@
 											"    order.compositePoLines[1].details.productIds[0].productId = \"97807643541134\";",
 											"    ",
 											"    //set proper material Type",
-											"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
+											"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
 											"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(order));",
 											"});"
 										],
@@ -4599,8 +4599,8 @@
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_one_physical_one_electronic_lines.json\", (err, res) => {",
 											"    let order = utils.prepareOrder(res.json());",
-											"     order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
-											"     order.compositePoLines[1].eresource.materialType=pm.globals.get(\"materialType\");",
+											"     order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
+											"     order.compositePoLines[1].eresource.materialType = pm.globals.get(\"materialType\");",
 											"    pm.variables.set(\"po_one_physical_one_electronic_lines\", JSON.stringify(order));",
 											"});",
 											"",
@@ -4956,7 +4956,7 @@
 											"    order.compositePoLines[1].checkinItems = false;",
 											"    order = utils.deletePoNumber(order);",
 											"    //set proper material Type ",
-											"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
+											"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
 											"    pm.globals.set(\"po_listed_print_monograph_receiving_history\", JSON.stringify(utils.prepareOrder(order)));",
 											"});"
 										],
@@ -5131,7 +5131,7 @@
 											"    order.compositePoLines[1].details.productIds[0].productId = \"97807643541132\";",
 											"    ",
 											"    //set proper material Type",
-											"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
+											"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
 											"    ",
 											"    pm.globals.set(\"po_listed_print_monograph_with_checking_items_true\", JSON.stringify(utils.prepareOrder(order)));",
 											"});"
@@ -6661,9 +6661,9 @@
 													"    order.compositePoLines[0].orderFormat = \"P/E Mix\";",
 													"    ",
 													"    //put proper material type",
-													"    order.compositePoLines[0].eresource.materialType=pm.globals.get(\"materialType\");",
-													"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
-													"    order.compositePoLines[1].eresource.materialType=pm.globals.get(\"materialType\");",
+													"    order.compositePoLines[0].eresource.materialType = pm.globals.get(\"materialType\");",
+													"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
+													"    order.compositePoLines[1].eresource.materialType = pm.globals.get(\"materialType\");",
 													"    ",
 													"    order = utils.deletePoNumber(order);",
 													"    // Set retrieved content for further requests",
@@ -8398,7 +8398,7 @@
 													"    delete order.compositePoLines[0].eresource.createInventory;",
 													"    delete order.compositePoLines[0].physical.createInventory;",
 													"    ",
-													"    order.compositePoLines[0].physical.materialType=pm.globals.get(\"materialType\");",
+													"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
 													"",
 													"    pm.variables.set(\"orderWithCreateInventoryNull1\", JSON.stringify(utils.prepareOrder(order)));",
 													"});"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -14760,7 +14760,7 @@
 					"        pm.expect(poLine.locations, \"locations should be present\").to.be.an('array').that.is.not.empty;",
 					"        pm.expect(poLine.orderFormat, \"orderFormat expected\").to.exist;",
 					"        pm.expect(poLine.owner, \"owner not expected\").to.not.exist;",
-					"        pm.expect(poLine.paymentStatus, \"paymentStatus not expected\").to.not.exist;",
+					"        pm.expect(poLine.paymentStatus, \"paymentStatus expected\").to.exist;",
 					"        pm.expect(poLine.poLineDescription, \"poLineDescription not expected\").to.not.exist;",
 					"        pm.expect(poLine.poLineNumber, \"poLineNumber is expected\").to.exist;",
 					"        pm.expect(poLine.publicationDate, \"publicationDate not expected\").to.not.exist;",


### PR DESCRIPTION
## PURPOSE
https://issues.folio.org/browse/MODORDERS-195 - To add material type to each resource separately

## APPROACH

- Added a new test in setup to fetch the existing material type from /material-types API, so that tests can run and create items independent of environment
- Changed all test cases to utilize the material type obtained from the API
- Changed validations relating to the required fields

ADDITIONAL CHANGES
Fixed issues with calculating inventory items quantity for "Other"


Verified against folio-testing
<img width="1278" alt="Screen Shot 2019-04-11 at 1 39 34 AM" src="https://user-images.githubusercontent.com/41596468/55933933-fc0b5c80-5bfc-11e9-984f-16845bd51562.png">
