### PR TITLE
MODORDERS-211 Order Status: Align POL Payment and Receipt status withPO Status when opening order

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "27da0d38-8063-4fdc-87be-a7579953747c",
+		"_postman_id": "e4102c55-b9f2-4f9d-86a9-c9828da8c67a",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -3876,7 +3876,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"poNumber\": \"{{poNumber}}\"\n}"
+											"raw": "{\n\t\"poNumber\": \"{{poNumber}}\",\n\t\"vendor\": \"{{activeVendorId}}\"\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
@@ -4122,6 +4122,7 @@
 											"    pendingOrder.compositePoLines = pendingOrder.compositePoLines.concat(order.compositePoLines);",
 											"    // Set Open status",
 											"    pendingOrder.workflowStatus = \"Open\";",
+											"    pendingOrder.compositePoLines.forEach(poLine => poLine.paymentStatus = \"Pending\");",
 											"    pm.variables.set(\"request_body\", JSON.stringify(pendingOrder));",
 											"    pm.globals.unset(\"another_complete_order_content\");",
 											"});",
@@ -4172,6 +4173,7 @@
 											"        utils.validatePoLines(order, 4, true);",
 											"        //check status changed",
 											"        order.compositePoLines.forEach(line => utils.validateReceiptStatus(line, \"Awaiting Receipt\"));",
+											"        order.compositePoLines.forEach(line => utils.validatePaymentStatus(line, \"Awaiting Payment\"));",
 											"    });",
 											"});"
 										],
@@ -4419,7 +4421,7 @@
 											"    // Set new product ids to be sure that new instances will be created",
 											"    order.compositePoLines[0].details.productIds[0].productId = \"97807643541133\";",
 											"    order.compositePoLines[1].details.productIds[0].productId = \"97807643541134\";",
-											"    ",
+											"    order.compositePoLines.forEach(poLine => poLine.paymentStatus = \"Partially Paid\");",
 											"    //set proper material Type",
 											"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
 											"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(order));",
@@ -4448,6 +4450,7 @@
 											"});",
 											"",
 											"jsonData.compositePoLines.forEach(line => utils.validateReceiptStatus(line, \"Awaiting Receipt\"));",
+											"jsonData.compositePoLines.forEach(line => utils.validatePaymentStatus(line, \"Partially Paid\"));",
 											"utils.verifyOrderCalculatedInfo(jsonData);",
 											"",
 											"pm.test(\"Each order has these optional fields\", function() {",
@@ -4629,6 +4632,7 @@
 											"    pm.globals.set(\"OpenOrderPEPol1\", pm.response.json().compositePoLines[0].id); ",
 											"    pm.globals.set(\"OpenOrderPEPol2\", pm.response.json().compositePoLines[1].id);    ",
 											"    order.compositePoLines.forEach(line => utils.validateReceiptStatus(line, \"Awaiting Receipt\"));",
+											"    order.compositePoLines.forEach(line => utils.validatePaymentStatus(line, \"Fully Paid\"));",
 											"});"
 										],
 										"type": "text/javascript"
@@ -4776,6 +4780,7 @@
 											"        order = utils.deletePoNumber(order);",
 											"        for(var i = 0; i < order.compositePoLines.length; i++) {",
 											"    \t  order.compositePoLines[i].receiptStatus = \"Receipt Not Required\";",
+											"    \t  order.compositePoLines[i].paymentStatus = \"Pending\";",
 											"        }",
 											"        ",
 											"        pm.globals.set(\"order_with_receipt_not_required_lines\", JSON.stringify(utils.prepareOrder(order)));",
@@ -4805,6 +4810,7 @@
 											"});",
 											"",
 											"jsonData.compositePoLines.forEach(line => utils.validateReceiptStatus(line, \"Receipt Not Required\"));",
+											"jsonData.compositePoLines.forEach(line => utils.validatePaymentStatus(line, \"Awaiting Payment\"));",
 											"",
 											"pm.test(\"Each order has these optional fields\", function() {",
 											"    pm.expect(jsonData.id).to.exist;",
@@ -7531,7 +7537,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"ISBN\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"f34d27c6-a8eb-461b-acd6-5dea81771e70\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialType}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": {\n                \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n                \"description\": \"ABCDEFGHIJKLMNO\"\n            },\n            \"tags\": [\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFG\",\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFGHIJKLMNO\"\n            ],\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
+											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"vendor\": \"{{activeVendorId}}\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"ISBN\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"f34d27c6-a8eb-461b-acd6-5dea81771e70\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"owner\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialType}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": {\n                \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n                \"description\": \"ABCDEFGHIJKLMNO\"\n            },\n            \"tags\": [\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFG\",\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFGHIJKLMNO\"\n            ],\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -10273,7 +10279,8 @@
 									"script": {
 										"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
 										"exec": [
-											""
+											"let utils = eval(globals.loadUtils);",
+											"pm.variables.set(\"orderBody\", JSON.stringify(utils.buildOrderWithMinContent()));"
 										],
 										"type": "text/javascript"
 									}
@@ -10312,7 +10319,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\n}"
+									"raw": "{{orderBody}}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/bad-id",
@@ -14159,7 +14166,7 @@
 					"     * Build Order with minimal required fields.",
 					"     */",
 					"    utils.buildOrderWithMinContent = function() {",
-					"        return {};",
+					"        return {\"vendor\": pm.variables.get(\"activeVendorId\")};",
 					"    };",
 					"",
 					"    /**",
@@ -14328,6 +14335,15 @@
 					"            } else {",
 					"                pm.expect(poLine.receiptDate, \"Receipt date should be empty\").to.not.exist;",
 					"            }",
+					"        });",
+					"    };",
+					"    ",
+					"    /**",
+					"     * Validates that PO Line's payment status updated to expected",
+					"     */",
+					"    utils.validatePaymentStatus = function(poLine, paymentStatus) {",
+					"        pm.test(poLine.poLineNumber + \" PO Line should have \" + paymentStatus + \" payment status\", function() {",
+					"            pm.expect(poLine.paymentStatus, \"Payment status should be \" + paymentStatus).to.equal(paymentStatus);",
 					"        });",
 					"    };",
 					"",
@@ -14760,7 +14776,7 @@
 					"        pm.expect(poLine.locations, \"locations should be present\").to.be.an('array').that.is.not.empty;",
 					"        pm.expect(poLine.orderFormat, \"orderFormat expected\").to.exist;",
 					"        pm.expect(poLine.owner, \"owner not expected\").to.not.exist;",
-					"        pm.expect(poLine.paymentStatus, \"paymentStatus expected\").to.exist;",
+					"        pm.expect(poLine.paymentStatus, \"paymentStatus not expected\").to.equal(\"Pending\");",
 					"        pm.expect(poLine.poLineDescription, \"poLineDescription not expected\").to.not.exist;",
 					"        pm.expect(poLine.poLineNumber, \"poLineNumber is expected\").to.exist;",
 					"        pm.expect(poLine.publicationDate, \"publicationDate not expected\").to.not.exist;",


### PR DESCRIPTION
- added utils.validatePaymentStatus method
- Added checks of payment statuses for "Pending->Open" order transition for cases: 
  - poLines payment status is "Pending" and should change
  - poLines payment status is not "Pending" and shouldn't be changed

Since the tests were falling due to the changes, added `purchaseOrder.vendor` to requests where it's required

Collection run on folio-testing
![image](https://user-images.githubusercontent.com/41672277/56037711-a4720b80-5d38-11e9-93ff-ea6b22b1718d.png)
