### PR TITLE
Correct mod-permissions Q2.1 test failures

### DIFF
--- a/mod-permissions/mod-permissions.postman_collection.json
+++ b/mod-permissions/mod-permissions.postman_collection.json
@@ -1,13 +1,12 @@
 {
 	"info": {
-		"_postman_id": "c291f870-f31d-413a-8b0a-58ee67bae4b0",
-		"name": "mod-permissions copy",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+		"_postman_id": "00b1be28-896a-4694-8935-b7b64b543f6f",
+		"name": "mod-permissions",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "authentication",
-			"description": null,
 			"item": [
 				{
 					"name": "/authn/login",
@@ -45,7 +44,18 @@
 							"mode": "raw",
 							"raw": "{\"username\":\"{{username}}\",\"password\":\"{{password}}\"}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/authn/login"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"authn",
+								"login"
+							]
+						}
 					},
 					"response": []
 				}
@@ -53,7 +63,6 @@
 		},
 		{
 			"name": "permissions",
-			"description": null,
 			"item": [
 				{
 					"name": "/perms/permissions",
@@ -130,10 +139,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions?length=50",
 							"protocol": "{{protocol}}",
@@ -296,7 +301,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"permissionName\":\"{{currentSubPermissionName1}}\",\n  \"displayName\": \"fake sub perm one\",\n  \"description\": \"fake sub permission one\",\n  \"visible\": true,\n  \"mutable\" : true,\n  \"tags\": [\n    \"tag1\",\n    \"tag2\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "Creating the first sub permission."
 					},
 					"response": []
@@ -445,7 +461,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"permissionName\":\"{{currentSubPermissionName2}}\",\n  \"displayName\": \"fake sub perm two\",\n  \"description\": \"fake sub permission two\",\n  \"visible\": true,\n  \"mutable\" : true,\n  \"tags\": [\n    \"tag1\",\n    \"tag2\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						}
 					},
 					"response": []
 				},
@@ -596,7 +623,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"permissionName\":\"{{currentPermissionName}}\",\n  \"displayName\": \"fake perm one\",\n  \"description\": \"fake permission with fake sub permissions\",\n  \"visible\": true,\n  \"mutable\" : true,\n  \"subPermissions\":[\n  \t\"{{currentSubPermissionName1}}\",\n  \t\"{{currentSubPermissionName2}}\"\n  \t],\n  \"tags\": [\n    \"tag1\",\n    \"tag2\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "Create a permission with sub permission one and sub permission two."
 					},
 					"response": []
@@ -747,7 +785,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"permissionName\":\"{{currentPermissionName2}}\",\n  \"displayName\": \"fake perm two\",\n  \"description\": \"fake permission with fake sub permissions\",\n  \"visible\": true,\n  \"mutable\" : true,\n  \"subPermissions\":[\n  \t\"{{currentSubPermissionName2}}\"\n  \t],\n  \"tags\": [\n    \"tag1\",\n    \"tag2\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "Create a permission with sub permission two."
 					},
 					"response": []
@@ -938,7 +987,18 @@
 							"mode": "raw",
 							"raw": "{\r\n  \"userId\":\"{{testUserid}}\",\r\n  \"permissions\":[\"{{currentPermissionName}}\"]\r\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"users"
+							]
+						},
 						"description": "Assign permissions and permission sets for a specific user."
 					},
 					"response": []
@@ -1009,10 +1069,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}/permissions?expanded=false",
 							"protocol": "{{protocol}}",
@@ -1104,10 +1160,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}/permissions?expanded=true",
 							"protocol": "{{protocol}}",
@@ -1190,10 +1242,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}/permissions?full=true",
 							"protocol": "{{protocol}}",
@@ -1275,10 +1323,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{testUserid}}/permissions?indexField=userId&full=false",
 							"protocol": "{{protocol}}",
