### PR TITLE
MODNOTES-91: Update tests mod notes

### DIFF
--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -2072,7 +2072,7 @@
 													"",
 													"//Test that domain matches what was passed in POST request",
 													"pm.test('domain matches', function() {",
-													"    pm.expect(response.content).to.eq('eholdings');",
+													"    pm.expect(response.domain).to.eq('eholdings');",
 													"});",
 													"    ",
 													"//Test that content matches what was passed in POST request",
@@ -2190,7 +2190,7 @@
 													"",
 													"//Test that domain matches what was passed in POST request",
 													"pm.test('domain matches', function() {",
-													"    pm.expect(response.content).to.eq('eholdings');",
+													"    pm.expect(response.domain).to.eq('eholdings');",
 													"});",
 													"    ",
 													"//Check that linksList is not empty",
@@ -2502,7 +2502,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"type\": \"Low Priority\",\n\t\"title\" : \"BU Campus Access Issues\",\n\t\"content\": \"There have been access issues at the BU campus since the weekend\",\n\t\"typeId\": \"13d00c36-a94f-434d-9cd2-c7ea159303da\"\n}"
+											"raw": "{\n\t\"type\": \"Low Priority\",\n\t\"title\" : \"BU Campus Access Issues\",\n\t\"content\": \"There have been access issues at the BU campus since the weekend\",\n\t\"typeId\": \"13d00c36-a94f-434d-9cd2-c7ea159303da\",\n\t\"domain\": \"eholdings\"\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes?lang=",
@@ -2577,7 +2577,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"type\": \"Low Priority\",\n\t\"title\" : \"BU Campus Access Issues\",\n\t\"content\": \"There have been access issues at the BU campus since the weekend\",\n\t\"typeId\": \"13d00c36-a94f-434d-9cd2-c7ea159303da\"\n}"
+											"raw": "{\n\t\"type\": \"Low Priority\",\n\t\"title\" : \"BU Campus Access Issues\",\n\t\"content\": \"There have been access issues at the BU campus since the weekend\",\n\t\"typeId\": \"13d00c36-a94f-434d-9cd2-c7ea159303da\",\n\t\"domain\": \"eholdings\"\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes?lang=A1",
@@ -3100,7 +3100,7 @@
 													"    pm.expect(response.type).to.equal(pm.environment.get(\"noteTypeName\"), \"noteTypeName does not match\");",
 													"    pm.expect(response.title).to.equal(pm.environment.get(\"noteTitle\"), \"title does not match\");",
 													"    pm.expect(response.content).to.equal(pm.environment.get(\"noteContent\"), \"title does not match\");",
-													"    pm.expect(response.content).to.equal(pm.environment.get(\"noteDomain\"), \"domain does not match\");",
+													"    pm.expect(response.domain).to.equal(pm.environment.get(\"noteDomain\"), \"domain does not match\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -3645,7 +3645,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"title\" : \"\",\r\n\t\"content\": \"\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"\",\r\n\t\t\t\"type\": \"\"\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"title\" : \"\",\r\n\t\"content\": \"\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"domain\": \"updated domain\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"\",\r\n\t\t\t\"type\": \"\"\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{noteId-creating-in-post}}",
@@ -3716,7 +3716,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\",\r\n\t\t\t\"domain\": \"eholdings\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"domain\": \"eholdings\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{incorrectNoteId}}",
@@ -3786,7 +3786,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\",\r\n\t\t\t\"domain\": \"eholdings\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"domain\": \"eholdings\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{$guid}}?lang=",
@@ -3862,7 +3862,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\",\r\n\t\t\t\"domain\": \"eholdings\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"domain\": \"eholdings\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{$guid}}?lang=A1",
@@ -3997,7 +3997,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\",\r\n\t\t\t\"domain\": \"eholdings\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"domain\": \"eholdings\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{$guid}}",
@@ -4075,7 +4075,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\",\r\n\t\t\t\"domain\": \"eholdings\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"domain\": \"eholdings\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{$guid}}",

