### PR TITLE
Update service points tests(mod-inventory-storage)

### DIFF
--- a/mod-inventory-storage/mod-inventory-storage.postman_collection.json
+++ b/mod-inventory-storage/mod-inventory-storage.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "911c6faf-646d-44da-a623-c92e43255ec1",
+		"_postman_id": "06b0870f-6f0a-40ee-b704-f2b526c33e12",
 		"name": "mod-inventory-storage",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -9966,20 +9966,16 @@
 					"response": []
 				},
 				{
-					"name": "/service-points - get/{id} 500",
+					"name": "/service-points - get/{id} 404",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "ef53980b-2480-4bbf-81df-dea358ba9e96",
 								"exec": [
-									"pm.test(\"Status is 500 - bad id\", function () {",
-									"    pm.response.to.have.status(500);",
-									"});",
-									"",
-									"/* JIRA: MODINVSTOR-197 */",
-									"pm.test(\"Response must be valid and have an error message\", function () {",
-									"    pm.expect(responseBody.toLowerCase().includes(\"errormessage\")).to.be.true; ",
+									"pm.test(\"Status is 404 - bad id\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.body();",
 									"});",
 									""
 								],
@@ -10245,7 +10241,7 @@
 					"response": []
 				},
 				{
-					"name": "/service-points - put/{id} - 500",
+					"name": "/service-points - put/{id} - 404",
 					"event": [
 						{
 							"listen": "test",
@@ -10253,15 +10249,10 @@
 								"id": "ab3fa3f5-eab0-410e-8420-95b6dc3555be",
 								"exec": [
 									"",
-									"pm.test(\"Status is 500 - bad Id\", function () {",
-									"    pm.response.to.have.status(500);",
-									"});",
-									"",
-									"/* JIRA: MODINVSTOR-197 */",
-									"pm.test(\"Response must be valid and have an error message\", function () {",
-									"    pm.expect(responseBody.toLowerCase().includes(\"errormessage\")).to.be.true; ",
-									"});",
-									""
+									"pm.test(\"Status is 404 - bad Id\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    pm.response.to.have.body();",
+									"});"
 								],
 								"type": "text/javascript"
 							}


### PR DESCRIPTION
The following API tests were failing after Q2.1 release:                                             
                                                                               
 1.  AssertionError  Status is 500 - bad id                                    
                     expected response to have status code 500 but got 404     
                     at assertion:0 in test-script                             
                     inside "service-point / /service-points - get/{id} 500"   
                                                                               
 2.  AssertionError  Response must be valid and have an error message          
                     expected false to be true                                 
                     at assertion:1 in test-script                             
                     inside "service-point / /service-points - get/{id} 500"   
                                                                               
 3.  AssertionError  Status is 500 - bad Id                                    
                     expected response to have status code 500 but got 404     
                     at assertion:0 in test-script                             
                     inside "service-point / /service-points - put/{id} - 500" 
                                                                               
 4.  AssertionError  Response must be valid and have an error message          
                     expected false to be true                                 
                     at assertion:1 in test-script                             
                     inside "service-point / /service-points - put/{id} - 500" 

Per https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/service-point.html#, the updated error response codes make sense. Fix tests accordingly.