@@ -1551,17 +1595,15 @@
 					"response": []
 				},
 				{
-					"name": "/perms/users/{{newpermissionuserid}}/permissions 500",
+					"name": "/perms/users/{{newpermissionuserid}}/permissions (400 - invalid user)",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "1f9e17d4-efb0-40a3-b983-4948a715b2ef",
-								"type": "text/javascript",
 								"exec": [
-									"pm.test(\"Status is 500\", function () {",
-									"    pm.response.to.have.status(500);",
-									"    pm.response.to.have.status(\"Internal Server Error\");",
+									"pm.test(\"Status is 400\", function () {",
+									"    pm.response.to.have.status(400);",
 									"});",
 									"",
 									"//verify header",
@@ -1578,7 +1620,8 @@
 									"let commonHeaderTests = eval(str);",
 									"commonHeaderTests.negative();",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1832,7 +1875,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"permissionName\":\"{{currentPermissionName}}\",\n  \"displayName\": \"fake perm one\",\n  \"description\": \"fake permission with fake sub permissions\",\n  \"visible\": true,\n  \"mutable\" : false,\n  \"subPermissions\": [\n    \"foo1\",\n    \"foo2\",\n    \"foo3\",\n    \"foo4\"\n  ],\n  \"tags\": [\n    \"tag1\",\n    \"tag2\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "POST Permission with name fake.permission.one that already exists"
 					},
 					"response": []
@@ -1902,7 +1956,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"permissionName\":\"fake.permission.two\",\n  \"displayName\": \"fake perm two\",\n  \"description\": \"fake permission with fake sub permissions\",\n  \"visible\": true,\n  \"mutable\" : true\n  \"subPermissions\": [\n    \"foo1\",\n    \"foo2\",\n    \"foo3\",\n    \"foo4\"\n  ],\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "Malformated JSON body"
 					},
 					"response": []
@@ -1973,7 +2038,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"permissionName\":\"fake.permission.three\",\n  \"displayName\": \"fake perm one\",\n  \"description\": \"fake permission with fake sub permissions\",\n  \"visible\": true,\n  \"mutable\" : true,\n  \"subPermissions\": [\n    \"foo1\",\n    \"foo2\",\n    \"foo3\",\n    \"foo4\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "Attempting to add non-existent permissions as sub-permisisons"
 					},
 					"response": []
@@ -2044,7 +2120,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \"description\": \"fake permission with fake sub permissions\",\n  \"visible\": true,\n  \"mutable\" : \"dsfdf\",\n  \"subPermissions\": [\n    \"foo1\",\n    \"foo2\",\n    \"foo3\",\n    \"foo4\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "POST request with mutable attribute as string rather than boolean"
 					},
 					"response": []
@@ -2115,7 +2202,18 @@
 							"mode": "raw",
 							"raw": "{ \n  \n  \"description\": \"fake permission with fake sub permissions\",\n  \"visible\": \"dfdfdf\",\n  \"mutable\" : true,\n  \"subPermissions\": [\n    \"foo1\",\n    \"foo2\",\n    \"foo3\",\n    \"foo4\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions"
+							]
+						},
 						"description": "POST request with visible attribute as string rather than boolean"
 					},
 					"response": []
@@ -2175,23 +2273,32 @@
 							"mode": "raw",
 							"raw": "{\r\n  \"id\":\"{{newpermissionuserid}}\",\r\n  \"userId\": \"{{testUserid}}\",\r\n  \"permissions\":[\"{{currentSubPermissionId2}}\"]\r\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"users"
+							]
+						},
 						"description": "POST with same existing userid and permissionuserid"
 					},
 					"response": []
 				},
 				{
-					"name": "/perms/users 500",
+					"name": "/perms/users (missing id 422)",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "557dbbf7-5ed6-4460-9fd6-de4e6062374c",
-								"type": "text/javascript",
 								"exec": [
-									"pm.test(\"Status is 500\", function () {",
-									"    pm.response.to.have.status(500);",
-									"    pm.response.to.have.status(\"Internal Server Error\");",
+									"pm.test(\"Status is 422\", function () {",
+									"    pm.response.to.have.status(422);",
 									"});",
 									"",
 									"",
@@ -2210,7 +2317,8 @@
 									"let commonHeaderTests = eval(str);",
 									"commonHeaderTests.negative();",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2234,7 +2342,18 @@
 							"mode": "raw",
 							"raw": "{\r\n  \"userId\":true,\r\n  \"permissions\":[\"{{currentPermissionName}}\"]\r\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"users"
+							]
+						},
 						"description": "POST with invalid userID"
 					},
 					"response": []
