### PR TITLE
MODORDERS-218 adjust order status based on poLine's statuses

### DIFF
--- a/mod-orders/README.md
+++ b/mod-orders/README.md
@@ -19,6 +19,8 @@ Folder | Description
 `- Pending To Open order` | Verifies that order transition from `Pending` to `Open` status can be successful and expected records created in the Inventory.
 `- Open order` | Verifies that an order can be successfully created in `Open` status and expected records created in the Inventory.
 `- Receiving` | Verifies that resources can be successfully received for `Open` orders and item records updated in the Inventory.
+`- Close orders updating payment status of each PO Line` | Update PO Lines' payment statuses of `Open` orders so the system should close the order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218)).
+`- Check closed orders and re-open` | Contains sets of requests: <br> 1. Get orders and verify that their workflow status is `Closed`. If this is `true`, modify one of PO Line's payment status so the order becomes `Open` eventually.  <br> 2. Roll back one of received piece so the order becomes `Open` eventually. <br> 3. Verify that orders were successfully re-opened by operations described above. <br> <br> See [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218) for more details.
 `- PO Number` | Verifies PO Number generation/validation
 `- Get Orders` | Verifies that orders can be be retrieved by CQL query
 `Negative Tests` | Contains various requests and tests to verify expected negative cases e.g. validation of the request etc.
@@ -31,33 +33,14 @@ Folder | Description
 
 ### Collection variables
 
-Variable | Description  
- --- | --- 
-`mod-ordersResourcesURL` | Path to mod-orders test resources
-`schema_loc` | Path to acquisitions schemas
-`module` | Sub-Path to indicate where order storage schemas located
-`schema_composite_purchase_order` | File name of the composite purchase order schema
-`schema_adjustment` | File name of the adjustment schema
-`schema_alert` | File name of the alert schema
-`schema_claim` | File name of the claim schema
-`schema_composite_po_line` | File name of the composite purchase order line schema
-`schema_cost` | File name of the cost schema
-`schema_details` | File name of the details schema
-`schema_eresource` | File name of the eresource schema
-`schema_fund_distribution` | File name of the fund distribution schema
-`schema_location` | File name of the location schema
-`schema_physical` | File name of the physical schema
-`schema_renewal` | File name of the renewal schema
-`schema_reporting_code` | File name of the reporting code schema
-`schema_source` | File name of the source schema
-`schema_vendor_detail` | File name of the vendor detail schema
-`schema_metadata` | File name of the metadata schema
-`raml_loc` | Path to RMB schemas
-`poLines-limit` | Purchase Order Lines Limit to be used for configuration update
+Variable | Initial Value | Description  
+ --- | --- | --- 
+`mod-ordersResourcesURL` | https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources | Path to mod-orders test resources
+`poLines-limit` | 10 | Purchase Order Lines Limit to be used for configuration update
 
 ### Collection utility functions
 