--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -890,7 +890,7 @@
 										{
 											"listen": "test",
 											"script": {
-												"id": "e22771dd-c71a-461f-943f-d56887021fa6",
+												"id": "dbf759c2-93cb-457d-8bbc-10f9e064b2e8",
 												"exec": [
 													"pm.test(\"success test - 200 and JSON body\", function() {",
 													"    pm.response.to.be.ok;",
@@ -904,17 +904,12 @@
 													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
-													"pm.test(\"validate data\", function() {",
-													"    pm.expect(response.totalRecords).to.equal(1);",
-													"    pm.expect(response.notes.length).to.equal(1);",
-													"    pm.expect(response.notes[0].id).to.equal(pm.environment.get(\"noteId\"), \"id does not match\");",
-													"    pm.expect(response.notes[0].typeId).to.equal(pm.environment.get(\"noteTypeId\"), \"typeId does not match\");",
-													"    pm.expect(response.notes[0].type).to.equal(pm.environment.get(\"noteTypeName\"), \"noteTypeName does not match\");",
-													"    pm.expect(response.notes[0].title).to.equal(pm.environment.get(\"noteTitle\"), \"noteTitle does not match\");",
-													"    pm.expect(response.notes[0].content).to.equal(pm.environment.get(\"noteContent\"), \"content does not match\");",
-													"    pm.expect(response.notes[0].domain).to.equal(pm.environment.get(\"noteDomain\"), \"domain does not match\");",
-													"    pm.expect(response.notes[0].links[0].id).to.equal(pm.environment.get(\"noteLinkId\"), \"link's field does not match\");",
-													"    pm.expect(response.notes[0].links[0].type).to.equal(pm.environment.get(\"noteLinkType\"), \"link's field does not match\");",
+													"    pm.test(\"validate domain\", function() {",
+													"    if(response.notes.length > 0) {",
+													"        for(let i in response.notes) {",
+													"            pm.expect(response.notes[i].domain).to.equal(pm.environment.get(\"noteDomain\"), \"noteDomain does not match\");",
+													"        }",
+													"    }",
 													"});"
 												],
 												"type": "text/javascript"
@@ -925,13 +920,13 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "x-okapi-tenant",
-												"value": "{{xokapitenant}}",
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}",
 												"type": "text"
 											},
 											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}",
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}",
 												"type": "text"
 											}
 										],
