### PR TITLE
Part of MODNOTES-98: Cleanup notes and note types

### DIFF
--- a/mod-notes/mod-notes.postman_collection.json
+++ b/mod-notes/mod-notes.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4c927380-70ef-42f7-8d0e-a831320a2bad",
+		"_postman_id": "674a46ff-8965-4c55-af63-1f9a1738d8e0",
 		"name": "mod-notes",
 		"description": "Tests for the endpoints:\n/notes\n/note-types\n\nTests include:\n* /notes (CR)\n* /notes/_self (CR)\n* /notes/{id} (RUD)\n* /note-types (CR)\n* /note-types/{id} (RUD)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -8357,7 +8357,7 @@
 					"response": []
 				},
 				{
-					"name": "/note/{{noteId-creating-in-post-second}} - 201 Copy",
+					"name": "/note/{{noteId-creating-in-post-second}} - 201",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -8434,6 +8434,84 @@
 						"description": "Create a new note with read only fields set. These will be replaced with server side enforced values. The read only values will be ignored and note creation will succeed."
 					},
 					"response": []
+				},
+				{
+					"name": "/note/{{noteId-creating-in-post}} - 201",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "489cefc9-561e-4e0a-9ea8-a535867f5859",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "363e43fd-a2ba-467d-8b4d-4670122c4043",
+								"exec": [
+									"pm.test(\"success test\", function() {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									"",
+									"pm.sendRequest({",
+									"    url: pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + \"/note-types/\" + pm.environment.get(\"noteTypeId-creating-in-post-second\"),",
+									"    method: 'GET',",
+									"    header: {",
+									"        'X-Okapi-Tenant': pm.environment.get(\"xokapitenant\"),",
+									"        'X-Okapi-Token': pm.environment.get(\"xokapitoken\"),",
+									"        'Content-Type': 'application/json'",
+									"    },",
+									"}, function(err, res) {",
+									"    console.log(res);",
+									"    pm.test(\"Note does not exist\", function () {",
+									"         res.code === 404;",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-Okapi-Tenant",
+								"type": "text",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"type": "text",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/notes/{{noteId-creating-in-post}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"notes",
+								"{{noteId-creating-in-post}}"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -8441,7 +8519,7 @@
 			"name": "teardown note-types",
 			"item": [
 				{
-					"name": "/note-types/{{noteType-createing-in-post-second}} - 201",
+					"name": "/note-types/{{noteType-creating-in-post-second}} - 201",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -8654,6 +8732,84 @@
 							"path": [
 								"note-types",
 								"{{noteTypeIdSecond}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/note-types/{{noteTypeId-creating-in-post}}",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "489cefc9-561e-4e0a-9ea8-a535867f5859",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "363e43fd-a2ba-467d-8b4d-4670122c4043",
+								"exec": [
+									"pm.test(\"success test\", function() {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									"",
+									"pm.sendRequest({",
+									"    url: pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + \"/note-types/\" + pm.environment.get(\"noteTypeId-creating-in-post-second\"),",
+									"    method: 'GET',",
+									"    header: {",
+									"        'X-Okapi-Tenant': pm.environment.get(\"xokapitenant\"),",
+									"        'X-Okapi-Token': pm.environment.get(\"xokapitoken\"),",
+									"        'Content-Type': 'application/json'",
+									"    },",
+									"}, function(err, res) {",
+									"    console.log(res);",
+									"    pm.test(\"Note does not exist\", function () {",
+									"         res.code === 404;",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-Okapi-Tenant",
+								"type": "text",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"type": "text",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/note-types/{{noteTypeId-creating-in-post}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"note-types",
+								"{{noteTypeId-creating-in-post}}"
 							]
 						}
 					},


### PR DESCRIPTION
Certain notes and note types being created are not being deleted leading to tests eventually hitting note-type count of 25 resulting in failure. Cleanup left over notes and note types.