-The functions are defined in the Pre-request Scripts section of the collection. The main idea is to create reusable functions to not duplicate data in the tests.
+The functions and request body templates are defined in the `Pre-request Scripts` section of the collection. The main idea is to create reusable functions to not duplicate the same logic in the tests.
 
 ### Issue tracker
 

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -4816,7 +4816,183 @@
 							"response": []
 						},
 						{
-							"name": "Receive all pieces for an order with 4 lines",
+							"name": "Receive all pieces for order with P/E Mix and Electronic lines",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"utils.prepareReceivingRequestForOrder(globals.completeOpenOrderId);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"receivingRqBody\"));",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has all pieces successfully received\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeReceived.length);",
+											"    // All pieces should be successfully received",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.completeOpenOrderId, (err, res) => {",
+											"    let order = res.json();",
+											"    order.compositePoLines.forEach(line => {",
+											"        utils.validateReceiptStatus(line, \"Fully Received\");",
+											"        // check that payment status is still `Partially Paid`",
+											"        utils.validatePaymentStatus(line, \"Partially Paid\");",
+											"        utils.validateInventoryItemsReceived(line);",
+											"        utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 0, \"Expected\");",
+											"    });",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{receivingRqBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								},
+								"description": "Receives all piece records for an order created by `Create Open order with P/E Mix and Electronic lines` and  request (see [MODORDERS-162](https://issues.folio.org/browse/MODORDERS-162)).  \nThe order will be still `Open` after this operation because all PO Lines have `Partially Paid` payment status (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Receive all pieces for order with physical and electronic lines",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"utils.prepareReceivingRequestForOrder(globals.physElecOpenOrderId);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"receivingRqBody\"));",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has all pieces successfully received\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeReceived.length);",
+											"    // All pieces should be successfully received",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});",
+											"",
+											"utils.sendGetRequest(\"/orders/composite-orders/\" + globals.completeOpenOrderId, (err, res) => {",
+											"    let order = res.json();",
+											"    order.compositePoLines.forEach(line => {",
+											"        utils.validateReceiptStatus(line, \"Fully Received\");",
+											"        // check that payment status is still `Partially Paid`",
+											"        utils.validatePaymentStatus(line, \"Partially Paid\");",
+											"        utils.validateInventoryItemsReceived(line);",
+											"        utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 0, \"Expected\");",
+											"    });",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{receivingRqBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								},
+								"description": "Receives all piece records for an order created by `Create Open order with physical and electronic lines` and  request (see [MODORDERS-162](https://issues.folio.org/browse/MODORDERS-162)).  \nThe order will become `Closed` after this operation because all PO Lines have `Fully Paid` payment status and `Fully Received` receipt status once all piece records are received (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Receive all pieces for order with 4 lines",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -4896,9 +5072,703 @@
 										"receive"
 									]
 								},
-								"description": "Receives all piece records for an order created by `Create another Pending order` and  request (see [MODORDERS-162](https://issues.folio.org/browse/MODORDERS-162)). The PO Line is with 10 pieces, create inventory is `false`."
+								"description": "Receives all piece records for an order created by requests from `Pending To Open order` folder (see [MODORDERS-162](https://issues.folio.org/browse/MODORDERS-162)).\nThe order will be closed after this operation (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
 							},
 							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Close orders updating payment status of each PO Line",
