### PR TITLE
MODORDERS-207 - Adding cases for checkin

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -8595,7 +8595,8 @@
 											"disabled": true
 										}
 									]
-								}
+								},
+								"description": "creates a piece without any items in inventory and performs check-in. \nTests to see if the piece status is changed.\nThe order used for checkin is created in the request \"Create order all po lines checkin\""
 							},
 							"response": []
 						},
@@ -8683,7 +8684,8 @@
 										"orders",
 										"check-in"
 									]
-								}
+								},
+								"description": "rever the checked in piece in the prior request to Expected status"
 							},
 							"response": []
 						},
@@ -8771,7 +8773,8 @@
 										"orders",
 										"check-in"
 									]
-								}
+								},
+								"description": "Do not create a new piece, but the existing piece must be successfully checked in"
 							},
 							"response": []
 						},
@@ -8863,7 +8866,8 @@
 										"orders",
 										"check-in"
 									]
-								}
+								},
+								"description": "creates a piece with items in inventory and performs check-in. Tests to see if the piece status is changed and also the Po line status. The order used for checkin is created in the request \"Create order all po lines checkin\""
 							},
 							"response": []
 						},
@@ -8952,7 +8956,8 @@
 										"orders",
 										"check-in"
 									]
-								}
+								},
+								"description": "rever the checked in piece with items. The item status as well as the piece status must be modified"
 							},
 							"response": []
 						}
@@ -13887,7 +13892,12 @@
 										"exec": [
 											"pm.test(\"Status code is 204\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"// Clean-Up",
+											"pm.globals.unset(\"checkin_electronic_poLine\");",
+											"pm.globals.unset(\"checkin_physical_poLine\");",
+											"pm.globals.unset(\"poAllPoLineCheckin\");"
 										],
 										"type": "text/javascript"
 									}
@@ -14717,8 +14727,6 @@
 					"            pm.test(expectedCount + \" Item Records marked as received for PO Line with number=\" + poLine.poLineNumber, function() {",
 					"                let body = res.json();",
 					"                pm.expect(body, \"GET Items response is not in json format\").to.exist;",
-					"                console.log(body);",
-					"                console.log(body.totalRecords);",
 					"                pm.expect(body.totalRecords, \"Quantity of items received for PO Line should be \" + expectedCount).to.equal(expectedCount);",
 					"                body.items.forEach(function(item) {",
 					"                    pm.expect(item.barcode, \"Barcode should not be empty\").to.not.be.empty;",
@@ -15296,7 +15304,6 @@
 					"    utils.getItemsByPoLine = function(line) {",
 					"        return new Promise((resolve) => {",
 					"            let expectedCount;",
-					"            console.log(\"%%%%%%%%\"+line.checkinItems);",
 					"            //we donot know the checkin count before, so use a default",
 					"            if (line.checkinItems === true) {",
 					"                expectedCount = 100;",
@@ -15304,7 +15311,6 @@
 					"            else {",
 					"                expectedCount = utils.calculateExpectedItemsQuantity(line);",
 					"            }",
-					"            console.log(\"%%%%%%%%\"+expectedCount);",
 					"            utils.getItemsByPoLineId(line.id, expectedCount, (err, response) => {",
 					"                pm.test(\"Search for item records by PO Line id=\" + line.id, function() {",
 					"                    if (response.code !== 200) {",
@@ -15324,7 +15330,8 @@
 					"            });",
 					"        });",
 					"    };",
-					"     /**check-in methods",
+					"     /**",
+					"      * check-in methods",
 					"     */",
 					"     utils.postRequest = function (path, postBody, handler) {",
 					"        pm.sendRequest({",
@@ -15341,6 +15348,11 @@
 					"            }",
 					"        }, handler);",
 					"    }",
+					"    ",
+					"    /**",
+					"     *This method creates a piece and also calls the prepares the check-in body.",
+					"     * If itemId is not provided the check-in flow just updates the piece record",
+					"     */",
 					"    utils.createPieceAndCheckInBody = function (compPoLine, itemId) {",
 					"        let pieceTemplate = globals.testData.piece.bodyTemplate;",
 					"        pieceTemplate.locationId = compPoLine.locations[0].locationId;",
@@ -15357,9 +15369,18 @@
 					"        }",
 					"        pm.variables.set(\"checkinPoLineId\", compPoLine.id);",
 					"        utils.postRequest(\"/orders/pieces\", pieceTemplate, (err, res) => {",
+					"            pm.test(\"creating piece for check-in \", function(){",
+					"                    pm.expect(res).to.have.property('code', 201);",
+					"                });",
 					"            utils.prepareCheckinBody(compPoLine, res.json().id);",
-					"        })",
+					"        });",
 					"    }",
+					"    ",
+					"    /**",
+					"     * This method is used for both checking in a piece and also reverting it,",
+					"     * If the checkinstatus is not provided by default it is set to check-in item",
+					"     * ",
+					"     */",
 					"    utils.prepareCheckinBody = function (compPoLine, pieceId, checkinStatus) {",
 					"        let checkinRq = globals.testData.checkin.bodyTemplate;",
 					"        let toBeCheckedInTemplate = checkinRq.toBeCheckedIn.pop();",
@@ -15378,13 +15399,23 @@
 					"        console.log(JSON.stringify(checkinRq));",
 					"        pm.variables.set(\"checkinBody\", JSON.stringify(checkinRq));",
 					"    }",
+					"    ",
+					"    /**",
+					"     * Get the holding where the item needs to be created , create an item",
+					"     * and then use the item id to create a piece",
+					"     * ",
+					"     */",
 					"    utils.prepareCheckinBodyWithItems = function (compPoLine) {",
 					"        utils.sendGetRequest(\"/holdings-storage/holdings?limit=1&query=instanceId==\" + compPoLine.instanceId + \" and permanentLocationId==\" + compPoLine.locations[0].locationId, (err, res) => {",
 					"            utils.createItem(compPoLine.id, res.json().holdingsRecords[0].id, (err, res) => {",
+					"                pm.test(\"creating item for check-in\", function(){",
+					"                    pm.expect(res).to.have.property('code', 201);",
+					"                });",
 					"                utils.createPieceAndCheckInBody(compPoLine, res.json().id);",
 					"            });",
 					"        });",
 					"    }",
+					"    ",
 					"    utils.createItem = function (poLineId, holdingsRecordId, handler) {",
 					"        let itemTemplate = globals.testData.item.bodyTemplate;",
 					"        itemTemplate.holdingsRecordId = holdingsRecordId;",
@@ -15405,9 +15436,9 @@
 					"                        pm.test(\"No item(s) expected to exist for PO line with id=\" + line.id, () => {",
 					"                            pm.expect(items.length).to.eql(0);",
 					"                        });",
-					"                        //for checkin there can be a case where the items are not created but holdings are created",
 					"                    }",
 					"                    ",
+					"                    //for checkin there can be a case where the items are not created but holdings are created",
 					"                    if (items.length === 0) {",
 					"                            utils.sendGetRequest(\"/holdings-storage/holdings?limit=100&query=instanceId==\" + line.instanceId, (err, res) => {",
 					"                                let body = res.json();",