@@ -2288,7 +2407,18 @@
 							"mode": "raw",
 							"raw": "{\r\n  \"id\": \"mypermsuserid\",\r\n  \"userId\": \"fakeuserid\"\r\n  \"permissions\":[]\r\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"users"
+							]
+						},
 						"description": "malformed json"
 					},
 					"response": []
@@ -2359,7 +2489,19 @@
 							"mode": "raw",
 							"raw": "{\n  \"id\": \"{{currentPermissionId}}\",\n  \"permissionName\": \"{{currentPermissionName}}\",\n  \"displayName\": \"fake sub perm one\",\n  \"description\": \"fake permission with fake sub permissions updated\",\n  \"visible\": true,\n  \"mutable\":false,\n  \"subPermissions\": [\n   \"{{currentSubPermissionName2}}\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -2428,7 +2570,19 @@
 							"mode": "raw",
 							"raw": "{\n \"permissionName\": \"{{currentPermissionName}}\",\n  \"description\": \"fake permission with fake sub permissions updated\",\n  \"visible\": true,\n  \"mutable\":false,\n  \"subPermissions\": [\n   \"{{currentSubPermissionName2}}\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						},
 						"description": "POST with no no id attribute in request"
 					},
 					"response": []
@@ -2498,7 +2652,19 @@
 							"mode": "raw",
 							"raw": "{\n  \"id\": \"{{currentPermissionId}}\",\n  \"permissionName\": \"{{currentPermissionName}}\",\n  \"description\": \"fake permission with fake sub permissions updated\",\n  \"visible\": true,\n  \"mutable\":true,\n  \"subPermissions\": [\n    \"foo1\",\n    \"foo2\",\n    \"foo3\",\n    \"foo4\",\n    \"foo5\",\n    \"foo7\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						},
 						"description": "PUT with non existing sub/child permissions"
 					},
 					"response": []
@@ -2568,7 +2734,19 @@
 							"mode": "raw",
 							"raw": "{\n  \"id\": \"{{currentPermissionId}}\",\n  \"permissionName\": \"fake.permission.two\",\n  \"description\": \"fake permission with fake sub permissions updated\",\n  \"visible\": true,\n  \"mutable\":true\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						},
 						"description": "PUT to update permission name since that property cannot change"
 					},
 					"response": []
@@ -2639,7 +2817,19 @@
 							"mode": "raw",
 							"raw": "{\r\n  \"id\":\"{{newpermissionuserid}}\",\r\n  \"userId\": \"{{testUserid}}\",\r\n  \"permissions\":[\"{{currentSubPermissionName2}}\"]\r\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"users",
+								"{{newpermissionuserid}}"
+							]
+						},
 						"description": "Update user permissions set"
 					},
 					"response": []
@@ -2715,11 +2905,19 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -2794,11 +2992,19 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentSubPermissionId2}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentSubPermissionId2}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentSubPermissionId2}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -2861,10 +3067,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions?length=100&query=(description=fake permission with fake sub permissions)",
 							"protocol": "{{protocol}}",
@@ -2956,10 +3158,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions?expandSubs=false&query=(description=fake permission with fake sub permissions)",
 							"protocol": "{{protocol}}",
@@ -3050,10 +3248,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions?expandSubs=true&query=(description=fake permission with fake sub permissions)",
 							"protocol": "{{protocol}}",
@@ -3138,10 +3332,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users?length=50&hasPermissions={{currentSubPermissionName2}}",
 							"protocol": "{{protocol}}",