+					"item": [
+						{
+							"name": "Get order with 4 lines and update each one",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order with id=\" + globals.anotherCompleteOrderId + \" is retrieved and still Open\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"    pm.expect(order.compositePoLines).to.have.lengthOf(4);",
+											"",
+											"    utils.updatePoLinesPaymentStatus(order);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{anotherCompleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{anotherCompleteOrderId}}"
+									]
+								},
+								"description": "Gets order created by requests from `Pending To Open order` and updates PO Lines' payment status so the system should close the order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Get order with receipt not required and update each line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order with id=\" + globals.completeOpenOrderId + \" is retrieved and still Open\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"    pm.expect(order.compositePoLines).to.have.lengthOf(2);",
+											"",
+											"    utils.updatePoLinesPaymentStatus(order);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithoutInventoryRecordsId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{orderWithoutInventoryRecordsId}}"
+									]
+								},
+								"description": "Gets order created by `Create Order With receipt not required` request and updates PO Lines' payment status so the system should close the order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Get Mixed order and update each line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order with id=\" + globals.completeOpenOrderId + \" is retrieved and still Open\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"    pm.expect(order.compositePoLines).to.have.lengthOf(2);",
+											"",
+											"    utils.updatePoLinesPaymentStatus(order);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOpenOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{completeOpenOrderId}}"
+									]
+								},
+								"description": "Gets order created by `Create Open order with P/E Mix and Electronic lines` request and updates PO Lines' payment status so the system should close the order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						}
+					],
+					"description": "Update PO Lines' payment statuses of `Open` orders so the system should close the order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218)).",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "29244719-2601-47a5-b644-43352afbd73e",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "cc81ace0-a9b1-48dc-8add-8d8f934ab720",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Check closed orders and re-open",
+					"item": [
+						{
+							"name": "Order with 4 PO Lines should be already closed",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order is Closed\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Closed\");",
+											"    pm.expect(order.closeReason).to.exist;",
+											"    pm.expect(order.closeReason.reason).to.equal(\"Complete\");",
+											"",
+											"    // Update only payment status to re-open order eventually",
+											"    utils.updatePoLinePaymentStatus(order.compositePoLines[0], \"Cancelled\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{anotherCompleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{anotherCompleteOrderId}}"
+									]
+								},
+								"description": "Gets order created by requests from `Pending To Open order` and verifies that it is closed now.  \nIf all is okay, change `paymentStatus` of the first PO Line to `Cancelled`. This should re-open order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Order with receipt not required should be already closed",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order is Closed\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Closed\");",
+											"    pm.expect(order.closeReason).to.exist;",
+											"    pm.expect(order.closeReason.reason).to.equal(\"Complete\");",
+											"",
+											"    // Update only payment status to re-open order eventually",
+											"    utils.updatePoLinePaymentStatus(order.compositePoLines[0], \"Partially Paid\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithoutInventoryRecordsId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{orderWithoutInventoryRecordsId}}"
+									]
+								},
+								"description": "Gets order created by `Create Order With receipt not required` verifies that it is closed now.  \nIf all is okay, change `paymentStatus` of the first PO Line to `Partially Paid`. This should re-open order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Mixed order should be already closed",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order is Closed\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Closed\");",
+											"    pm.expect(order.closeReason).to.exist;",
+											"    pm.expect(order.closeReason.reason).to.equal(\"Complete\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOpenOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{completeOpenOrderId}}"
+									]
+								},
+								"description": "Gets order created by `Create Open order with P/E Mix and Electronic lines` verifies that it is closed now (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Mixed order: revert 1 received piece for Electronic line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"eval(globals.loadUtils).prepareRollBackReceivingRequestForPoLineOfFormat(globals.completeOpenOrderId, \"Electronic Resource\", 1);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let jsonRq = JSON.parse(pm.variables.get(\"receivingRqBody\"));",
+											"",
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"The reponse has successfully reverted piece\", function () {",
+											"    let jsonRs = pm.response.json();",
+											"    pm.expect(jsonRs.totalRecords).to.equal(jsonRq.totalRecords);",
+											"    pm.expect(jsonRs.receivingResults).to.have.lengthOf(jsonRq.toBeReceived.length);",
+											"    // All pieces should be successfully received",
+											"    utils.verifyReceivingResponse(jsonRs, jsonRq.totalRecords, 0);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{receivingRqBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								},
+								"description": "Revert 1 received piece record back to `Expected` and associated Inventory item back to `On order` for a PO Line with `Electronic Resource` order format from an order created by `Create Open order with P/E Mix and Electronic lines` request (see [MODORDERS-175](https://issues.folio.org/browse/MODORDERS-175))."
+							},
+							"response": []
+						},
+						{
+							"name": "Order with 4 PO Lines should be already reopened",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order is re-opened\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{anotherCompleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{anotherCompleteOrderId}}"
+									]
+								},
+								"description": "Gets order created by requests from `Pending To Open order` and verifies that it is closed now.  \nIf all is okay, change `paymentStatus` of the first PO Line to `Cancelled`. This should re-open order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Order with receipt not required should be already reopened",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order is re-opened\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithoutInventoryRecordsId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{orderWithoutInventoryRecordsId}}"
+									]
+								},
+								"description": "Gets order created by `Create Order With receipt not required` verifies that it is closed now.  \nIf all is okay, change `paymentStatus` of the first PO Line to `Partially Paid`. This should re-open order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						},
+						{
+							"name": "Mixed order should be already reopened",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Order is re-opened\", function() {",
+											"    pm.response.to.be.ok;",
+											"",
+											"    let order = pm.response.json();",
+											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOpenOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{completeOpenOrderId}}"
+									]
+								},
+								"description": "Gets order created by `Create Open order with P/E Mix and Electronic lines` verifies that it is closed now (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
+							},
+							"response": []
+						}
+					],
+					"description": "The folder contains sets of requests:  \n1. Get orders and verify that their workflow status is `Closed`. If this is true, modify one of PO Line's payment status so the order becomes `Open` eventually.\n2. Roll back one of received piece so the order becomes `Open` eventually.\n3. Verify that orders were successfully re-opened by operations described above.\n\nSee [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218) for more details.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "33ebe467-3c80-4a4f-a8d1-3a3747ea83e0",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "c7e0b8bc-84f1-46b6-8f1d-a468ef24312b",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						}
 					],
 					"_postman_isSubFolder": true