@@ -15429,7 +15460,7 @@
 					"                        promises.push(utils.processDeleteRequest(\"/item-storage/items/\" + item.id));",
 					"                    });",
 					"                    ",
-					"                    //handle a scenario where items do not exist for a holding but it is created while check-in order",
+					"                    //to cover a scenario where items do not exist for a holding but it is created while check-in order",
 					"                    promises.push(",
 					"                        new Promise((resolve) => {",
 					"                            utils.sendGetRequest(\"/holdings-storage/holdings?limit=100&query=instanceId==\" + line.instanceId, (err, res) => {",
@@ -15849,163 +15880,163 @@
 	],
 	"variable": [
 		{
-			"id": "22ff6f01-3a7e-415f-b296-640de2e98dfb",
+			"id": "a4f0096c-f928-474c-992b-9383625e848c",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "4e345b04-8174-47a8-a3e4-9e3c328ea36f",
+			"id": "f12943b5-1c98-477e-b3e8-a42c537b6a09",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/acq-models/master",
 			"type": "string"
 		},
 		{
-			"id": "37c5fbfc-a18e-4599-bda6-3a7bb56ecc6a",
+			"id": "090b6e00-e4c4-4194-bc6a-c8998fd96312",
 			"key": "schema_composite_purchase_order",
 			"value": "composite_purchase_order.json",
 			"type": "string"
 		},
 		{
-			"id": "08ed0adb-7c38-451e-9799-2c5db7c58a6c",
+			"id": "4273acb0-da01-47aa-8c98-282ed9a26b7e",
 			"key": "schema_alert",
 			"value": "alert.json",
 			"type": "string"
 		},
 		{
-			"id": "f981703c-eafd-4235-a4f4-d735d7483e35",
+			"id": "256fb9b6-a4a9-4344-a5c4-0cd57aeb3078",
 			"key": "schema_claim",
 			"value": "claim.json",
 			"type": "string"
 		},
 		{
-			"id": "8934075d-72cd-47c0-b6a1-7ac45931c789",
+			"id": "846568b7-d21c-4559-8ed5-8d7f3f5f339c",
 			"key": "schema_composite_po_line",
 			"value": "composite_po_line.json",
 			"type": "string"
 		},
 		{
-			"id": "bd095cab-79c4-4449-97e0-e80928034554",
+			"id": "76bac7c7-df51-4a77-9ec7-dd2b0b1e0e00",
 			"key": "schema_cost",
 			"value": "cost.json",
 			"type": "string"
 		},
 		{
-			"id": "cf34aae9-c52c-4293-93e9-63d1ec4930db",
+			"id": "c020004f-c2fc-459e-a462-92aac180ceff",
 			"key": "schema_details",
 			"value": "details.json",
 			"type": "string"
 		},
 		{
-			"id": "7529973d-a864-4707-9a8f-a2d8258eda4b",
+			"id": "235a97f2-3088-4f8e-9afa-ce3b4fb6a3c4",
 			"key": "schema_eresource",
 			"value": "eresource.json",
 			"type": "string"
 		},
 		{
-			"id": "65ed988f-6405-4bd7-a0f6-27e540837eeb",
+			"id": "007f26ad-47bd-4392-a023-d31eee97d4a1",
 			"key": "schema_fundDistribution",
 			"value": "fund_distribution.json",
 			"type": "string"
 		},
 		{
-			"id": "6ab97e92-4d25-4ec6-8288-23023b2c8551",
+			"id": "4bead911-c630-45b4-9abc-5afe05d2612c",
 			"key": "schema_location",
 			"value": "location.json",
 			"type": "string"
 		},
 		{
-			"id": "31589cce-e71e-48c8-a576-c9a0b70f7274",
+			"id": "f7b719aa-6fb6-4da7-b1f4-e3125e4d61a1",
 			"key": "schema_physical",
 			"value": "physical.json",
 			"type": "string"
 		},
 		{
-			"id": "5d39fc31-3c0d-4806-8113-bac0bd9f1d58",
+			"id": "12b37121-7e0c-4a43-b7d3-2e25caf1eeb8",
 			"key": "schema_renewal",
 			"value": "renewal.json",
 			"type": "string"
 		},
 		{
-			"id": "31ab6f54-d823-4c8a-bf89-98654b291653",
+			"id": "4cbbdef8-2c69-4261-afe8-2093b045c38c",
 			"key": "schema_reporting_code",
 			"value": "reporting_code.json",
 			"type": "string"
 		},
 		{
-			"id": "5688e398-82c1-4f3c-a056-863bcbfe841d",
+			"id": "dbefdcb9-4f87-4107-91dc-10f351c27867",
 			"key": "schema_source",
 			"value": "source.json",
 			"type": "string"
 		},
 		{
-			"id": "c60523fd-597f-46c9-8414-e85d71ca2479",
+			"id": "ce197754-bff3-4658-9091-47e409cfb2b9",
 			"key": "schema_vendorDetail",
 			"value": "vendor_detail.json",
 			"type": "string"
 		},
 		{
-			"id": "c0c0b98e-b42f-4a89-9120-6a846347213d",
+			"id": "3d95d927-69b1-476c-86e9-4c1a59152a29",
 			"key": "schema_orderFormat",
 			"value": "order_format.json",
 			"type": "string"
 		},
 		{
-			"id": "7d2587de-7b77-4b71-adc9-cf04c2daa245",
+			"id": "ff8cff09-3668-4f0b-89b8-58cc7f73ed6d",
 			"key": "schema_receiptStatus",
 			"value": "receipt_status.json",
 			"type": "string"
 		},
 		{
-			"id": "0981fb4d-5040-4a68-aead-f1c8873c2cf1",
+			"id": "f35d1c1b-ef93-4821-86af-a582bc498f35",
 			"key": "storage_module",
 			"value": "mod-orders-storage",
 			"type": "string"
 		},
 		{
-			"id": "c915d014-4915-406a-801a-930afcb7ec32",
+			"id": "1474db6d-b527-42f9-ae66-1dcb7e8b5ca5",
 			"key": "business_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "625efe10-de33-4ec7-989d-ba4d9d45e298",
+			"id": "75cfde83-d2da-4fa5-baf6-082597ec0a28",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "88f5074f-a16d-4229-ae75-cce9db449710",
+			"id": "6057836c-e712-4261-8535-a09be0c5ab9d",
 			"key": "schema_poNumber",
 			"value": "po_number.json",
 			"type": "string"
 		},
 		{
-			"id": "fd410383-f51e-4519-b458-1bb8c7ec46b0",
+			"id": "4af8bf72-cabb-4819-87d9-66c32084025a",
 			"key": "raml_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/raml/raml1.0",
 			"type": "string"
 		},
 		{
-			"id": "1f04db93-d44a-42ec-8e5f-96d360900eaf",
+			"id": "7ed8e829-ba13-4bfc-a8a0-2ac5ff422535",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "d9c7e0ec-6239-4a96-9046-88b0c7e3514a",
+			"id": "d32ef6d3-ef55-48ed-8cd7-8981c5fafd82",
 			"key": "orders_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "c448741f-bd66-4ad6-a23b-bb7e8785a2cc",
+			"id": "849f2816-1c9a-4970-b97b-39487e6da524",
 			"key": "schema_productIdType",
 			"value": "product_id_type.json",
 			"type": "string"
 		},
 		{
-			"id": "668b53e9-d04b-45bb-a5d9-c0bba0ee3473",
+			"id": "de889976-1158-4da8-b7b4-f2e28ae5d263",
 			"key": "common_folder",
 			"value": "common",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1564,6 +1564,73 @@
 								"description": "Get material types to be used accross the orders while interaction with inventory"
 							},
 							"response": []
+						},
+						{
+							"name": "Get Loan type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Successfully retrieved default loan type\", function () {",
+											"    pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    jsonData = pm.response.json();",
+											"});",
+											"});  ",
+											"",
+											"pm.test(\"Get the default loan type\", function () {",
+											"    pm.globals.set(\"loanType\", jsonData.loantypes[0].id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/loan-types?query=name==\"Can Circulate\"",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"loan-types"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "name==\"Can Circulate\""
+										}
+									]
+								},
+								"description": "Get material types to be used accross the orders while interaction with inventory"
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -4117,6 +4184,8 @@
 											"    order.compositePoLines[0].orderFormat = \"Physical Resource\";",
 											"    setPhysicalInfo(order.compositePoLines[0]);",
 											"    order.compositePoLines[1].orderFormat = \"Other\";",
