### PR TITLE
MODNOTES-80 API Tests for POST /note-types

### DIFF
--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -324,7 +324,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"name\": \"Test Priority - {{noteType-uuid}}\"\r\n}"
+							"raw": "{\r\n  \"name\": \"Test - {{noteType-uuid}}\"\r\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
@@ -404,7 +404,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"name\": \"TestTwo Priority - {{noteType-uuid}}\"\r\n}"
+							"raw": "{\r\n  \"name\": \"TestTwo - {{noteType-uuid}}\"\r\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
@@ -6294,6 +6294,919 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "POST note-types",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "/note-types - 201",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "d2c58203-5ec6-4cab-969f-6a3d088bd3f3",
+												"exec": [
+													"var uuid = require('uuid');",
+													"pm.variables.set(\"noteType-uuid\", uuid.v4());"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "9892fde5-887e-4dec-87b2-3aae99c4742b",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.have.status(201);",
+													"    pm.response.to.be.json;",
+													"    pm.response.to.have.header(\"Location\");",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													" pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_noteTypeItem\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test('expected attributes are present', function() {",
+													"    pm.expect(response).to.be.an('object');",
+													"    pm.expect(response).to.include.all.keys(\"id\", \"name\");",
+													"});",
+													"    ",
+													"//Test that name matches",
+													"pm.test('Name matches value passed in', function() {",
+													"    pm.expect(response.name).to.eq('Note-Type - ' + pm.variables.get('noteType-uuid'));",
+													"});",
+													"",
+													"if(response.id){",
+													"pm.environment.set(\"noteTypeId-creating-in-post\", response.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"name\": \"Note-Type - {{noteType-uuid}}\"\r\n}\r\n"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note"
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 201 (ignore read only fields)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "489cefc9-561e-4e0a-9ea8-a535867f5859",
+												"exec": [
+													"var uuid = require('uuid');",
+													"",
+													"pm.variables.set(\"createDate\", \"2001-01-01T19:18:27.437+0000\");",
+													"pm.variables.set(\"createUser\", uuid.v4());",
+													"pm.variables.set(\"updateDate\", \"2001-02-02T18:17:21.427+0000\");",
+													"pm.variables.set(\"updateUser\", uuid.v4());"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "363e43fd-a2ba-467d-8b4d-4670122c4043",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.have.status(201);",
+													"    pm.response.to.be.json;",
+													"    pm.response.to.have.header(\"Location\");",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													" pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_noteTypeItem\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test('expected attributes are present', function() {",
+													"    pm.expect(response).to.be.an('object');",
+													"    pm.expect(response).to.include.all.keys(\"id\", \"name\");",
+													"});",
+													"    ",
+													"//Test that name matches",
+													"pm.test('Name matches value passed in', function() {",
+													"    pm.expect(response.name).to.eq('Creating Second NoteType');",
+													"});",
+													"",
+													"if(response.id){",
+													"pm.environment.set(\"noteTypeId-creating-in-post-second\", response.id);",
+													"}",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\": \"Creating Second NoteType\",\n    \"metadata\": {\n        \"createdDate\": \"{{createDate}}\",\n        \"createdByUserId\": \"{{createUser}}\",\n        \"updatedDate\": \"{{updateDate}}\",\n        \"updatedByUserId\": \"{{updateUser}}\"\n    }\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note with read only fields set. These will be replaced with server side enforced values. The read only values will be ignored and note creation will succeed."
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "/note-types - 400 (already existing note-type)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "50e4af93-4308-4650-b077-2ea16c8d2a27",
+												"exec": [
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"name\": \"Creating Second NoteType\"\r\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 400 (bad JSON)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "d2c58203-5ec6-4cab-969f-6a3d088bd3f3",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "47249d58-d9fe-4c06-b174-bb8c46778178",
+												"exec": [
+													"pm.test(\"400 - bad JSON\", function() {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.have.body();",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Bad Json\"\n"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note with invalid JSON."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 400 (no body)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "98af75d3-f8fd-43e3-87ef-9713cde5fc63",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "85d07ea2-1cbd-4c69-bfcd-22bc4792b46c",
+												"exec": [
+													"pm.test(\"400 - no body\", function() {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"Response having error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"Json content error HV000116: The object to be validated must not be null.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note with no body."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 400 (wrong content-type)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "98af75d3-f8fd-43e3-87ef-9713cde5fc63",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "85d07ea2-1cbd-4c69-bfcd-22bc4792b46c",
+												"exec": [
+													"pm.test(\"400 - no body\", function() {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"Response having error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"Content-type header must be [\\\"application/json\\\"] but it is \\\"application/xml\\\"\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/xml"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note with the wrong content type header."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types?lang= - 400 (empty lang)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "b4eb31aa-fd01-42bd-889f-8d45f89b86a6",
+												"exec": [
+													"pm.test(\"400 test - empty lang\", function() {",
+													"    pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"Response having negative lang parameter error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"\\n 'lang' parameter is incorrect. parameter value {} is not valid: must match \\\"[a-zA-Z]{2}\\\"\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "e76c1f39-e634-4afc-a603-c482f7ee0ffe",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Empty Lang\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types?lang=",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											],
+											"query": [
+												{
+													"key": "lang",
+													"value": ""
+												}
+											]
+										},
+										"description": "Failure case where the \"lang\" query parameter is empty."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types?lang=A1 - 400 (bad lang)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "46027576-3136-4e2e-aa98-cff058f7668c",
+												"exec": [
+													"pm.test(\"400 test - bad lang\", function() {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"Response having negative lang parameter error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"\\n 'lang' parameter is incorrect. parameter value {A1} is not valid: must match \\\"[a-zA-Z]{2}\\\"\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "9a4fa2d9-1ca3-466d-9344-87f789ce83b7",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Wrong Lang\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types?lang=A1",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											],
+											"query": [
+												{
+													"key": "lang",
+													"value": "A1"
+												}
+											]
+										},
+										"description": "Failure case where the \"lang\" query parameter is invalid. It should be [a-zA-Z]{2}."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 403",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "6bc0c240-5aad-45d2-84e5-c23c7f9ccd87",
+												"exec": [
+													"pm.test(\"403 test\", function() {",
+													"    pm.response.to.have.status(403);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"validate permission\", function() {",
+													"    pm.expect(pm.response.text()).to.include(\"note.types.item.post\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "a7dd8211-8177-4859-a0b5-7f6b8114f935",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Forbidden Access\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Failure test for a user missing the required permission."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 422 (empty JSON)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "dcdb7118-883d-4c89-a2c7-560672229ad7",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "f4e71988-38dc-47dd-b8f2-bdb44975b9c7",
+												"exec": [
+													"pm.test(\"422 - missing text field\", function() {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"   pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_errors\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note with an empty JSON body."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 422 (unknown field)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "9d64c5c0-aa66-470a-a622-01b26b186f3f",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "2e75c0f3-53e7-4bbf-900e-3a175d80b399",
+												"exec": [
+													"pm.test(\"422 - missing text field\", function() {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"   pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_errors\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"InvalidName\" : \"Invalid name\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note with JSON body containing an unknown field."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types - 422 (unknown metadata field)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "aaa94bf3-30a7-4bd4-b873-83e8bb420e63",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "cacf3aec-fdb5-4d5c-b4ec-8753466a3932",
+												"exec": [
+													"pm.test(\"422 - unknown metadata field\", function() {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"   pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_errors\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\": \"Invalid metadata\",\n\t\"metadata\": {\n\t\t\"xyzzy\": \"867-5309\"\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types"
+											]
+										},
+										"description": "Create a new note with JSON body containing an unknown metadata field."
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "8544f7e4-03ea-4d81-af2e-2a71e8eab0a5",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "9d3290ae-11b6-45f3-b73b-221b4c9df8e2",
+								"type": "text/javascript",
+								"exec": [
+									" tv4.addSchema(\"schema_metadata.schema\", pm.environment.get(\"schema_metadata\"));",
+									" tv4.addSchema(\"schema_userDisplayInfo.json\", pm.environment.get(\"schema_userDisplayInfo\"));",
+									" tv4.addSchema(\"schema_link.json\", pm.environment.get(\"schema_link\"));",
+									" tv4.addSchema(\"schema_error.schema\", pm.environment.get(\"schema_error\"));",
+									" "
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "GET note-types by id",
 					"item": [
 						{
@@ -6757,9 +7670,7 @@
 						"id": "cf476f90-4123-4dc7-9ce1-3c9eddec1a2b",
 						"type": "text/javascript",
 						"exec": [
-							" tv4.addSchema(\"schema_noteTypeItem.json\", pm.environment.get(\"schema_noteTypeItem\"));",
-							" tv4.addSchema(\"schema_noteTypeUsage.json\", pm.environment.get(\"schema_noteTypeUsage\"));",
-							" tv4.addSchema(\"schema_metadata.schema\", pm.environment.get(\"schema_metadata\"));"
+							" tv4.addSchema(\"schema_noteTypeItem.json\", pm.environment.get(\"schema_noteTypeItem\"));"
 						]
 					}
 				}
@@ -6895,6 +7806,138 @@
 							"path": [
 								"note-types",
 								"{{noteTypeIdSecond}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE note-type created in post",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "28b5c6af-1d14-4c12-bf64-4ad6b13b3c1e",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d7912ab7-5630-4a3c-9608-c03a42bed5fe",
+								"exec": [
+									"//Check that status is 204",
+									"pm.test(\"Status is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Okapi-Token",
+								"type": "text",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "X-Okapi-Tenant",
+								"type": "text",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId-creating-in-post}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"note-types",
+								"{{noteTypeId-creating-in-post}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE note-type created in post second time",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "28b5c6af-1d14-4c12-bf64-4ad6b13b3c1e",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d7912ab7-5630-4a3c-9608-c03a42bed5fe",
+								"exec": [
+									"//Check that status is 204",
+									"pm.test(\"Status is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Okapi-Token",
+								"type": "text",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "X-Okapi-Tenant",
+								"type": "text",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId-creating-in-post-second}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"note-types",
+								"{{noteTypeId-creating-in-post-second}}"
 							]
 						}
 					},


### PR DESCRIPTION
## Purpose 
Covering /note-types endpoint by tests.
https://issues.folio.org/browse/MODNOTES-80

## Approach
Creating API tests for note-type by id endpoint.