@@ -14328,21 +15198,15 @@
 					"        if (compPOL.checkinItems != null && compPOL.checkinItems) {",
 					"            return false;",
 					"        }",
-					"        if (compPOL.eresource != null && compPOL.eresource.createInventory === \"Instance, Holding, Item\") {",
-					"            return true;",
-					"        }",
-					"        return false;",
-					"    }",
+					"        return compPOL.eresource != null && compPOL.eresource.createInventory === \"Instance, Holding, Item\";",
+					"    };",
 					"",
 					"    utils.isItemsUpdateRequiredForPhysical = function(compPOL) {",
 					"        if (compPOL.checkinItems != null && compPOL.checkinItems) {",
 					"            return false;",
 					"        }",
-					"        if (compPOL.physical != null && compPOL.physical.createInventory === \"Instance, Holding, Item\") {",
-					"            return true;",
-					"        }",
-					"        return false;",
-					"    }",
+					"        return compPOL.physical != null && compPOL.physical.createInventory === \"Instance, Holding, Item\";",
+					"    };",
 					"",
 					"    /**",
 					"     * Validates presence of the PO line sub-object elements",
@@ -14414,6 +15278,34 @@
 					"        pm.expect(poLine.tags, \"tags should be empty\").to.be.an('array').that.is.empty;",
 					"        pm.expect(poLine.title, \"title expected\").to.exist;",
 					"        pm.expect(poLine.vendorDetail, \"vendorDetail not expected\").to.not.exist;",
+					"    };",
+					"",
+					"    /**",
+					"     * Updates each PO Line's payment status with provided one.",
+					"     * If status is not provided, \"Fully Paid\" is used for even and \"Payment Not Required\" for odd ones.",
+					"     */",
+					"    utils.updatePoLinesPaymentStatus = function(order, status) {",
+					"        // Update only payment status",
+					"        let lines = order.compositePoLines;",
+					"        for (let i = 0; i < lines.length; i++) {",
+					"            let newStatus = status;",
+					"            if (!newStatus) {",
+					"                newStatus = (i % 2 === 0) ? \"Fully Paid\" : \"Payment Not Required\";",
+					"            }",
+					"            // Send update line request with delay",
+					"            setTimeout(() => utils.updatePoLinePaymentStatus(lines[i], newStatus), 500 * i);",
+					"        }",
+					"    };",
+					"",
+					"    /**",
+					"     * Updates PO Line's payment status with provided one and sends PUT request.",
+					"     */",
+					"    utils.updatePoLinePaymentStatus = function(poLine, status) {",
+					"        // Update only payment status",
+					"        poLine.paymentStatus = status;",
+					"        utils.sendPutRequest(\"/orders/order-lines/\" + poLine.id, poLine, (err, response) => {",
+					"            pm.test(\"PO Line updated with number=\" + poLine.poLineNumber, () => pm.expect(response.code).to.eql(204));",
+					"        });",
 					"    };",
 					"",
 					"    /**",
@@ -14583,8 +15475,8 @@
 					"                raw: JSON.stringify(postBody)",
 					"            }",
 					"        }, handler);",
-					"    }",
-					"    ",
+					"    };",
+					"",
 					"    /**",
 					"     *This method creates a piece and also calls the prepares the check-in body.",
 					"     * If itemId is not provided the check-in flow just updates the piece record",
@@ -14593,7 +15485,7 @@
 					"        let pieceTemplate = globals.testData.piece.bodyTemplate;",
 					"        pieceTemplate.locationId = compPoLine.locations[0].locationId;",
 					"        pieceTemplate.poLineId = compPoLine.id;",
-					"        if(compPoLine.orderFormat == \"Electronic Resource\"){",
+					"        if(compPoLine.orderFormat === \"Electronic Resource\"){",
 					"            pieceTemplate.format = \"Electronic\";",
 					"        }else{",
 					"            pieceTemplate.format = \"Physical\";",
@@ -14634,8 +15526,8 @@
 					"        checkinRq.toBeCheckedIn.push(toBeCheckedInTemplate);",
 					"        console.log(JSON.stringify(checkinRq));",
 					"        pm.variables.set(\"checkinBody\", JSON.stringify(checkinRq));",