+											"    //using a new product Id for Other , because it can have create Inventory different based on the environment",
+											"    order.compositePoLines[1].details.productIds[0].productId = \"768768768768\";",
 											"    setPhysicalInfo(order.compositePoLines[1]);",
 											"    ",
 											"    pendingOrder.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
@@ -8498,7 +8567,7 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"name": "check-in",
+					"name": "Check-in",
 					"item": [
 						{
 							"name": "check-in pieces without items in Inventory",
@@ -8960,6 +9029,28 @@
 								"description": "rever the checked in piece with items. The item status as well as the piece status must be modified"
 							},
 							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "ab27b964-955c-4491-86dd-eb8085658f9e",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "a9c355ce-ab55-4d87-a0af-027fa014a6c6",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						}
 					],
 					"_postman_isSubFolder": true
@@ -12640,7 +12731,7 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"name": "check-in",
+					"name": "Check-in",
 					"item": [
 						{
 							"name": "check-in already received piece",
@@ -15880,163 +15971,163 @@
 	],
 	"variable": [
 		{
-			"id": "a4f0096c-f928-474c-992b-9383625e848c",
+			"id": "ff471e0a-84a6-4060-93d7-9324d6f7c772",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "f12943b5-1c98-477e-b3e8-a42c537b6a09",
+			"id": "092e5f68-0f02-4ca0-9802-e365053909b6",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/acq-models/master",
 			"type": "string"
 		},
 		{
-			"id": "090b6e00-e4c4-4194-bc6a-c8998fd96312",
+			"id": "f243c27a-cdb9-4299-a1fa-8890f5ebc827",
 			"key": "schema_composite_purchase_order",
 			"value": "composite_purchase_order.json",
 			"type": "string"
 		},
 		{
-			"id": "4273acb0-da01-47aa-8c98-282ed9a26b7e",
+			"id": "39083b98-51b9-4692-b469-9b9db91bd126",
 			"key": "schema_alert",
 			"value": "alert.json",
 			"type": "string"
 		},
 		{
-			"id": "256fb9b6-a4a9-4344-a5c4-0cd57aeb3078",
+			"id": "18a97ff3-f967-47e5-9fc6-df8a7d154e1e",
 			"key": "schema_claim",
 			"value": "claim.json",
 			"type": "string"
 		},
 		{
-			"id": "846568b7-d21c-4559-8ed5-8d7f3f5f339c",
+			"id": "b8453125-78b1-437b-8df4-4266de145e68",
 			"key": "schema_composite_po_line",
 			"value": "composite_po_line.json",
 			"type": "string"
 		},
 		{
-			"id": "76bac7c7-df51-4a77-9ec7-dd2b0b1e0e00",
+			"id": "bb6a4903-25fe-41c0-af1d-b4bc277d9fd7",
 			"key": "schema_cost",
 			"value": "cost.json",
 			"type": "string"
 		},
 		{
-			"id": "c020004f-c2fc-459e-a462-92aac180ceff",
+			"id": "a2966b2b-a4b4-4f7b-b51f-c5d5003ee009",
 			"key": "schema_details",
 			"value": "details.json",
 			"type": "string"
 		},
 		{
-			"id": "235a97f2-3088-4f8e-9afa-ce3b4fb6a3c4",
+			"id": "446000e8-47ba-4ac7-a4b5-930ba218af5b",
 			"key": "schema_eresource",
 			"value": "eresource.json",
 			"type": "string"
 		},
 		{
-			"id": "007f26ad-47bd-4392-a023-d31eee97d4a1",
+			"id": "ca442409-f6c0-4e67-ad3c-7dd3759602c5",
 			"key": "schema_fundDistribution",
 			"value": "fund_distribution.json",
 			"type": "string"
 		},
 		{
-			"id": "4bead911-c630-45b4-9abc-5afe05d2612c",
+			"id": "7cb3a96d-a183-40e5-8e8f-4360a43bc18c",
 			"key": "schema_location",
 			"value": "location.json",
 			"type": "string"
 		},
 		{
-			"id": "f7b719aa-6fb6-4da7-b1f4-e3125e4d61a1",
+			"id": "7b27689f-287a-4b3c-b9dd-b7c338a11f05",
 			"key": "schema_physical",
 			"value": "physical.json",
 			"type": "string"
 		},
 		{
-			"id": "12b37121-7e0c-4a43-b7d3-2e25caf1eeb8",
+			"id": "1f6f7826-ae3e-4986-a5ae-6bffef59bcd1",
 			"key": "schema_renewal",
 			"value": "renewal.json",
 			"type": "string"
 		},
 		{
-			"id": "4cbbdef8-2c69-4261-afe8-2093b045c38c",
+			"id": "a4ab225e-2ccd-4241-b6a2-cdedb19ee3c8",
 			"key": "schema_reporting_code",
 			"value": "reporting_code.json",
 			"type": "string"
 		},
 		{
-			"id": "dbefdcb9-4f87-4107-91dc-10f351c27867",
+			"id": "674a7855-b750-443a-aba4-e8e5b63ec5b9",
 			"key": "schema_source",
 			"value": "source.json",
 			"type": "string"
 		},
 		{
-			"id": "ce197754-bff3-4658-9091-47e409cfb2b9",
+			"id": "c33dd130-0bd0-4434-9269-a21fcd2de44e",
 			"key": "schema_vendorDetail",
 			"value": "vendor_detail.json",
 			"type": "string"
 		},
 		{
-			"id": "3d95d927-69b1-476c-86e9-4c1a59152a29",
+			"id": "9190e9cd-b9a8-49ff-bcf5-6e83c100ab95",
 			"key": "schema_orderFormat",
 			"value": "order_format.json",
 			"type": "string"
 		},
 		{
-			"id": "ff8cff09-3668-4f0b-89b8-58cc7f73ed6d",
+			"id": "176cb4b7-017a-40e4-86b4-97dced95d48e",
 			"key": "schema_receiptStatus",
 			"value": "receipt_status.json",
 			"type": "string"
 		},
 		{
-			"id": "f35d1c1b-ef93-4821-86af-a582bc498f35",
+			"id": "b6080b8f-cb74-40e6-9f2f-396059a02f18",
 			"key": "storage_module",
 			"value": "mod-orders-storage",
 			"type": "string"
 		},
 		{
-			"id": "1474db6d-b527-42f9-ae66-1dcb7e8b5ca5",
+			"id": "13dd2746-311e-4617-9f48-03e1887b929a",
 			"key": "business_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "75cfde83-d2da-4fa5-baf6-082597ec0a28",
+			"id": "ed50f16f-0cab-40b7-bc8d-7a3e1618aa99",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "6057836c-e712-4261-8535-a09be0c5ab9d",
+			"id": "ae6a35bd-eada-4e48-a0a1-88c2d6208209",
 			"key": "schema_poNumber",
 			"value": "po_number.json",
 			"type": "string"
 		},
 		{
-			"id": "4af8bf72-cabb-4819-87d9-66c32084025a",
+			"id": "1d6562e1-be65-445b-baa3-204461ee32be",
 			"key": "raml_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/raml/raml1.0",
 			"type": "string"
 		},
 		{
-			"id": "7ed8e829-ba13-4bfc-a8a0-2ac5ff422535",
+			"id": "4250d872-e563-49fa-a8ed-af88bff8e443",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "d32ef6d3-ef55-48ed-8cd7-8981c5fafd82",
+			"id": "8eec6020-2232-4277-bcc7-ccd660ae36ef",
 			"key": "orders_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "849f2816-1c9a-4970-b97b-39487e6da524",
+			"id": "8e197e9b-ed95-4c98-b884-a8468736e092",
 			"key": "schema_productIdType",
 			"value": "product_id_type.json",
 			"type": "string"
 		},
 		{
-			"id": "de889976-1158-4da8-b7b4-f2e28ae5d263",
+			"id": "8b6628fc-4e3b-4039-b4c4-82674faa7e65",
 			"key": "common_folder",
 			"value": "common",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "0c5a5eab-1ab8-4ba5-8c9f-89b4b8781512",
-		"name": "mod-orders copy",
+		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -4749,13 +4749,10 @@
 											"    order.compositePoLines[1].checkinItems = true;",
 											"",
 											"    // Set new product ids to be sure that new instances will be created",
-											"    delete order.compositePoLines[0].details.productIds;",
-											"    delete order.compositePoLines[1].details.productIds;",
+											"    order.compositePoLines[0].details.productIds.pop();",
 											"    ",
 											"    order.compositePoLines[0].details.productIds[0].productId = \"11311321131132\";",
-											"    order.compositePoLines[0].details.productIds[0].productIdType = \"ISBN\";",
 											"    order.compositePoLines[1].details.productIds[0].productId = \"11321331132133\";",
-											"    order.compositePoLines[0].details.productIds[0].productIdType = \"ISBN\";",
 											"    ",
 											"    order.compositePoLines[0].title = \"Hey! Just API testing checkin\"",
 											"    order.compositePoLines[1].title = \"Hey! Just API testing checkin with no items\"",
@@ -14611,8 +14608,9 @@
 					"            pm.test(expectedCount + \" Item Records exist for PO Line with number=\" + line.poLineNumber, function() {",
 					"                let body = res.json();",
 					"                pm.expect(body, \"GET Items response is not in json format\").to.exist;",
-					"",
-					"                if (utils.isItemsUpdateRequired(line)) {",
+					"                let isCheckin = typeof line.checkinItems === \"undefined\" ? false : line.checkinItems;",
+					"                //items are not created for checkin while opening the order, but can be created later",
+					"                if (utils.isItemsUpdateRequired(line) && !isCheckin) {",
 					"                    pm.expect(body.totalRecords, \"Quantity of items created for PO Line should be \" + expectedCount).to.equal(expectedCount);",
 					"                } else {",
 					"                    pm.expect(body.totalRecords, \"Quantity of items should be zero\").to.equal(0);",
@@ -14772,10 +14770,6 @@
 					"    };",
 					"",
 					"    utils.isItemsUpdateRequired = function(compPOL) {",
-					"        if (compPOL.checkinItems != null && compPOL.checkinItems === true) {",
-					"            return false;",
-					"        }",
-					"",
 					"        let itemsRequiredForEresource = false;",
 					"        let itemsRequiredForPhysical = false;",
 					"",
@@ -15301,7 +15295,16 @@
 					"     */",
 					"    utils.getItemsByPoLine = function(line) {",
 					"        return new Promise((resolve) => {",
-					"            let expectedCount = utils.calculateExpectedItemsQuantity(line);",
+					"            let expectedCount;",
+					"            console.log(\"%%%%%%%%\"+line.checkinItems);",
+					"            //we donot know the checkin count before, so use a default",
+					"            if (line.checkinItems === true) {",
+					"                expectedCount = 100;",
+					"            }",
+					"            else {",
+					"                expectedCount = utils.calculateExpectedItemsQuantity(line);",
+					"            }",
+					"            console.log(\"%%%%%%%%\"+expectedCount);",
 					"            utils.getItemsByPoLineId(line.id, expectedCount, (err, response) => {",
 					"                pm.test(\"Search for item records by PO Line id=\" + line.id, function() {",
 					"                    if (response.code !== 200) {",
@@ -15402,19 +15405,20 @@
 					"                        pm.test(\"No item(s) expected to exist for PO line with id=\" + line.id, () => {",
 					"                            pm.expect(items.length).to.eql(0);",
 					"                        });",
-					"                        if (items.length === 0) {",
+					"                        //for checkin there can be a case where the items are not created but holdings are created",
+					"                    }",
+					"                    ",
+					"                    if (items.length === 0) {",
 					"                            utils.sendGetRequest(\"/holdings-storage/holdings?limit=100&query=instanceId==\" + line.instanceId, (err, res) => {",
 					"                                let body = res.json();",
-					"                                // if (utils.isHoldingsUpdateRequired(line)) {",
 					"                                body.holdingsRecords.forEach(hld => {",
 					"                                    holdingsIds.push(hld.id);",
 					"                                });",
-					"                                //   }",
 					"                                resolve(holdingsIds);",
 					"                            });",
-					"                        }",
-					"                        return;",
+					"                            return;",
 					"                    }",
+					"                    ",
 					"",
 					"                    let promises = [];",
 					"                    items.forEach(item => {",
@@ -15424,12 +15428,27 @@
 					"                        }",
 					"                        promises.push(utils.processDeleteRequest(\"/item-storage/items/\" + item.id));",
 					"                    });",
+					"                    ",
+					"                    //handle a scenario where items do not exist for a holding but it is created while check-in order",
+					"                    promises.push(",
+					"                        new Promise((resolve) => {",
+					"                            utils.sendGetRequest(\"/holdings-storage/holdings?limit=100&query=instanceId==\" + line.instanceId, (err, res) => {",
+					"                                let body = res.json();",
+					"                                body.holdingsRecords.forEach(hld => {",
+					"                                    if (!holdingsIds.includes(hld.id)) {",
+					"                                        holdingsIds.push(hld.id);",
+					"                                    }",
+					"                                });",
+					"                                resolve(res.code);",
+					"                            });",
+					"                        }));",
 					"",
 					"                    // Wait for items to be deleted and then return holdings ids as a result of the promise defined in the top",
 					"                    Promise.all(promises)",
 					"                    // The promisses will be always resolved so not handling reject case",
 					"                        .then(itemDelResults => {",
 					"                            // Returning the holding ids regardless of the result of the item deletion jut to try to delete holdings in any case",
+					"                            ",
 					"                            resolve(holdingsIds);",
 					"",
 					"                            let deletedQty = itemDelResults.filter(code => code === 204).length;",
@@ -15830,163 +15849,163 @@
 	],
 	"variable": [
 		{
-			"id": "3573e6fb-0948-43c3-bd6a-01d7577421f4",
+			"id": "22ff6f01-3a7e-415f-b296-640de2e98dfb",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "7958a9af-3b13-4a03-99ce-afd2cabd58bc",
+			"id": "4e345b04-8174-47a8-a3e4-9e3c328ea36f",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/acq-models/master",
 			"type": "string"
 		},
 		{
-			"id": "3a2d1381-e8f2-4a7c-aae8-2c0e4c1987fd",
+			"id": "37c5fbfc-a18e-4599-bda6-3a7bb56ecc6a",
 			"key": "schema_composite_purchase_order",
 			"value": "composite_purchase_order.json",
 			"type": "string"
 		},
 		{
-			"id": "c1771ded-244a-4538-9c38-743a191a31cc",
+			"id": "08ed0adb-7c38-451e-9799-2c5db7c58a6c",
 			"key": "schema_alert",
 			"value": "alert.json",
 			"type": "string"
 		},
 		{
-			"id": "0c08282f-4845-4163-b626-3f7c4cf78342",
+			"id": "f981703c-eafd-4235-a4f4-d735d7483e35",
 			"key": "schema_claim",
 			"value": "claim.json",
 			"type": "string"
 		},
 		{
-			"id": "d8c22c9a-fd01-44de-ac29-ca026cf5c551",
+			"id": "8934075d-72cd-47c0-b6a1-7ac45931c789",
 			"key": "schema_composite_po_line",
 			"value": "composite_po_line.json",
 			"type": "string"
 		},
 		{
-			"id": "713caa13-11ee-4b50-8f2e-1668876b66f6",
+			"id": "bd095cab-79c4-4449-97e0-e80928034554",
 			"key": "schema_cost",
 			"value": "cost.json",
 			"type": "string"
 		},
 		{
-			"id": "9f63b425-d6b0-4067-a1e6-72668868f9e1",
+			"id": "cf34aae9-c52c-4293-93e9-63d1ec4930db",
 			"key": "schema_details",
 			"value": "details.json",
 			"type": "string"
 		},
 		{
-			"id": "15c5fe03-5c76-434c-87f0-28f0087b5758",
+			"id": "7529973d-a864-4707-9a8f-a2d8258eda4b",
 			"key": "schema_eresource",
 			"value": "eresource.json",
 			"type": "string"
 		},
 		{
-			"id": "86bc8fa4-7a5a-4390-a044-600b02f33a5d",
+			"id": "65ed988f-6405-4bd7-a0f6-27e540837eeb",
 			"key": "schema_fundDistribution",
 			"value": "fund_distribution.json",
 			"type": "string"
 		},
 		{
-			"id": "1488c2f3-4c07-4295-bd3b-d5aba2c9b6d4",
+			"id": "6ab97e92-4d25-4ec6-8288-23023b2c8551",
 			"key": "schema_location",
 			"value": "location.json",
 			"type": "string"
 		},
 		{
-			"id": "d8a99dd7-b79f-4c3b-9884-575b807890ae",
+			"id": "31589cce-e71e-48c8-a576-c9a0b70f7274",
 			"key": "schema_physical",
 			"value": "physical.json",
 			"type": "string"
 		},
 		{
-			"id": "5b799621-ddcf-44b4-b950-d8ebf63a52f2",
+			"id": "5d39fc31-3c0d-4806-8113-bac0bd9f1d58",
 			"key": "schema_renewal",
 			"value": "renewal.json",
 			"type": "string"
 		},
 		{
-			"id": "b04d48de-94e7-420c-a379-948eacb3fe8a",
+			"id": "31ab6f54-d823-4c8a-bf89-98654b291653",
 			"key": "schema_reporting_code",
 			"value": "reporting_code.json",
 			"type": "string"
 		},
 		{
-			"id": "b2206055-48f7-40e3-9ff8-8dfe9b8e063b",
+			"id": "5688e398-82c1-4f3c-a056-863bcbfe841d",
 			"key": "schema_source",
 			"value": "source.json",
 			"type": "string"
 		},
 		{
-			"id": "5224357c-e3d8-4423-85cb-1eee5461a7ef",
+			"id": "c60523fd-597f-46c9-8414-e85d71ca2479",
 			"key": "schema_vendorDetail",
 			"value": "vendor_detail.json",
 			"type": "string"
 		},
 		{
-			"id": "94aae42d-bc49-4b21-b005-fe64248b9e42",
+			"id": "c0c0b98e-b42f-4a89-9120-6a846347213d",
 			"key": "schema_orderFormat",
 			"value": "order_format.json",
 			"type": "string"
 		},
 		{
-			"id": "0756fadf-70c6-4d4a-919c-18e9f1dd23a4",
+			"id": "7d2587de-7b77-4b71-adc9-cf04c2daa245",
 			"key": "schema_receiptStatus",
 			"value": "receipt_status.json",
 			"type": "string"
 		},
 		{
-			"id": "5e7c5ba1-f8ba-4397-a7c3-006b16d78fb8",
+			"id": "0981fb4d-5040-4a68-aead-f1c8873c2cf1",
 			"key": "storage_module",
 			"value": "mod-orders-storage",
 			"type": "string"
 		},
 		{
-			"id": "301fea28-aebc-4308-a1f3-8c3d8a903bfe",
+			"id": "c915d014-4915-406a-801a-930afcb7ec32",
 			"key": "business_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "dcb5cb4b-f683-4151-b458-86ade9bd7cd6",
+			"id": "625efe10-de33-4ec7-989d-ba4d9d45e298",
 			"key": "schema_metadata",
 			"value": "metadata.schema",
 			"type": "string"
 		},
 		{
-			"id": "7e2ca12b-6e4d-4934-98aa-f714b858dd46",
+			"id": "88f5074f-a16d-4229-ae75-cce9db449710",
 			"key": "schema_poNumber",
 			"value": "po_number.json",
 			"type": "string"
 		},
 		{
-			"id": "90068f31-c201-443f-a229-869ab5b8e083",
+			"id": "fd410383-f51e-4519-b458-1bb8c7ec46b0",
 			"key": "raml_loc",
 			"value": "https://raw.githubusercontent.com/folio-org/raml/raml1.0",
 			"type": "string"
 		},
 		{
-			"id": "ce7309f6-aac5-4a37-8452-bde81da022f1",
+			"id": "1f04db93-d44a-42ec-8e5f-96d360900eaf",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "8d40040d-c8d4-4ec1-ad55-7c8661069370",
+			"id": "d9c7e0ec-6239-4a96-9046-88b0c7e3514a",
 			"key": "orders_module",
 			"value": "mod-orders",
 			"type": "string"
 		},
 		{
-			"id": "33142d57-2ac3-460b-a153-8cbf81fb0922",
+			"id": "c448741f-bd66-4ad6-a23b-bb7e8785a2cc",
 			"key": "schema_productIdType",
 			"value": "product_id_type.json",
 			"type": "string"
 		},
 		{
-			"id": "5ad91fec-2fd0-4368-9eaf-99658dcc880a",
+			"id": "668b53e9-d04b-45bb-a5d9-c0bba0ee3473",
 			"key": "common_folder",
 			"value": "common",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "280c325c-1685-4559-9383-14bc3d4d38ac",
-		"name": "mod-orders",
+		"_postman_id": "0c5a5eab-1ab8-4ba5-8c9f-89b4b8781512",
+		"name": "mod-orders copy",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -4727,6 +4727,131 @@
 								"description": "Create a purchase order in Open status based on `po_listed_print_monograph.json` from mod-orders. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117)).\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `true`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`, checkinItems is `true`."
 							},
 							"response": []
+						},
+						{
+							"name": "Create order all po lines checkin",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_one_physical_one_electronic_lines.json\", (err, res) => {",
+											"    let order  = res.json();",
+											"    order.workflowStatus = \"Open\";",
+											"    order = utils.deletePoNumber(order);",
+											"    order.poNumber = \"CH3CK1NPHYELEC\";",
+											"",
+											"    // Set checkingItems flag",
+											"    order.compositePoLines[0].checkinItems = true;",
+											"    order.compositePoLines[1].checkinItems = true;",
+											"",
+											"    // Set new product ids to be sure that new instances will be created",
+											"    delete order.compositePoLines[0].details.productIds;",
+											"    delete order.compositePoLines[1].details.productIds;",
+											"    ",
+											"    order.compositePoLines[0].details.productIds[0].productId = \"11311321131132\";",
+											"    order.compositePoLines[0].details.productIds[0].productIdType = \"ISBN\";",
+											"    order.compositePoLines[1].details.productIds[0].productId = \"11321331132133\";",
+											"    order.compositePoLines[0].details.productIds[0].productIdType = \"ISBN\";",
+											"    ",
+											"    order.compositePoLines[0].title = \"Hey! Just API testing checkin\"",
+											"    order.compositePoLines[1].title = \"Hey! Just API testing checkin with no items\"",
+											"    ",
+											"    //set proper material Type",
+											"    order.compositePoLines[0].physical.materialType = pm.globals.get(\"materialType\");",
+											"    ",
+											"    //set create Inventory so that no item interaction is necessary",
+											"    order.compositePoLines[1].eresource.createInventory = \"Instance, Holding\";",
+											"    ",
+											"    pm.variables.set(\"poForTestingCheckin\", JSON.stringify(utils.prepareOrder(order)));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											" ",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    jsonData = pm.response.json();",
+											"});",
+											"",
+											"jsonData.compositePoLines.forEach(line => {",
+											"     utils.validateReceiptStatus(line, \"Awaiting Receipt\");",
+											"    if(line.orderFormat === \"Physical Resource\"){",
+											"        pm.globals.set(\"checkin_physical_poLine\", line);",
+											"    }else{",
+											"        pm.globals.set(\"checkin_electronic_poLine\", line);",
+											"    }",
+											"    });",
+											"",
+											"pm.test(\"Each order has these optional fields\", function() {",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.globals.set(\"poAllPoLineCheckin\", jsonData.id); ",
+											"    pm.expect(jsonData.approved).to.exist;",
+											"    pm.expect(jsonData.poNumber).to.exist;",
+											"    pm.expect(jsonData.notes).to.exist;",
+											"    pm.expect(jsonData.totalItems).to.exist;",
+											"    pm.expect(jsonData.vendor).to.exist;",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "",
+										"type": "text",
+										"value": "",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{poForTestingCheckin}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders"
+									]
+								},
+								"description": "Create a purchase order in Open status based on `po_listed_print_monograph.json` from mod-orders. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117)).\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `true`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`, checkinItems is `true`."
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -8369,6 +8494,468 @@
 									]
 								},
 								"description": "Create an order with minimal required fields (update based on [MODORDERS-136](https://issues.folio.org/browse/MODORDERS-136) and [MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145)."
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "check-in",
+					"item": [
+						{
+							"name": "check-in pieces without items in Inventory",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "36abaaa2-063f-42d6-9cb0-c4020c263425",
+										"exec": [
+											"//create piece - > need po line id , format , (can add location )",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"let compPoLine = pm.globals.get(\"checkin_electronic_poLine\");",
+											"",
+											"",
+											"utils.createPieceAndCheckInBody(compPoLine);",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "4f537129-29fc-4653-9e93-b75d7b56131b",
+										"exec": [
+											"//verify that the po line receipt status is partially received",
+											"//verify that the piece status is updated to Received",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"checkinBody\"));",
+											"let checkinPoLineId = pm.variables.get(\"checkinPoLineId\");",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has 1 pieces successfully checked-in\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeCheckedIn.length);",
+											"    // One pieces should be successfully checked-in",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + checkinPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Partially Received\");",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 0, \"Expected\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{checkinBody}}"
+								},
+								"url": {
+									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "http",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									],
+									"query": [
+										{
+											"key": "",
+											"value": "",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "revert checked-in piece without items in inventory",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c2ee708a-93a0-44e8-b34e-ab5725cf702f",
+										"exec": [
+											"//verify piece status is set to expected",
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"checkinBody\"));",
+											"let checkinPoLineId = pm.globals.get(\"checkin_electronic_poLine\").id;",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has 1 pieces successfully reverted\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeCheckedIn.length);",
+											"    // One pieces should be successfully checked-in",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + checkinPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Awaiting Receipt\");",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 1, \"Expected\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "4ef77f6a-87da-447a-937c-7d1ace325bcf",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let compPoLine = pm.globals.get(\"checkin_electronic_poLine\");",
+											"",
+											"utils.sendGetRequest(\"/orders-storage/pieces?limit=1&query=poLineId==\"+compPoLine.id +\" and format == Electronic and receivingStatus == Received\", (err,res) => {",
+											"    utils.prepareCheckinBody(compPoLine,res.json().pieces[0].id,\"On Order\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{checkinBody}}"
+								},
+								"url": {
+									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "http",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "check-in the existing piece",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c2ee708a-93a0-44e8-b34e-ab5725cf702f",
+										"exec": [
+											"//verify piece status is set to expected",
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"checkinBody\"));",
+											"let checkinPoLineId = pm.globals.get(\"checkin_electronic_poLine\").id;",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has 1 pieces successfully reverted\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeCheckedIn.length);",
+											"    // One pieces should be successfully checked-in",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + checkinPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Partially Received\");",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 0, \"Expected\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "4ef77f6a-87da-447a-937c-7d1ace325bcf",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let compPoLine = pm.globals.get(\"checkin_electronic_poLine\");",
+											"",
+											"utils.sendGetRequest(\"/orders-storage/pieces?limit=1&query=poLineId==\"+compPoLine.id +\" and format == Electronic and receivingStatus == Expected\", (err,res) => {",
+											"    utils.prepareCheckinBody(compPoLine,res.json().pieces[0].id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{checkinBody}}"
+								},
+								"url": {
+									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "http",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "check-in pieces with items in inventory",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "10952b47-f0f6-4745-bf89-fc354c3f7a81",
+										"exec": [
+											"//get holdings record Id -> need instance id and location id",
+											"//get loan type id",
+											"//create item -> need material type, loan type and holdings Id",
+											"//create piece - > need po line id , format , (can add location )",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"let compPoLine = pm.globals.get(\"checkin_physical_poLine\");",
+											"",
+											"",
+											"utils.prepareCheckinBodyWithItems(compPoLine);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "78b05458-c363-4075-809d-ee1077eda07f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"checkinBody\"));",
+											"let checkinPoLineId = pm.variables.get(\"checkinPoLineId\");",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has 1 pieces successfully checked-in\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeCheckedIn.length);",
+											"    // One pieces should be successfully checked-in",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + checkinPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Partially Received\");",
+											"    utils.validateInventoryItemsReceived(line, 1, \"In Process\");",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 0, \"Expected\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{checkinBody}}"
+								},
+								"url": {
+									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "http",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "revert checked-in piece with items in inventory",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "deaf3447-5310-4de3-b85e-79a6bddd2035",
+										"exec": [
+											"//verify piece status is set to expected",
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"checkinBody\"));",
+											"let checkinPoLineId = pm.globals.get(\"checkin_physical_poLine\").id;",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has 1 pieces successfully reverted\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeCheckedIn.length);",
+											"    // One pieces should be successfully checked-in",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/order-lines/\" + checkinPoLineId, (err, res) => {",
+											"    let line = res.json();",
+											"    utils.validateReceiptStatus(line, \"Awaiting Receipt\");",
+											"     utils.validateInventoryItemsReceived(line, 1, \"On Order\");",
+											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 1, \"Expected\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "7d45ea8a-6f0e-4c0e-9c5d-4eab489f57af",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let compPoLine = pm.globals.get(\"checkin_physical_poLine\");",
+											"",
+											"utils.sendGetRequest(\"/orders-storage/pieces?limit=1&query=poLineId==\"+compPoLine.id +\" and format == Physical and receivingStatus == Received\", (err,res) => {",
+											"    utils.prepareCheckinBody(compPoLine,res.json().pieces[0].id,\"On Order\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{checkinBody}}"
+								},
+								"url": {
+									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "http",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
 							},
 							"response": []
 						}
@@ -12049,6 +12636,98 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "check-in",
+					"item": [
+						{
+							"name": "check-in already received piece",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c2ee708a-93a0-44e8-b34e-ab5725cf702f",
+										"exec": [
+											"//verify piece status is set to expected",
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"checkinBody\"));",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has 1 piece failed to process\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeCheckedIn.length);",
+											"    // One pieces should be successfully checked-in",
+											"    utils.verifyReceivingResponse(jsonRs, 0, 1);",
+											"    let receivingItemResults = jsonRs.receivingResults[0].receivingItemResults;",
+											"     pm.expect(receivingItemResults[0].processingStatus).to.exist;",
+											"     pm.expect(receivingItemResults[0].processingStatus.type).to.equal(\"failure\");",
+											"     pm.expect(receivingItemResults[0].processingStatus.error).to.exist;",
+											"     pm.expect(receivingItemResults[0].processingStatus.error.code).to.equal(\"pieceAlreadyReceived\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "4ef77f6a-87da-447a-937c-7d1ace325bcf",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let compPoLine = pm.globals.get(\"checkin_electronic_poLine\");",
+											"",
+											"utils.sendGetRequest(\"/orders-storage/pieces?limit=1&query=poLineId==\"+compPoLine.id +\" and format == Electronic and receivingStatus == Received\", (err,res) => {",
+											"    utils.prepareCheckinBody(compPoLine,res.json().pieces[0].id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{checkinBody}}"
+								},
+								"url": {
+									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "http",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			]
 		},
@@ -13190,6 +13869,69 @@
 								"description": "GET /orders/composite-orders/id requests that return 204"
 							},
 							"response": []
+						},
+						{
+							"name": "Delete order all polines checkin",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.poAllPoLineCheckin, true);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{poAllPoLineCheckin}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{poAllPoLineCheckin}}"
+									]
+								},
+								"description": "DELETE /orders/composite-orders/id requests that return 204"
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -13657,6 +14399,52 @@
 					"            }],",
 					"            \"totalRecords\": 1",
 					"        }",