@@ -5868,16 +5863,9 @@
 											"script": {
 												"id": "aeb905b1-c769-4098-8a08-dbf039375edc",
 												"exec": [
-													"pm.test(\"422 test - empty lang\", function() {",
-													"    pm.response.to.have.status(422);",
+													"pm.test(\"400 test - empty lang\", function() {",
+													"    pm.response.to.have.status(400);",
 													"    pm.response.to.have.body();",
-													"});",
-													"",
-													"var response = pm.response.json();",
-													"",
-													"   pm.test(\"Validate schema\", function () {",
-													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_errors\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 													"});",
 													"",
 													""

--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1b4a4280-6f1c-4a2a-9888-dc2cdaabc84b",
+		"_postman_id": "4c927380-70ef-42f7-8d0e-a831320a2bad",
 		"name": "mod-notes",
 		"description": "Tests for the endpoints:\n/notes\n/note-types\n\nTests include:\n* /notes (CR)\n* /notes/_self (CR)\n* /notes/{id} (RUD)\n* /note-types (CR)\n* /note-types/{id} (RUD)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -487,9 +487,9 @@
 									"pm.environment.set(\"noteId\", response.id);",
 									"pm.environment.set(\"noteTitle\", response.title);",
 									"pm.environment.set(\"noteContent\", response.content);",
+									"pm.environment.set(\"noteDomain\", response.domain);",
 									"pm.environment.set(\"noteLinkId\", response.links[0].id);",
 									"pm.environment.set(\"noteLinkType\", response.links[0].type);",
-									"pm.environment.set(\"noteLinkDomain\", response.links[0].domain);",
 									"pm.environment.set(\"incorrectNoteId\", \"12345\");",
 									""
 								],
@@ -519,7 +519,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"title\" : \"Title - {{note-uuid}}\",\r\n  \"content\": \"Content - {{note-uuid}}\",\r\n  \"type\": \"{{noteTypeName}}\",\r\n  \"typeId\": \"{{noteTypeId}}\",\r\n  \"links\": [\r\n    {\r\n      \"id\" : \"583-2356521-758038\",\r\n      \"type\": \"resource\",\r\n      \"domain\": \"eholdings\"\r\n    }\r\n  ]\r\n}"
+							"raw": "{\r\n  \"title\" : \"Title - {{note-uuid}}\",\r\n  \"content\": \"Content - {{note-uuid}}\",\r\n  \"type\": \"{{noteTypeName}}\",\r\n  \"typeId\": \"{{noteTypeId}}\",\r\n  \"domain\": \"eholdings\",\r\n  \"links\": [\r\n    {\r\n      \"id\" : \"583-2356521-758038\",\r\n      \"type\": \"resource\"\r\n    }\r\n  ]\r\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes",
@@ -598,7 +598,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"title\" : \"SecondTitle - {{note-uuid}}\",\r\n  \"content\": \"SecondContent - {{note-uuid}}\",\r\n  \"type\": \"{{noteTypeNameSecond}}\",\r\n  \"typeId\": \"{{noteTypeIdSecond}}\",\r\n  \"links\": [\r\n    {\r\n      \"id\" : \"584-2356521-758038\",\r\n      \"type\": \"resource\",\r\n      \"domain\": \"eholdings\"\r\n    }\r\n  ]\r\n}"
+							"raw": "{\r\n  \"title\" : \"SecondTitle - {{note-uuid}}\",\r\n  \"content\": \"SecondContent - {{note-uuid}}\",\r\n  \"type\": \"{{noteTypeNameSecond}}\",\r\n  \"typeId\": \"{{noteTypeIdSecond}}\",\r\n  \"domain\": \"eholdings\",\r\n  \"links\": [\r\n    {\r\n      \"id\" : \"584-2356521-758038\",\r\n      \"type\": \"resource\"\r\n    }\r\n  ]\r\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes",
@@ -740,9 +740,9 @@
 													"    pm.expect(response.notes[0].type).to.equal(pm.environment.get(\"noteTypeName\"), \"noteTypeName does not match\");",
 													"    pm.expect(response.notes[0].title).to.equal(pm.environment.get(\"noteTitle\"), \"title does not match\");",
 													"    pm.expect(response.notes[0].content).to.equal(pm.environment.get(\"noteContent\"), \"content does not match\");",
+													"    pm.expect(response.notes[0].domain).to.equal(pm.environment.get(\"noteDomain\"), \"domain does not match\");",
 													"    pm.expect(response.notes[0].links[0].id).to.equal(pm.environment.get(\"noteLinkId\"), \"link's field does not match\");",
 													"    pm.expect(response.notes[0].links[0].type).to.equal(pm.environment.get(\"noteLinkType\"), \"link's field does not match\");",
-													"    pm.expect(response.notes[0].links[0].domain).to.equal(pm.environment.get(\"noteLinkDomain\"), \"link's field does not match\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -826,9 +826,9 @@
 													"    pm.expect(response.notes[0].type).to.equal(pm.environment.get(\"noteTypeName\"), \"noteTypeName does not match\");",
 													"    pm.expect(response.notes[0].title).to.equal(pm.environment.get(\"noteTitle\"), \"noteTitle does not match\");",
 													"    pm.expect(response.notes[0].content).to.equal(pm.environment.get(\"noteContent\"), \"content does not match\");",
+													"    pm.expect(response.notes[0].domain).to.equal(pm.environment.get(\"noteDomain\"), \"domain does not match\");",
 													"    pm.expect(response.notes[0].links[0].id).to.equal(pm.environment.get(\"noteLinkId\"), \"link's field does not match\");",
 													"    pm.expect(response.notes[0].links[0].type).to.equal(pm.environment.get(\"noteLinkType\"), \"link's field does not match\");",
-													"    pm.expect(response.notes[0].links[0].domain).to.equal(pm.environment.get(\"noteLinkDomain\"), \"link's field does not match\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -881,6 +881,46 @@
 											]
 										},
 										"description": "Returns an existing note-types via a collection"
+									},
+									"response": []
+								},
+								{
+									"name": "/notes?query=domain={{noteDomain}}",
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes?query=domain={{noteDomain}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"notes"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "domain={{noteDomain}}"
+												}
+											]
+										}
 									},
 									"response": []
 								},
@@ -2022,13 +2062,17 @@
 													"",
 													"pm.test('expected attributes are present', function() {",
 													"    pm.expect(response).to.be.an('object');",
-													"    pm.expect(response).to.include.all.keys(\"id\", \"typeId\", \"title\", \"content\", \"creator\", ",
-													"    \"metadata\", \"links\");",
+													"    pm.expect(response).to.include.all.keys(\"id\", \"typeId\", \"title\", \"content\", \"domain\", \"creator\", \"metadata\", \"links\");",
 													"});",
 													"",
 													"//Test that title matches what was passed in POST request",
 													"pm.test('title matches value passed in', function() {",
 													"    pm.expect(response.title).to.eq('BU Campus Access Issues');",