-					"    }",
-					"    ",
+					"    };",
+					"",
 					"    /**",
 					"     * Get the holding where the item needs to be created , create an item",
 					"     * and then use the item id to create a piece",
@@ -14650,14 +15542,14 @@
 					"                utils.createPieceAndCheckInBody(compPoLine, res.json().id);",
 					"            });",
 					"        });",
-					"    }",
-					"    ",
+					"    };",
+					"",
 					"    utils.createItem = function (poLineId, holdingsRecordId, handler) {",
 					"        let itemTemplate = globals.testData.item.bodyTemplate;",
 					"        itemTemplate.holdingsRecordId = holdingsRecordId;",
 					"        itemTemplate.purchaseOrderLineIdentifier = poLineId;",
 					"        utils.postRequest(\"/item-storage/items\", itemTemplate, handler);",
-					"    }",
+					"    };",
 					"",
 					"    /**",
 					"     * Deletes Item records from Inventory. The function returns Promise which holds holdings ids once completed",
@@ -14924,16 +15816,7 @@
 					"     * @param body with updated data",
 					"     */",
 					"    utils.updateConfig = function(body) {",
-					"        pm.sendRequest({",
-					"            url: utils.buildOkapiUrl(\"/configurations/entries/\" + body.id),",
-					"            method: \"PUT\",",
-					"            header: {",
-					"                \"X-Okapi-Token\": pm.variables.get(\"xokapitoken\"),",
-					"                \"Content-type\": \"application/json\",",
-					"                \"Accept-Encoding\": \"identity\"",
-					"            },",
-					"            body: JSON.stringify(body)",
-					"        }, function(err, response) {",
+					"        utils.sendPutRequest(\"/configurations/entries/\" + body.id, body, (err, response) => {",
 					"            pm.test(\"Config updated. Config name = \" + body.configName, function() {",
 					"                pm.expect(response.code).to.eql(204);",
 					"            });",
@@ -14956,32 +15839,26 @@
 					"     * Sends GET request and uses passed handler to handle result",
 					"     */",
 					"    utils.sendGetRequest = function(path, handler) {",
-					"        pm.sendRequest({",
-					"                url: utils.buildOkapiUrl(path),",
-					"                method: \"GET\",",
-					"                header: {",
-					"                    \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-					"                    \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\")",
-					"                }",
-					"            },",
-					"            handler",
-					"        );",
+					"        pm.sendRequest(utils.buildPmRequest(path, \"GET\"), handler);",
+					"    };",
+					"",
+					"    /**",
+					"     * Sends PUT request and uses passed handler to handle result",
+					"     */",
+					"    utils.sendPutRequest = function(path, body, handler) {",
+					"        // Build request and add required header and body",
+					"        let pmRq = utils.buildPmRequest(path, \"PUT\");",
+					"        pmRq.header[\"Content-type\"] = \"application/json\";",
+					"        pmRq.body = JSON.stringify(body);",
+					"",
+					"        pm.sendRequest(pmRq, handler);",
 					"    };",
 					"",
 					"    /**",
 					"     * Sends DELETE request and uses passed handler to handle result",
 					"     */",
 					"    utils.sendDeleteRequest = function(path, handler) {",
-					"        pm.sendRequest({",
-					"                url: utils.buildOkapiUrl(path),",
-					"                method: \"DELETE\",",
-					"                header: {",
-					"                    \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-					"                    \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\")",
-					"                }",
-					"            },",
-					"            handler",
-					"        );",
+					"        pm.sendRequest(utils.buildPmRequest(path, \"DELETE\"), handler);",
 					"    };",
 					"",
 					"    /**",
@@ -15013,12 +15890,14 @@
 					"        pm.globals.unset(\"poToCheckinItemsId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryNullId1\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryNullId2\");",
+					"        pm.globals.unset(\"orderWithCreateInventoryNullId3\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryNoneId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryInstanceId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryInstanceHoldingId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryInstanceHoldingItemId\");",
 					"        pm.globals.unset(\"newEmptyPoLine\");",
 					"        pm.globals.unset(\"poNumber\");",
+					"        pm.globals.unset(\"loanType\");",
 					"        pm.globals.unset(\"materialType\");",
 					"",
 					"        pm.environment.unset(\"xokapitoken\");",