+					"    },",
+					"    piece: {",
+					"        bodyTemplate: {",
+					"                 \"caption\": \"Volume\",",
+					"                 \"comment\": \"creating Piece from API test\",",
+					"                 \"format\": \"\",",
+					"                 \"locationId\": \"\",",
+					"                 \"poLineId\": \"\",",
+					"                 \"receivingStatus\": \"Expected\",",
+					"                 \"supplement\": true",
+					"            }",
+					"    },",
+					"    checkin: {",
+					"        bodyTemplate: {",
+					"            \"toBeCheckedIn\": [",
+					"              {",
+					"                \"poLineId\": \"\",",
+					"                \"checkedIn\": \"\",",
+					"                \"checkInPieces\": [",
+					"                    {",
+					"                        \"id\": \"\",",
+					"                        \"barcode\": Math.floor(Math.random() * 1000),",
+					"                        \"comment\": \"checkedin from API test\",",
+					"                        \"caption\": \"Vol. 1\",",
+					"                        \"createItem\": true,",
+					"                        \"supplement\": false,",
+					"                        \"locationId\": \"\",",
+					"                        \"accessionNumber\": \"1956.1\",",
+					"                        \"itemDescription\": \"This is the piece item checkin\",",
+					"                        \"electronicBookplate\": \"This item is from API tests\",",
+					"                        \"itemStatus\": \"\"",
+					"                    }]",
+					"              }],",
+					"              \"totalRecords\":1",
+					"        }",
+					"    },",
+					"    item: {",
+					"        bodyTemplate: {",
+					"                 \"holdingsRecordId\": \"\",",
+					"                 \"permanentLoanTypeId\": pm.variables.get(\"loanType\"),",
+					"                 \"materialTypeId\": pm.variables.get(\"materialType\"),",
+					"                 \"status\": {",
+					"                        \"name\": \"On Order\"",
+					"                    },",
+					"                 \"purchaseOrderLineIdentifier\":\"\"",
+					"            }",
 					"    }",
 					"",
 					"};",