+													"});",
+													"",
+													"//Test that domain matches what was passed in POST request",
+													"pm.test('domain matches', function() {",
+													"    pm.expect(response.content).to.eq('eholdings');",
 													"});",
 													"    ",
 													"//Test that content matches what was passed in POST request",
@@ -2044,12 +2088,6 @@
 													"//Check that linksList element matches with value",
 													"pm.test('checking linksList', function(){",
 													"    pm.expect(response.links[0].type).eq(\"package\");",
-													"    pm.expect(response.links[0].domain).eq(\"eholdings\");",
-													"});",
-													"",
-													"//Test that title matches what was passed in POST request",
-													"pm.test('title matches value passed in', function() {",
-													"    pm.expect(response.title).to.eq('BU Campus Access Issues');",
 													"});",
 													"",
 													"if(response.id){",
@@ -2081,7 +2119,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n  \"type\": \"Low Priority\",\r\n  \"title\" : \"BU Campus Access Issues\",\r\n  \"content\": \"There have been access issues at the BU campus since the weekend\",\r\n  \"typeId\": \"{{noteTypeId}}\",\r\n  \"links\": [\r\n    {\r\n      \"id\" : \"583-2356521\",\r\n      \"type\": \"package\",\r\n      \"domain\": \"eholdings\"\r\n    }\r\n  ]\r\n}"
+											"raw": "{\r\n  \"type\": \"Low Priority\",\r\n  \"title\" : \"BU Campus Access Issues\",\r\n  \"content\": \"There have been access issues at the BU campus since the weekend\",\r\n  \"typeId\": \"{{noteTypeId}}\",\r\n  \"domain\": \"eholdings\",\r\n  \"links\": [\r\n    {\r\n      \"id\" : \"583-2356521\",\r\n      \"type\": \"package\"\r\n    }\r\n  ]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes",
@@ -2136,7 +2174,7 @@
 													"",
 													"pm.test('expected attributes are present', function() {",
 													"    pm.expect(response).to.be.an('object');",
-													"    pm.expect(response).to.include.all.keys(\"id\", \"typeId\", \"title\", \"content\", \"creator\", ",
+													"    pm.expect(response).to.include.all.keys(\"id\", \"typeId\", \"title\", \"content\", \"domain\", \"creator\", ",
 													"    \"metadata\", \"links\");",
 													"});",
 													"",
@@ -2149,6 +2187,11 @@
 													"pm.test('content matches', function() {",
 													"    pm.expect(response.content).to.eq('There have been access issues at the BU campus since the weekend');",
 													"});",
+													"",
+													"//Test that domain matches what was passed in POST request",
+													"pm.test('domain matches', function() {",
+													"    pm.expect(response.content).to.eq('eholdings');",
+													"});",
 													"    ",
 													"//Check that linksList is not empty",
 													"pm.test('LinksList is not empty', function(){",
@@ -2158,7 +2201,6 @@
 													"//Check that linksList element matches with value",
 													"pm.test('checking linksList', function(){",
 													"    pm.expect(response.links[0].type).eq(\"resource\");",
-													"    pm.expect(response.links[0].domain).eq(\"eholdings\");",
 													"});",
 													"",
 													"pm.test(\"validate Location header\", () => {",
@@ -2194,7 +2236,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"title\": \"BU Campus Access Issues\",\n    \"content\": \"There have been access issues at the BU campus since the weekend\",\n    \"typeId\": \"{{noteTypeId}}\",\n    \"metadata\": {\n    \t\"createdDate\": \"{{createDate}}\",\n        \"createdByUserId\": \"{{createUser}}\",\n        \"updatedDate\": \"{{updateDate}}\",\n        \"updatedByUserId\": \"{{updateUser}}\"\n    \t\n    },\n    \"links\": [\n        {\n            \"id\": \"583-2356521-758038\",\n            \"type\": \"resource\",\n            \"domain\": \"eholdings\"\n        }\n    ]\n}"
+											"raw": "{\n    \"title\": \"BU Campus Access Issues\",\n    \"content\": \"There have been access issues at the BU campus since the weekend\",\n    \"typeId\": \"{{noteTypeId}}\",\n    \"domain\": \"eholdings\",\n    \"metadata\": {\n    \t\"createdDate\": \"{{createDate}}\",\n        \"createdByUserId\": \"{{createUser}}\",\n        \"updatedDate\": \"{{updateDate}}\",\n        \"updatedByUserId\": \"{{updateUser}}\"\n    \t\n    },\n    \"links\": [\n        {\n            \"id\": \"583-2356521-758038\",\n            \"type\": \"resource\"\n        }\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes",
@@ -3058,6 +3100,7 @@
 													"    pm.expect(response.type).to.equal(pm.environment.get(\"noteTypeName\"), \"noteTypeName does not match\");",
 													"    pm.expect(response.title).to.equal(pm.environment.get(\"noteTitle\"), \"title does not match\");",
 													"    pm.expect(response.content).to.equal(pm.environment.get(\"noteContent\"), \"title does not match\");",
