### PR TITLE
MODNOTES-82 API Tests for PUT /note-types/{typeId}

### DIFF
--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -296,7 +296,8 @@
 									"});",
 									"",
 									"pm.environment.set(\"noteTypeId\", response.id);",
-									"pm.environment.set(\"noteTypeName\", response.name);"
+									"pm.environment.set(\"noteTypeName\", response.name);",
+									"pm.environment.set(\"noteTypeIdNotExisting\",\"00c00fe0-0000-000f-a00a-e000b000d000\");"
 								],
 								"type": "text/javascript"
 							}
@@ -6395,12 +6396,7 @@
 											"script": {
 												"id": "489cefc9-561e-4e0a-9ea8-a535867f5859",
 												"exec": [
-													"var uuid = require('uuid');",
-													"",
-													"pm.variables.set(\"createDate\", \"2001-01-01T19:18:27.437+0000\");",
-													"pm.variables.set(\"createUser\", uuid.v4());",
-													"pm.variables.set(\"updateDate\", \"2001-02-02T18:17:21.427+0000\");",
-													"pm.variables.set(\"updateUser\", uuid.v4());"
+													""
 												],
 												"type": "text/javascript"
 											}
@@ -6462,7 +6458,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"name\": \"Creating Second NoteType\",\n    \"metadata\": {\n        \"createdDate\": \"{{createDate}}\",\n        \"createdByUserId\": \"{{createUser}}\",\n        \"updatedDate\": \"{{updateDate}}\",\n        \"updatedByUserId\": \"{{updateUser}}\"\n    }\n}"
+											"raw": "{\n    \"name\": \"Creating Second NoteType\",\n    \"metadata\": {\n        \"createdDate\": \"2019-04-11T08:56:10.163+0000\",\n        \"createdByUserId\": \"e26660ef-a8b3-5672-a4c8-1a7b5290f834\",\n        \"createdByUsername\": \"diku_admin\",\n        \"updatedDate\": \"2019-04-11T08:56:10.163+0000\",\n        \"updatedByUserId\": \"e26660ef-a8b3-5672-a4c8-1a7b5290f834\"\n    }\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types",
@@ -7651,6 +7647,619 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "PUT note-type by id",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "/note-types/{id} - 204",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "6f1b83dd-dd78-4091-a71a-2cb8a75e0bc7",
+												"exec": [
+													"pm.test(\"success test - 204 and no body\", function() {",
+													"    pm.response.to.have.status(204);",
+													"    pm.response.to.not.be.withBody;",
+													"});",
+													"",
+													"//Check that status is 204",
+													"pm.test(\"Status is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													"",
+													"pm.sendRequest({",
+													"    url: pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + \"/note-types/\" + pm.environment.get(\"noteTypeId\"),",
+													"    method: 'GET',",
+													"    header: {",
+													"        'X-Okapi-Tenant': pm.environment.get(\"xokapitenant\"),",
+													"        'X-Okapi-Token': pm.environment.get(\"xokapitoken\"),",
+													"        'Content-Type': 'application/json'",
+													"    },",
+													"}, function(err, res) {",
+													"    pm.test(\"Name is changed\", function () {",
+													"        pm.expect(res.json().name).to.equal(\"Test - Updated\");",
+													"    });",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "3c91d9cc-4f5a-4416-957b-7848bf43fd38",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Test - Updated\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{noteTypeId}}"
+											]
+										},
+										"description": "Updates an existing note"
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - (empty name)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "9d64c5c0-aa66-470a-a622-01b26b186f3f",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "79e5a5b5-32d7-464d-ac1d-dc8b705f203b",
+												"exec": [
+													"pm.test(\"success test - 204 and no body\", function() {",
+													"    pm.response.to.have.status(204);",
+													"    pm.response.to.not.be.withBody;",
+													"});",
+													"",
+													"//Check that status is 204",
+													"pm.test(\"Status is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													"",
+													"pm.sendRequest({",
+													"    url: pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + \"/note-types/\" + pm.environment.get(\"noteTypeId\"),",
+													"    method: 'GET',",
+													"    header: {",
+													"        'X-Okapi-Tenant': pm.environment.get(\"xokapitenant\"),",
+													"        'X-Okapi-Token': pm.environment.get(\"xokapitoken\"),",
+													"        'Content-Type': 'application/json'",
+													"    },",
+													"}, function(err, res) {",
+													"    pm.test(\"Name is changed\", function () {",
+													"        pm.expect(res.json().name).to.equal(\"\");",
+													"    });",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{noteTypeId}}"
+											]
+										},
+										"description": "Update an existing note with JSON body missing the required \"text\" field."
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "/note-types/{id} - 400 (invalid id format in URL)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "e0535ffb-0247-43b7-880c-e90e74a7b09a",
+												"exec": [
+													"pm.test(\"400 test - invalid id format in URL\", function() {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"Response having negative lang parameter error message\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.have.body(\"invalid input syntax for uuid: \\\"12345\\\"\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "2d37b73e-f81e-4079-88e8-dcc2ae81db02",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Invalid Format URl\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/12345",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"12345"
+											]
+										},
+										"description": "Updates an existing note with an invalid id format"
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - 403",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "37417d71-7f2c-4ff0-b4c3-420aac5bf6b7",
+												"exec": [
+													"pm.test(\"403 test\", function() {",
+													"    pm.response.to.have.status(403);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"pm.test(\"validate permission\", function() {",
+													"    pm.expect(pm.response.text()).to.include(\"note.types.item.put\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "fc943a45-a2da-462c-8910-3746fa12cf63",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{noteTypeId}}"
+											]
+										},
+										"description": "Failure test for a user missing the required permission."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - 404",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "e7323028-c782-4e36-9f00-e7209fe3b99d",
+												"exec": [
+													"pm.test(\"404 test\", function() {",
+													"    pm.response.to.have.status(404);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "d4351f0f-adb3-4994-9f25-9869782c708d",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Not Found\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeIdNotExisting}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{noteTypeIdNotExisting}}"
+											]
+										},
+										"description": "Updates an existing note with an unknown id"
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - 422 (empty JSON)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "42676a49-83cc-4c27-afc1-efb64fb18d0a",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "8664ff6c-55c7-4014-b869-fce54a563bc1",
+												"exec": [
+													"pm.test(\"422 - missing text field\", function() {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													" pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_errors\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Error message exist\", function() {",
+													"    pm.expect(response.errors[0].message).to.eq(\"may not be null\");",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{noteTypeId}}"
+											]
+										},
+										"description": "Update an existing note with an empty JSON body."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - 422 (unknown field)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "310ebf88-f3ce-4d20-a640-f28bdd343e07",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "7c8c6944-72ba-421f-8c17-0acefe2b56cc",
+												"exec": [
+													"pm.test(\"422 - missing text field\", function() {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													" pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_errors\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"name\" : \"Name\",\n\t\"xyzzy\": \"867-5309\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"note-types",
+												"{{noteTypeId}}"
+											]
+										},
+										"description": "Update an existing note with JSON body containing an unknown field."
+									},
+									"response": []
+								},
+								{
+									"name": "/note-types/{id} - 422 (unknown metadata field)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "8834cd24-eb40-44d1-ba86-4a32b7e63259",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "8bd865f6-0eef-473b-acb4-d0f5c1735ef9",
+												"exec": [
+													"pm.test(\"422 - unknown metadata field\", function() {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													" pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_errors\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"link\": \"/items/xxxxxx\",\n\t\"text\": \"xxxxxxxx\",\n\t\"metadata\": {\n\t\t\"xyzzy\": \"867-5309\"\n\t}\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{noteTypeId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"notes",
+												"{{noteTypeId}}"
+											]
+										},
+										"description": "Update an existing note with JSON body containing an unknown metadata field."
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -7670,7 +8279,8 @@
 						"id": "cf476f90-4123-4dc7-9ce1-3c9eddec1a2b",
 						"type": "text/javascript",
 						"exec": [
-							" tv4.addSchema(\"schema_noteTypeItem.json\", pm.environment.get(\"schema_noteTypeItem\"));"
+							" tv4.addSchema(\"schema_noteTypeItem.json\", pm.environment.get(\"schema_noteTypeItem\"));",
+							" tv4.addSchema(\"schema_error.schema\", pm.environment.get(\"schema_error\"));"
 						]
 					}
 				}


### PR DESCRIPTION
## Purpose
Covering /note-types endpoint by tests.
https://issues.folio.org/browse/MODNOTES-82
## Approach
Creating API tests for note-type endpoint.