@@ -13897,12 +14685,14 @@
 					"    };",
 					"",
 					"    /**",
-					"     * Validates that PO Line's receipt status updated to expected",
+					"     * Validates that PO Line's receipt status updated to expected,",
+					"     * and incase of checkin the receipt date has to be validated ",
+					"     * if receipt status is partially received, as it is updated for first piece checkec-in",
 					"     */",
 					"    utils.validateReceiptStatus = function(poLine, receiptStatus) {",
 					"        pm.test(poLine.poLineNumber + \" PO Line should have \" + receiptStatus + \" receipt status\", function() {",
 					"            pm.expect(poLine.receiptStatus, \"Receipt status should be \" + receiptStatus).to.equal(receiptStatus);",
-					"            if (\"Fully Received\" === receiptStatus) {",
+					"            if (\"Fully Received\" === receiptStatus || (poLine.checkinItems === true && \"Partially Received\" === receiptStatus)) {",
 					"                pm.expect(poLine.receiptDate, \"Receipt date should be set\").to.not.be.empty;",
 					"            } else {",
 					"                pm.expect(poLine.receiptDate, \"Receipt date should be empty\").to.not.exist;",
@@ -13922,12 +14712,15 @@
 					"    /**",
 					"     * Validates that items received in the inventory (MODORDERS-103)",
 					"     */",