+													"    pm.expect(response.content).to.equal(pm.environment.get(\"noteDomain\"), \"domain does not match\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -3482,6 +3525,7 @@
 													"        pm.expect(response.typeId).to.equal(pm.environment.get(\"noteTypeId\"));",
 													"        pm.expect(response.title).to.equal(\"Updated title\");",
 													"        pm.expect(response.content).to.equal(\"Updated content\");",
+													"        pm.expect(response.domain).to.equal(\"Updated domain\");",
 													"    });",
 													"});",
 													""
@@ -3520,7 +3564,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"type\" : \"Type\",\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\",\r\n\t\t\t\"domain\": \"eholdings\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"type\" : \"Type\",\r\n\t\"title\" : \"Updated title\",\r\n\t\"content\": \"Updated content\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"domain\": \"Updated domain\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"583-2356521\",\r\n\t\t\t\"type\": \"package\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{noteId-creating-in-post}}",
@@ -3601,7 +3645,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"title\" : \"\",\r\n\t\"content\": \"\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"\",\r\n\t\t\t\"type\": \"\",\r\n\t\t\t\"domain\": \"\"\r\n\t\t\t\r\n\t\t}\r\n\t\t]\r\n}"
+											"raw": "{\r\n\t\"title\" : \"\",\r\n\t\"content\": \"\",\r\n\t\"typeId\": \"{{noteTypeId}}\",\r\n\t\"links\": [\r\n\t\t{\r\n\t\t\t\"id\" : \"\",\r\n\t\t\t\"type\": \"\"\r\n\t\t}\r\n\t\t]\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{noteId-creating-in-post}}",

--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -886,6 +886,41 @@
 								},
 								{
 									"name": "/notes?query=domain={{noteDomain}}",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "e22771dd-c71a-461f-943f-d56887021fa6",
+												"exec": [
+													"pm.test(\"success test - 200 and JSON body\", function() {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"   pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_noteCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"validate data\", function() {",
+													"    pm.expect(response.totalRecords).to.equal(1);",
+													"    pm.expect(response.notes.length).to.equal(1);",
+													"    pm.expect(response.notes[0].id).to.equal(pm.environment.get(\"noteId\"), \"id does not match\");",
+													"    pm.expect(response.notes[0].typeId).to.equal(pm.environment.get(\"noteTypeId\"), \"typeId does not match\");",
+													"    pm.expect(response.notes[0].type).to.equal(pm.environment.get(\"noteTypeName\"), \"noteTypeName does not match\");",
+													"    pm.expect(response.notes[0].title).to.equal(pm.environment.get(\"noteTitle\"), \"noteTitle does not match\");",
+													"    pm.expect(response.notes[0].content).to.equal(pm.environment.get(\"noteContent\"), \"content does not match\");",
+													"    pm.expect(response.notes[0].domain).to.equal(pm.environment.get(\"noteDomain\"), \"domain does not match\");",
+													"    pm.expect(response.notes[0].links[0].id).to.equal(pm.environment.get(\"noteLinkId\"), \"link's field does not match\");",
+													"    pm.expect(response.notes[0].links[0].type).to.equal(pm.environment.get(\"noteLinkType\"), \"link's field does not match\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
 									"request": {
 										"method": "GET",
 										"header": [


### PR DESCRIPTION
We refactored notes to be domain specific as part of https://issues.folio.org/browse/MODNOTES-89 and https://issues.folio.org/browse/MODNOTES-90. Update API tests accordingly. 

Also, noticed few unrelated tests were failing as well. Fixed those too.