@@ -15099,39 +15978,9 @@
 			"type": "string"
 		},
 		{
-			"id": "fc35cb36-2f74-405a-a388-9346605704b7",
-			"key": "storage_module",
-			"value": "mod-orders-storage",
-			"type": "string"
-		},
-		{
-			"id": "1a8f6619-69c6-4021-b6ff-fd7b5c6d7599",
-			"key": "business_module",
-			"value": "mod-orders",
-			"type": "string"
-		},
-		{
-			"id": "64973f63-79b2-4dca-be29-71ec46a1d241",
-			"key": "raml_loc",
-			"value": "https://raw.githubusercontent.com/folio-org/raml/raml1.0",
-			"type": "string"
-		},
-		{
 			"id": "c9eeba3e-9d77-4af3-854c-fbc2d73eb31a",
 			"key": "poLines-limit",
 			"value": "10",
-			"type": "string"
-		},
-		{
-			"id": "c3cd4a6f-c978-49fc-86b2-98402a4769be",
-			"key": "orders_module",
-			"value": "mod-orders",
-			"type": "string"
-		},
-		{
-			"id": "599bf47a-7e2b-4e5f-afb3-a086b6c8d0fb",
-			"key": "common_folder",
-			"value": "common",
 			"type": "string"
 		}
 	]

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -8649,8 +8649,8 @@
 									"raw": "{{checkinBody}}"
 								},
 								"url": {
-									"raw": "http://{{url}}:{{okapiport}}/orders/check-in?",
-									"protocol": "http",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in?",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
@@ -8745,8 +8745,8 @@
 									"raw": "{{checkinBody}}"
 								},
 								"url": {
-									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
-									"protocol": "http",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
@@ -8834,8 +8834,8 @@
 									"raw": "{{checkinBody}}"
 								},
 								"url": {
-									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
-									"protocol": "http",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
@@ -8927,8 +8927,8 @@
 									"raw": "{{checkinBody}}"
 								},
 								"url": {
-									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
-									"protocol": "http",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
@@ -9017,8 +9017,8 @@
 									"raw": "{{checkinBody}}"
 								},
 								"url": {
-									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
-									"protocol": "http",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
@@ -12807,8 +12807,8 @@
 									"raw": "{{checkinBody}}"
 								},
 								"url": {
-									"raw": "http://{{url}}:{{okapiport}}/orders/check-in",
-									"protocol": "http",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],


### PR DESCRIPTION
Positive Tests:
- `Close orders updating payment status of each PO Line` folder contains requests which update PO Lines' payment statuses of `Open` orders so the system should close the order eventually.
  - Test example
    ![image](https://user-images.githubusercontent.com/43410167/56895599-406a7980-6a92-11e9-8309-cf8976e4b5be.png)
  - Functions which update PO Line's payment status
    ![image](https://user-images.githubusercontent.com/43410167/56895749-a35c1080-6a92-11e9-8c0d-84c957c99ebd.png)  
- `Check closed orders and re-open` folder contains sets of requests:
  1. Get orders and verify that their workflow status is `Closed`. If this is `true`, modify one of PO Line's payment status so the order becomes `Open` eventually.
     - Test example
     ![image](https://user-images.githubusercontent.com/43410167/56895910-08b00180-6a93-11e9-9d9d-acec1640688d.png)
  2. Roll back one of received piece so the order becomes `Open` eventually.
     ![image](https://user-images.githubusercontent.com/43410167/56895988-40b74480-6a93-11e9-91da-cf697f4567a8.png)
  3. Verify that orders were successfully re-opened by operations described above.
     ![image](https://user-images.githubusercontent.com/43410167/56896026-5af12280-6a93-11e9-8a8c-382c716baea3.png)
- Unused collection variables are deleted

New requests:
![image](https://user-images.githubusercontent.com/43410167/56896067-70664c80-6a93-11e9-8099-ec7893d74e84.png)

Local collection run
![image](https://user-images.githubusercontent.com/43410167/56895545-16b15280-6a92-11e9-88f5-55cae9e8de12.png)
![image](https://user-images.githubusercontent.com/43410167/56896137-a0155480-6a93-11e9-9d48-3bb75abe7ed1.png)
