### PR TITLE
MODNOTES-81 API Tests for GET /note-types/{typeId}

### DIFF
--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -5821,7 +5821,7 @@
 									"response": []
 								},
 								{
-									"name": "/notes?offset=-2147483649 - 400 (offset less than Integer.MIN_VALUE)",
+									"name": "/note-types?offset=-2147483649 - 400 (offset less than Integer.MIN_VALUE)",
 									"event": [
 										{
 											"listen": "test",
@@ -5856,14 +5856,14 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes?offset=-2147483649",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types?offset=-2147483649",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
 											],
 											"port": "{{okapiport}}",
 											"path": [
-												"notes"
+												"note-types"
 											],
 											"query": [
 												{
@@ -6292,6 +6292,452 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "GET note-types by id",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "/note-types/{noteTypeId} - 200",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "e8c8c16a-7bf6-47c0-9321-16c30c41a6c1",
+												"exec": [
+													"pm.test(\"success test - 200 and JSON body\", function() {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"   pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_noteTypeItem\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"validate data\", function() {",
+													"    pm.expect(response.id).to.equal(pm.environment.get(\"noteTypeId\"), \"id does not match\");",
+													"    pm.expect(response.name).to.equal(pm.environment.get(\"noteTypeName\"), \"name does not match\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "0dd47a4b-2c8e-4fb9-8fc3-3a75ba8d776e",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{noteTypeId}}"
+											]
+										},
+										"description": "Returns an existing note-types via a collection"
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "0dd3ff7e-2ace-4327-8389-88f2e2382ee2",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a4c0753b-8408-4aad-bffc-0251c1255f4d",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "/note-types/{id} - 400 (invalid id format in URL)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "3c311bd3-3072-4897-9763-6910c868d89e",
+												"exec": [
+													"pm.test(\"500 test - invalid id format in URL\", function() {",
+													"    pm.response.to.have.status(500);",
+													"    pm.response.to.have.body();",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "9a7071e2-187d-4496-9cd3-442d978289d8",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/12345",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"12345"
+											]
+										},
+										"description": "Returns an existing note with an invalid id format"
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id}?lang= - 400 (empty lang)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "aeb905b1-c769-4098-8a08-dbf039375edc",
+												"exec": [
+													"pm.test(\"400 test - empty lang\", function() {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"Response having negative limit parameter error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"\\n 'lang' parameter is incorrect. parameter value {} is not valid: must match \\\"[a-zA-Z]{2}\\\"\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{$guid}}?lang=",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{$guid}}"
+											],
+											"query": [
+												{
+													"key": "lang",
+													"value": ""
+												}
+											]
+										},
+										"description": "Failure case where the \"lang\" query parameter is empty."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id}?lang=A1 - 400 (bad lang)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "508c294a-9bd8-4191-b222-19d75ee89c95",
+												"exec": [
+													"pm.test(\"400 test - bad lang\", function() {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"Response having negative limit parameter error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"\\n 'lang' parameter is incorrect. parameter value {A1} is not valid: must match \\\"[a-zA-Z]{2}\\\"\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{$guid}}?lang=A1",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{$guid}}"
+											],
+											"query": [
+												{
+													"key": "lang",
+													"value": "A1"
+												}
+											]
+										},
+										"description": "Failure case where the \"lang\" query parameter is invalid. It should be [a-zA-Z]{2}."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - 403",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "5ee448c2-4b9b-493f-99f8-fe1644cf5c80",
+												"exec": [
+													"pm.test(\"403 test\", function() {",
+													"    pm.response.to.have.status(403);",
+													"    pm.response.to.have.body();",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "fc943a45-a2da-462c-8910-3746fa12cf63",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{$guid}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{$guid}}"
+											]
+										},
+										"description": "Failure test for a user missing the required permission."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - 404",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "ec2c712e-07cf-4077-903c-915fc8f89511",
+												"exec": [
+													"pm.test(\"404 test\", function() {",
+													"    pm.response.to.have.status(404);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"Response having error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"Not found\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "9a7071e2-187d-4496-9cd3-442d978289d8",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{$guid}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{$guid}}"
+											]
+										},
+										"description": "Returns an existing note with an unknown id"
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "82825c43-05bd-4a45-b666-c8eb36cc9352",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3db315ee-8292-4f84-92fd-e0fa6a6d1ed1",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -6311,7 +6757,9 @@
 						"id": "cf476f90-4123-4dc7-9ce1-3c9eddec1a2b",
 						"type": "text/javascript",
 						"exec": [
-							" tv4.addSchema(\"schema_noteTypeItem.json\", pm.environment.get(\"schema_noteTypeItem\"));"
+							" tv4.addSchema(\"schema_noteTypeItem.json\", pm.environment.get(\"schema_noteTypeItem\"));",
+							" tv4.addSchema(\"schema_noteTypeUsage.json\", pm.environment.get(\"schema_noteTypeUsage\"));",
+							" tv4.addSchema(\"schema_metadata.schema\", pm.environment.get(\"schema_metadata\"));"
 						]
 					}
 				}


### PR DESCRIPTION
## Purpose
Covering /note-types endpoint by tests.
https://issues.folio.org/browse/MODNOTES-81
## Approach
Creating API tests for note-type by id endpoint.