@@ -3213,10 +3403,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users?start=0",
 							"protocol": "{{protocol}}",
@@ -3307,10 +3493,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}?hasPermissions=\"{{currentPermissionName}}\"",
 							"protocol": "{{protocol}}",
@@ -3396,10 +3578,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{testUserid}}?indexField=userId",
 							"protocol": "{{protocol}}",
@@ -3472,10 +3650,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{testUserid}}?indexField=true",
 							"protocol": "{{protocol}}",
@@ -3549,11 +3723,19 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"group\": \"fse testing librarian\",\r\n  \"desc\": \"basic test lib group\"\r\n}"
-						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{$guid}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{$guid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"users",
+								"{{$guid}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -3603,7 +3785,19 @@
 							"mode": "raw",
 							"raw": ""
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentSubPermissionId2}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentSubPermissionId2}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentSubPermissionId2}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -3614,7 +3808,6 @@
 							"listen": "test",
 							"script": {
 								"id": "dceda716-e11e-47c0-88bf-38455422a69e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status is 204\", function () {",
 									"    pm.response.to.have.status(204);",
@@ -3629,7 +3822,8 @@
 									"",
 									"pm.environment.unset('currentSubPermissionName1')",
 									"pm.environment.unset('currentSubPermissionId1')"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3653,7 +3847,19 @@
 							"mode": "raw",
 							"raw": ""
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentSubPermissionId1}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentSubPermissionId1}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentSubPermissionId1}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -3702,7 +3908,19 @@
 							"mode": "raw",
 							"raw": ""
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						},
 						"description": "NOTE Delete sub permissions first"
 					},
 					"response": []
@@ -3753,7 +3971,19 @@
 							"mode": "raw",
 							"raw": ""
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId2}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId2}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId2}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -3829,7 +4059,19 @@
 							"mode": "raw",
 							"raw": ""
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{newpermissionuserid}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"users",
+								"{{newpermissionuserid}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -3881,7 +4123,19 @@
 							"mode": "raw",
 							"raw": ""
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -3938,7 +4192,19 @@
 							"mode": "raw",
 							"raw": ""
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/invalidstring",
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/invalidstring",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"invalidstring"
+							]
+						},
 						"description": "Invalid id in the permissions with a string values in the id"
 					},
 					"response": []
@@ -4002,7 +4268,19 @@
 							"mode": "raw",
 							"raw": "{\n  \"id\": \"{{currentPermissionId}}\",\n  \"permissionName\": \"{{currentPermissionName}}\",\n  \"description\": \"fake permission with fake sub permissions updated\",\n  \"visible\": true,\n  \"subPermissions\": [\n    \"foo1\",\n    \"foo2\",\n    \"foo3\",\n    \"foo4\",\n    \"foo5\",\n    \"foo7\"\n  ]\n}"
 						},