-					"    utils.validateInventoryItemsReceived = function(poLine, expectedQuantity) {",
+					"    utils.validateInventoryItemsReceived = function(poLine, expectedQuantity, itemStatus) {",
 					"        let expectedCount = typeof expectedQuantity === \"undefined\" ? utils.calculateExpectedItemsQuantity(poLine) : expectedQuantity;",
-					"        utils.sendGetRequest(\"/item-storage/items?limit=100&query=status.name==Received and purchaseOrderLineIdentifier==\" + poLine.id, (err, res) => {",
+					"        let status = typeof itemStatus === \"undefined\" ? \"Received\" : itemStatus;",
+					"        utils.sendGetRequest(\"/item-storage/items?limit=100&query=status.name==\"+status+  \" and purchaseOrderLineIdentifier==\" + poLine.id, (err, res) => {",
 					"            pm.test(expectedCount + \" Item Records marked as received for PO Line with number=\" + poLine.poLineNumber, function() {",
 					"                let body = res.json();",
 					"                pm.expect(body, \"GET Items response is not in json format\").to.exist;",
+					"                console.log(body);",
+					"                console.log(body.totalRecords);",
 					"                pm.expect(body.totalRecords, \"Quantity of items received for PO Line should be \" + expectedCount).to.equal(expectedCount);",
 					"                body.items.forEach(function(item) {",
 					"                    pm.expect(item.barcode, \"Barcode should not be empty\").to.not.be.empty;",
