### PR TITLE
MODKBEKBJ-226 - Correct mod-kb-ebsco-java tests

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4a19bb81-660a-4291-a629-bb0be24c0ed7",
+		"_postman_id": "dff0e36c-9c96-4995-9b09-d1de0fafecb9",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -23605,78 +23605,6 @@
 					"response": []
 				},
 				{
-					"name": "Delete tags for another test package",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "266c1544-d736-4b44-8b8e-53d87301e84e",
-								"exec": [
-									"pm.test(\"success test\", function() {",
-									"    pm.response.to.be.json;",
-									"});",
-									"",
-									"let response = pm.response.json();",
-									"",
-									"//Check that status is 200",
-									"pm.test(\"Status is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"//Validate response against json api schema",
-									"pm.test(\"Validate schema\", function () {",
-									"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
-									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
-									"});",
-									"//Check that tagList is empty in response",
-									" pm.test(\"Package with empty tagList\", function () {",
-									"     pm.expect(response.data.attributes.tags.tagList.length).to.eql(0);",
-									" });"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [
-							{
-								"key": "x-okapi-token",
-								"type": "text",
-								"value": "{{xokapitoken}}"
-							},
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/vnd.api+json"
-							},
-							{
-								"key": "x-okapi-tenant",
-								"value": "{{xokapitenant}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n   \"data\": {\n     \"type\": \"packages\",\n     \"attributes\": {\n       \"name\": \"new-another-custom-package-{{package-uuid}}\",\n       \"contentType\": \"Unknown\",\n       \"isSelected\": true,\n       \"tags\": {\n    \t\"tagList\": [\n\t\t\t]\n    \t}\n     }\n   }\n }"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post-again}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"eholdings",
-								"packages",
-								"{{custom-package-id-created-in-post-again}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "Delete tags to test resource",
 					"event": [
 						{
@@ -24184,65 +24112,6 @@
 								"eholdings",
 								"packages",
 								"{{custom-package-id-created-in-post-valid}}"
-							]
-						},
-						"description": "Delete custom package created in post."
-					},
-					"response": []
-				},
-				{
-					"name": "Delete custom package created in post again",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "967dd204-5352-4475-940d-0d16f2b81eee",
-								"exec": [
-									"pm.test(\"Status is 204\", function () {",
-									"    pm.response.to.have.status(204);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "67c6fa5e-953a-4222-bc89-1e86fb2900f4",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "x-okapi-tenant",
-								"value": "{{xokapitenant}}"
-							},
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post-again}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"eholdings",
-								"packages",
-								"{{custom-package-id-created-in-post-again}}"
 							]
 						},
 						"description": "Delete custom package created in post."


### PR DESCRIPTION
Per https://issues.folio.org/browse/MODKBEKBJ-226 - API Tests for mod-kb-ebsco-java are failing 

The following 2 tests are failing since the package that they are testing for got deleted by a previous test
- Delete custom package created in post again
- Delete tags for another test package

Both tests are expecting a package defined by environment variable - `custom-package-id-created-in-post-again`

After research found that package `custom-package-id-created-in-post-again` is being deleted by another test
`update custom package with isSelected false should delete it`
https://github.com/folio-org/folio-api-tests/pull/125/files

Removed cleanup script tests since they are no longer necessary with added test
