### PR TITLE
MODORGS-5 Create API Test Skeleton - updating endpoint name

### DIFF
--- a/mod-organizations-storage/mod-organizations-storage.postman_collection.json
+++ b/mod-organizations-storage/mod-organizations-storage.postman_collection.json
@@ -669,14 +669,14 @@
 									"raw": "{{organizationContent}}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organization-storage/organizations",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organization-storage",
+										"organizations-storage",
 										"organizations"
 									]
 								}
@@ -732,14 +732,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organization-storage/organizations/{{activeOrganizationId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations/{{activeOrganizationId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organization-storage",
+										"organizations-storage",
 										"organizations",
 										"{{activeOrganizationId}}"
 									]
@@ -792,14 +792,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organization-storage/organizations/{{activeOrganizationId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations/{{activeOrganizationId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organization-storage",
+										"organizations-storage",
 										"organizations",
 										"{{activeOrganizationId}}"
 									]
@@ -875,14 +875,14 @@
 									"raw": "{{organizationContent}}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organization-storage/organizations",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organization-storage",
+										"organizations-storage",
 										"organizations"
 									]
 								}
@@ -938,14 +938,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organization-storage/organizations?query=name adj for API Test",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations?query=name adj for API Test",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organization-storage",
+										"organizations-storage",
 										"organizations"
 									],
 									"query": [
@@ -1040,14 +1040,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organization-storage/organizations/{{inactiveOrganizationId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations/{{inactiveOrganizationId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organization-storage",
+										"organizations-storage",
 										"organizations",
 										"{{inactiveOrganizationId}}"
 									]
@@ -1095,14 +1095,14 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organization-storage/organizations?query=name adj for API Test",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations?query=name adj for API Test",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organization-storage",
+										"organizations-storage",
 										"organizations"
 									],
 									"query": [


### PR DESCRIPTION
Updating test to use latest endpoint names introduced by https://github.com/folio-org/mod-organizations-storage/pull/9
`organization-storage/organizations` -> `organizations-storage/organizations`

![image](https://user-images.githubusercontent.com/43410167/56044846-bb205e80-5d48-11e9-956c-2b679d0d9999.png)