@@ -14519,12 +15312,82 @@
 					"                    resolve(response.json().items);",
 					"",
 					"                    // Test expected items count as the last step to make sure delete requests are sent",
+					"                    // in case of checkin we do not know the item count",
+					"                  if(!line.checkinItems === true){",
 					"                    let foundItems = response.json().totalRecords;",
 					"                    pm.expect(foundItems, \"Expected items count does not match to found\").to.equal(expectedCount);",
+					"                    }",
 					"                });",
 					"            });",
 					"        });",
 					"    };",
+					"     /**check-in methods",
+					"     */",
+					"     utils.postRequest = function (path, postBody, handler) {",
+					"        pm.sendRequest({",
+					"            url: utils.buildOkapiUrl(path),",
+					"            method: 'POST',",
+					"            header: {",
+					"                \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
+					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\"),",
+					"                \"Content-type\": \"application/json\"",
+					"            },",
+					"            body: {",
+					"                mode: 'raw',",
+					"                raw: JSON.stringify(postBody)",
+					"            }",
+					"        }, handler);",
+					"    }",
+					"    utils.createPieceAndCheckInBody = function (compPoLine, itemId) {",
+					"        let pieceTemplate = globals.testData.piece.bodyTemplate;",
+					"        pieceTemplate.locationId = compPoLine.locations[0].locationId;",
+					"        pieceTemplate.poLineId = compPoLine.id;",
+					"        if(compPoLine.orderFormat == \"Electronic Resource\"){",
+					"            pieceTemplate.format = \"Electronic\";",
+					"        }else{",
+					"            pieceTemplate.format = \"Physical\";",
+					"        }",
+					"        if (typeof itemId === \"undefined\") {",
+					"            delete pieceTemplate.itemId;",
+					"        } else {",
+					"            pieceTemplate.itemId = itemId;",
+					"        }",
+					"        pm.variables.set(\"checkinPoLineId\", compPoLine.id);",
+					"        utils.postRequest(\"/orders/pieces\", pieceTemplate, (err, res) => {",
+					"            utils.prepareCheckinBody(compPoLine, res.json().id);",
+					"        })",
+					"    }",
+					"    utils.prepareCheckinBody = function (compPoLine, pieceId, checkinStatus) {",
+					"        let checkinRq = globals.testData.checkin.bodyTemplate;",
+					"        let toBeCheckedInTemplate = checkinRq.toBeCheckedIn.pop();",
+					"        let checkinPiecesTemplate = toBeCheckedInTemplate.checkInPieces.pop();",
+					"        toBeCheckedInTemplate.poLineId = compPoLine.id;",
+					"        toBeCheckedInTemplate.checkedIn = 1;",
+					"        checkinPiecesTemplate.id = pieceId;",
+					"        checkinPiecesTemplate.locationId = compPoLine.locations[0].locationId;",
+					"         if (typeof checkinStatus === \"undefined\") {",
+					"            checkinPiecesTemplate.itemStatus = \"In Process\";",
+					"         }else{",
+					"            checkinPiecesTemplate.itemStatus = checkinStatus;",
+					"         }",
+					"        toBeCheckedInTemplate.checkInPieces.push(checkinPiecesTemplate);",
+					"        checkinRq.toBeCheckedIn.push(toBeCheckedInTemplate);",
+					"        console.log(JSON.stringify(checkinRq));",
+					"        pm.variables.set(\"checkinBody\", JSON.stringify(checkinRq));",
+					"    }",
+					"    utils.prepareCheckinBodyWithItems = function (compPoLine) {",
+					"        utils.sendGetRequest(\"/holdings-storage/holdings?limit=1&query=instanceId==\" + compPoLine.instanceId + \" and permanentLocationId==\" + compPoLine.locations[0].locationId, (err, res) => {",
+					"            utils.createItem(compPoLine.id, res.json().holdingsRecords[0].id, (err, res) => {",
+					"                utils.createPieceAndCheckInBody(compPoLine, res.json().id);",
+					"            });",
+					"        });",
+					"    }",
+					"    utils.createItem = function (poLineId, holdingsRecordId, handler) {",
+					"        let itemTemplate = globals.testData.item.bodyTemplate;",
+					"        itemTemplate.holdingsRecordId = holdingsRecordId;",
+					"        itemTemplate.purchaseOrderLineIdentifier = poLineId;",
+					"        utils.postRequest(\"/item-storage/items\", itemTemplate, handler);",
+					"    }",
 					"",
 					"    /**",
 					"     * Deletes Item records from Inventory. The function returns Promise which holds holdings ids once completed",


### PR DESCRIPTION
## PURPOSE
Add new test cases to cover checkin flow

## APPROACH
- Added new util methods to create pieces and items as  they are not created by mod-orders during check in flow 
- Added new tests to cover scenarios 
    1) for checkin without items required in inventory(pieces will be created in a pre request step)
    2) checkin with items in inventory(pieces and items are created in pre-request step )
    3) revert checkin of pieces and also verifying that the item status and piece status are also reverted in inventory
    4) failure scenario which throws an error if a piece is tried to checkin again
    
Additional changes
1) Changed few util methods to cover scenarios for check-in where there can be holdings without items, and cleaning those records as well