-						"url": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}"
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions/{{currentPermissionId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"perms",
+								"permissions",
+								"{{currentPermissionId}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -4074,10 +4352,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions?length=1000&query=(permissionName=fake*)",
 							"protocol": "{{protocol}}",
@@ -4195,19 +4469,19 @@
 	],
 	"variable": [
 		{
-			"id": "b765b1bf-1c86-4651-907b-c959ce5bf87d",
+			"id": "f57b79e5-6d1e-4723-ae2d-ce309568c0b3",
 			"key": "retrieveSchemaFunction",
 			"value": "class Schemas {\n    retrieveRAMLUtilsSchema(schemaName, done) {\n        pm.sendRequest({\n            url: \"https://raw.githubusercontent.com/folio-org/raml/\" + pm.variables.get(\"raml-utils_version\") + \"/schemas/\" + schemaName,\n            method: 'GET',\n        }, (err, res) => {\n            if (err !== null) {\n                console.log(\"Schema retrieval error: \" + err);\n                done(null);\n                return;\n            }\n            if (res.code === 200) {\n                    done(res.json());\n                    return\n                } \n              console.log(\"Schema retrieval falied: \" + res.reason());\n                done(null);\n                }\n        );\n    };\n}",
 			"type": "string"
 		},
 		{
-			"id": "39bb6f46-444a-484c-a2bd-b6c27b827d44",
+			"id": "e7c2a684-0d62-4280-ab06-6ad529ced925",
 			"key": "raml-utils_version",
 			"value": "d771225d6adba30f54145332f093e9a3362be3ae",
 			"type": "string"
 		},
 		{
-			"id": "3380862a-05de-4c8d-bbff-4db398406cfd",
+			"id": "e9772d60-38a0-47e5-93cb-d54ec1a92e93",
 			"key": "commonTests",
 			"value": "class Header {\n    positive() {\n         pm.test(\"'X-Okapi-Trace' header is present\", function () {\n        pm.response.to.have.header(\"X-Okapi-Trace\");\n    });\n    \n    pm.test(\"'accept' header is present and has correct value\", function () {\n        pm.response.to.have.header(\"accept\");\n        pm.expect(pm.response.headers.get(\"accept\")).to.be.equal(\"*/*\"); \n    });\n    \n    pm.test(\"'accept-encoding' header is present and has correct value\", function () {\n        pm.response.to.have.header(\"accept-encoding\");\n        pm.expect(pm.response.headers.get(\"accept-encoding\")).to.be.equal(\"gzip, deflate\");\n    });\n    \n    \n    pm.test(\"'connection' header is present and has correct value\", function () {\n        pm.response.to.have.header(\"connection\");\n        pm.expect(pm.response.headers.get(\"connection\")).to.be.equal(\"keep-alive\");\n    });\n    \n    pm.test(\"'host' header is present\", function () {\n        pm.response.to.have.header(\"host\");\n    });\n    \n    pm.test(\"'x-okapi-request-id' header is present\", function () {\n        pm.response.to.have.header(\"x-okapi-request-id\");\n    });\n    \n    pm.test(\"'x-okapi-tenant' header is present and has correct value\", function () {\n        pm.response.to.have.header(\"x-okapi-tenant\");\n        pm.expect(pm.response.headers.get(\"x-okapi-tenant\")).to.be.equal(pm.environment.get(\"xokapitenant\"));\n    });\n    \n    pm.test(\"'x-okapi-token' header is present and has correct value\", function () {\n        pm.response.to.have.header(\"x-okapi-token\");\n        pm.expect(pm.response.headers.get(\"x-okapi-token\")).to.be.equal(pm.environment.get(\"xokapitoken\"));\n    });\n    \n    pm.test(\"'x-okapi-url' header is present\", function () {\n        pm.response.to.have.header(\"x-okapi-url\");\n    });\n    \n    pm.test(\"'x-okapi-user-id' header is present\", function () {\n        pm.response.to.have.header(\"x-okapi-user-id\");\n    });\n}\n\nnegative(){\n    pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {\n        pm.response.to.have.header(\"Transfer-Encoding\");\n        pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");\n    });\n    \n    pm.test(\"'X-Okapi-Trace' header is present\", function () {\n        pm.response.to.have.header(\"X-Okapi-Trace\");\n    });\n}\n\n}",
 			"type": "string"


### PR DESCRIPTION
mod-permissions API tests started failing with Q2.1 release.

Corrected below 2 failing tests:
(1) Invalid user id returns a 400 error
(2)Missing Id returns a 422 error

Also update name from `mod-permssions copy` to `mod-permissions`
Changes show some formatting difference as well as removal of GET body. 
These were done by Postman (no explicit updates)

```
  #  failure         detail                                                                      
                                                                                                 
 1.  AssertionError  Status is 500                                                               
                     expected response to have status code 500 but got 400                       
                     at assertion:0 in test-script                                               
                     inside "permissions / /perms/users/{{newpermissionuserid}}/permissions 500" 
                                                                                                 
 2.  AssertionError  Status is 500                                                               
                     expected response to have status code 500 but got 422                       
                     at assertion:0 in test-script                                               
                     inside "permissions / /perms/users 500"         
```