### PR TITLE
MODORDERS-230/MODORDERS-232 Inappropriate error response on missing inventory records

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "42827316-cd11-4c8c-a277-6fb24253e5b2",
+		"_postman_id": "4259cbfd-ad01-41cb-bd32-bf030218e79e",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -247,23 +247,11 @@
 											"let configNamesToProcess = testConfigs.configNames;",
 											"console.log(\"Config codes to process: \" + configNamesToProcess);",
 											"",
-											"let bodyTemplate = testConfigs.bodyTemplate;",
 											"for (var i = 0; i < configNamesToProcess.length; i++) {",
 											"    let configName = configNamesToProcess[i];",
 											"    let value = pm.variables.get(configName);",
-											"",
-											"    let existingConfig = utils.getConfigByName(configs, configName);",
-											"    if (existingConfig) {",
-											"        existingConfig.value = value;",
-											"        utils.updateConfig(existingConfig);",
-											"    } else {",
-											"        bodyTemplate.configName = configName;",
-											"        bodyTemplate.value = value;",
-											"        utils.createConfig(bodyTemplate);",
-											"",
-											"        // store new config",
-											"        configs.push(utils.copyJsonObj(bodyTemplate));",
-											"    }",
+											"   // let existingConfig = utils.getConfigByName(configs, configName);",
+											"    utils.updateOrCreateConfig(configs, configName, value);",
 											"}",
 											"",
 											"// Store current version of configs",
@@ -698,10 +686,6 @@
 										"value": "{{xokapitoken}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/identifier-types?query=name=={{identifierTypeName}}&limit=1",
 									"protocol": "{{protocol}}",
@@ -806,10 +790,6 @@
 										"value": "{{xokapitoken}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-types?query=code=={{inventory-instanceTypeCode}}&limit=1",
 									"protocol": "{{protocol}}",
@@ -1118,10 +1098,6 @@
 										"value": "{{xokapitoken}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/material-types?query=name=={{materialTypeName}}&limit=1",
 									"protocol": "{{protocol}}",
@@ -6665,10 +6641,6 @@
 										"value": "{{xokapitoken}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?limit=30&query=workflowStatus==Open AND orderFormat==Electronic Resource sortBy dateOrdered/sort.ascending",
 									"protocol": "{{protocol}}",
@@ -6771,10 +6743,6 @@
 										"value": "{{xokapitoken}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?limit=30&query=workflowStatus==Open AND orderFormat==Electronic Resource sortBy dateOrdered/sort.descending",
 									"protocol": "{{protocol}}",
@@ -9606,24 +9574,11 @@
 											"",
 											"console.log(\"Config codes to restore test values: \" + configNamesToProcess);",
 											"",
-											"let bodyTemplate = testConfigs.bodyTemplate;",
 											"for (var i = 0; i < configNamesToProcess.length; i++) {",
 											"    let configName = configNamesToProcess[i];",
 											"    let value = pm.variables.get(configName);",
 											"",
-											"    // Just in case check if the config available (should not be the case because all configs were deleted recently)",
-											"    let existingConfig = utils.getConfigByName(configs, configName);",
-											"    if (existingConfig) {",
-											"        existingConfig.value = value;",
-											"        utils.updateConfig(existingConfig);",
-											"    } else {",
-											"        bodyTemplate.configName = configName;",
-											"        bodyTemplate.value = value;",
-											"        utils.createConfig(bodyTemplate);",
-											"",
-											"        // store new config",
-											"        configs.push(utils.copyJsonObj(bodyTemplate));",
-											"    }",
+											"    utils.updateOrCreateConfig(configs, configName, value);",
 											"}",
 											"",
 											"// Store current version of configs",
@@ -9652,10 +9607,6 @@
 										"value": "{{xokapitoken}}"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=module==ORDERS",
 									"protocol": "{{protocol}}",
@@ -11464,6 +11415,481 @@
 												"orders",
 												"composite-orders",
 												"{{negativeTestsOpenOrderId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Verify missing inventory enties errors",
+							"item": [
+								{
+									"name": "Prepare missing instanceTypeCode config",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let configs = [];",
+													"pm.test(\"Get configs response is ok\", function () {",
+													"    pm.response.to.be.ok;",
+													"    configs = pm.response.json().configs;",
+													"});",
+													"",
+													"let configName = \"inventory-instanceTypeCode\";",
+													"let value = \"missing-type\";",
+													"",
+													"utils.updateOrCreateConfig(configs, configName, value);",
+													"",
+													"// Store current version of configs",
+													"pm.environment.set(\"current-orders-configs\", configs);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=module==ORDERS and configName==inventory-instanceTypeCode",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"configurations",
+												"entries"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "module==ORDERS and configName==inventory-instanceTypeCode"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update pending order to open with missingInstanceType error",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let testConfigs = globals.testData.configs;",
+													"",
+													"let order = utils.buildOrderWithMinContent();",
+													"",
+													"order.workflowStatus = \"Open\";",
+													"order.notes = [\"Open Order for Negative API Tests\"];",
+													"order.poNumber = \"instanceType\";",
+													"",
+													"let line = JSON.parse(globals.poLineForNegativeTests);",
+													"line.physical.createInventory = \"Instance\";",
+													"order.compositePoLines = [line];",
+													"pm.variables.set(\"orderBody\", JSON.stringify(order));",
+													"",
+													"    ",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let testConfigs = globals.testData.configs;",
+													"let error = {};",
+													"pm.test(\"Status code is 500 and one error\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    error = pm.response.json().errors[0];",
+													"    pm.expect(error.code).to.equal(\"missingInstanceType\");",
+													"    pm.expect(error.parameters[0].value).to.equal(\"missing-type\");",
+													"});",
+													"",
+													"let bodyTemplate = testConfigs.bodyTemplate;",
+													"let configs = pm.environment.get(\"current-orders-configs\");",
+													"let configName = \"inventory-instanceTypeCode\";",
+													"let existingConfig = utils.getConfigByName(configs, configName);",
+													"existingConfig.value = pm.variables.get(configName);",
+													"utils.updateConfig(existingConfig);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{orderBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsPendingOrderId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"composite-orders",
+												"{{negativeTestsPendingOrderId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Prepare missing instanceStatusCode config",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"",
+													"let configs = [];",
+													"pm.test(\"Get configs response is ok\", function () {",
+													"    pm.response.to.be.ok;",
+													"    configs = pm.response.json().configs;",
+													"});",
+													"",
+													"let configName = \"inventory-instanceStatusCode\";",
+													"let value = \"missing-status\";",
+													"",
+													"utils.updateOrCreateConfig(configs, configName, value);",
+													"",
+													"",
+													"// Store current version of configs",
+													"pm.environment.set(\"current-orders-configs\", configs);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=module==ORDERS and configName==inventory-instanceStatusCode",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"configurations",
+												"entries"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "module==ORDERS and configName==inventory-instanceStatusCode"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update pending order to open with missingInstanceStatus error",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"",
+													"let order = utils.buildOrderWithMinContent();",
+													"",
+													"order.workflowStatus = \"Open\";",
+													"order.notes = [\"Open Order for Negative API Tests\"];",
+													"order.poNumber = \"instanceStatus\";",
+													"",
+													"let line = JSON.parse(globals.poLineForNegativeTests);",
+													"line.physical.createInventory = \"Instance\";",
+													"order.compositePoLines = [line];",
+													"pm.variables.set(\"orderBody\", JSON.stringify(order));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let testConfigs = globals.testData.configs;",
+													"let error = {};",
+													"pm.test(\"Status code is 500 and one error\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    error = pm.response.json().errors[0];",
+													"    pm.expect(error.code).to.equal(\"missingInstanceStatus\");",
+													"    pm.expect(error.parameters[0].value).to.equal(\"missing-status\");",
+													"});",
+													"",
+													"let bodyTemplate = testConfigs.bodyTemplate;",
+													"let configs = pm.environment.get(\"current-orders-configs\");",
+													"let configName = \"inventory-instanceStatusCode\";",
+													"let existingConfig = utils.getConfigByName(configs, configName);",
+													"existingConfig.value = pm.variables.get(configName);",
+													"utils.updateConfig(existingConfig);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{orderBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsPendingOrderId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"composite-orders",
+												"{{negativeTestsPendingOrderId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Prepare missing loanTypeName config",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let configs = [];",
+													"pm.test(\"Get configs response is ok\", function () {",
+													"    pm.response.to.be.ok;",
+													"    configs = pm.response.json().configs;",
+													"});",
+													"",
+													"let configName = \"inventory-loanTypeName\";",
+													"let value = \"missing-type\";",
+													"",
+													"utils.updateOrCreateConfig(configs, configName, value);",
+													"",
+													"// Store current version of configs",
+													"pm.environment.set(\"current-orders-configs\", configs);",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=module==ORDERS and configName==inventory-loanTypeName",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"configurations",
+												"entries"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "module==ORDERS and configName==inventory-loanTypeName"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update pending order to open with missingLoanType error",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/print_monograph_for_create_inventory_test.json\", (err, res) => {",
+													"    let order  = res.json();",
+													"    order.workflowStatus = \"Open\";",
+													"    order.poNumber = \"loanType\";",
+													"    ",
+													"    //set createInventory value",
+													"    order.compositePoLines[0].id = JSON.parse(globals.poLineForNegativeTests).id;",
+													"    order.compositePoLines[0].eresource.createInventory = \"Instance, Holding, Item\";",
+													"    order.compositePoLines[0].physical.createInventory = \"Instance, Holding, Item\";",
+													"    order.compositePoLines[0].title = \"Test title\";",
+													"    order.compositePoLines[0].details.productIds[0].productType = \"Vendor Title Number\";",
+													"    ",
+													"    pm.variables.set(\"orderBody\", JSON.stringify(utils.prepareOrder(order)));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let testConfigs = globals.testData.configs;",
+													"let error = {};",
+													"pm.test(\"Status code is 500 and one error\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    error = pm.response.json().errors[0];",
+													"    pm.expect(error.code).to.equal(\"missingLoanType\");",
+													"    pm.expect(error.parameters[0].value).to.equal(\"missing-type\");",
+													"});",
+													"",
+													"let bodyTemplate = testConfigs.bodyTemplate;",
+													"let configs = pm.environment.get(\"current-orders-configs\");",
+													"let configName = \"inventory-loanTypeName\";",
+													"let existingConfig = utils.getConfigByName(configs, configName);",
+													"existingConfig.value = pm.variables.get(configName);",
+													"utils.updateConfig(existingConfig);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{orderBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsPendingOrderId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"composite-orders",
+												"{{negativeTestsPendingOrderId}}"
 											]
 										}
 									},
@@ -15371,7 +15797,7 @@
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"id": "638ecd6c-ee91-4b54-a37d-487714653b72",
 										"exec": [
 											""
 										],
@@ -15381,7 +15807,7 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"id": "ccbbd9a9-875f-4851-a9af-2df76cfc098e",
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
@@ -15560,6 +15986,61 @@
 				{
 					"name": "Inventory types",
 					"item": [
+						{
+							"name": "Verify and delete inventory records",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "444f69e9-e0af-4666-aa84-bb56caad1141",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let instances = [];",
+											"",
+											"pm.test(\"Get instances response is ok\", function () {",
+											"    pm.response.to.be.ok;",
+											"    instances = pm.response.json().instances;",
+											"});",
+											"",
+											"for (let i = 0; i < instances.length; i++) {",
+											"    utils.deleteInventoryRecordsByInstanceId(instances[i].id);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-storage/instances?query=identifiers == \"*\\\"identifierTypeId\\\": \\\"{{identifierTypeId}}\\\"*\"",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"instance-storage",
+										"instances"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "identifiers == \"*\\\"identifierTypeId\\\": \\\"{{identifierTypeId}}\\\"*\""
+										}
+									]
+								}
+							},
+							"response": []
+						},
 						{
 							"name": "Delete identifier type",
 							"event": [
@@ -16536,6 +17017,12 @@
 					"    utils.getItemsByPoLineId = function(id, limit, handler) {",
 					"        utils.sendGetRequest(\"/item-storage/items?limit=\" + limit + \"&query=purchaseOrderLineIdentifier==\" + id, handler);",
 					"    };",
+					"    /**",
+					"     * Search items by holdingId",
+					"     */",
+					"    utils.getItemsByHoldingId = function(holdingId, handler) {",
+					"        utils.sendGetRequest(\"/item-storage/items?limit=999&query=holdingsRecordId==\" + holdingId, handler);",
+					"    };",
 					"",
 					"    /**",
 					"     * Validates that Holdings Record was created  in the inventory",
@@ -16681,7 +17168,7 @@
 					"    utils.isItemsUpdateRequired = function(compPOL) {",
 					"        let itemsRequiredForEresource = false;",
 					"        let itemsRequiredForPhysical = false;",
-					"",
+					"       ",
 					"        if (compPOL.eresource != null) {",
 					"            itemsRequiredForEresource = compPOL.eresource.createInventory === \"Instance, Holding, Item\";",
 					"        }",
@@ -17414,6 +17901,35 @@
 					"                });",
 					"        });",
 					"    };",
+					"    ",
+					"    /**",
+					"     * Deletes Item records from Inventor by holding id",
+					"     */",
+					"    utils.deleteInventoryItemRecordsByHoldingId = function(holdingId) {",
+					"        return new Promise((resolve) => {",
+					"            // Get",
+					"            utils.getItemsByHoldingId(holdingId, (err, res) => {",
+					"                let items = res.json().items;",
+					"                let promises = [];",
+					"                    items.forEach(item => {",
+					"                        promises.push(utils.processDeleteRequest(\"/item-storage/items/\" + item.id));",
+					"                    });",
+					"",
+					"                    Promise.all(promises)",
+					"                    // The promisses will be always resolved so not handling reject case",
+					"                        .then(itemDelResults => {",
+					"                            // Returning the holding ids regardless of the result of the item deletion jut to try to delete holdings in any case",
+					"                            ",
+					"                            resolve(itemDelResults);",
+					"",
+					"                            let deletedQty = itemDelResults.filter(code => code === 204).length;",
+					"                            pm.test(items.length + \" item(s) should be deleted for PO Line with id=\" + line.id, () => {",
+					"                                pm.expect(deletedQty).to.eql(items.length);",
+					"                            });",
+					"                        });",
+					"            })",
+					"        });",
+					"    };",
 					"",
 					"    /**",
 					"     * Delete pieces related to PoLine in order",
@@ -17486,6 +18002,43 @@
 					"            Promise.all(promises)",
 					"                .then(success => {",
 					"                    return verifyRecordsDeletion ? utils.verifyInventoryRecordsDeleted(order) : success;",
+					"                })",
+					"                .then(result => clearTimeout(timerId))",
+					"                .catch(err => {",
+					"                    console.log(\"Error happened on Inventory Records deletion:\", err);",
+					"                    clearTimeout(timerId);",
+					"                });",
+					"        });",
+					"    };",
+					"    ",
+					"    /**",
+					"     * Cascasde Deletes Inventory Records by instanceId",
+					"     * Starting with Delete items-> holdings -> Instances",
+					"     *",
+					"     * Note: The timeout is required when Promise is used. See https://community.getpostman.com/t/using-native-javascript-promises-in-postman/636",
+					"     */",
+					"    utils.deleteInventoryRecordsByInstanceId = function(instanceId) {",
+					"        utils.sendGetRequest(\"/holdings-storage/holdings?query=instanceId==\" + instanceId, (err, res) => {",
+					"            let holdings = res.json().holdingsRecords;",
+					"           ",
+					"            const timerId = setTimeout(() => {}, 60000);",
+					"",
+					"            let promises = [];",
+					"            holdings.forEach(holding => {",
+					"                let holdingId = holding.id;",
+					"                // The function returns Promise",
+					"                promises.push(",
+					"                    utils.deleteInventoryItemRecordsByHoldingId(holdingId)",
+					"                        .then(itemsDelResult => {",
+					"                            return  utils.processDeleteRequest(\"/holdings-storage/holdings/\" + holdingId);",
+					"                        })",
+					"                    ",
+					"                );",
+					"            });",
+					"",
+					"            Promise.all(promises)",
+					"                .then(success => {",
+					"                    return  utils.deleteInventoryInstance(instanceId); ",
 					"                })",
 					"                .then(result => clearTimeout(timerId))",
 					"                .catch(err => {",
@@ -17585,9 +18138,27 @@
 					"        let config = configs.filter(value => value.configName === configName);",
 					"        return config.length > 0 ? config[0] : null;",
 					"    };",
+					"    ",
+					"       ",
+					"    utils.updateOrCreateConfig = function(configs, configName, value) {",
+					"        // Just in case check if the config available (should not be the case because all configs were deleted recently)",
+					"        let bodyTemplate = globals.testData.configs.bodyTemplate;",
+					"        let existingConfig = utils.getConfigByName(configs, configName);",
+					"        if (existingConfig) {",
+					"            existingConfig.value = value;",
+					"            utils.updateConfig(existingConfig);",
+					"        } else {",
+					"            bodyTemplate.configName = configName;",
+					"            bodyTemplate.value = value;",
+					"            utils.createConfig(bodyTemplate);",
+					"        ",
+					"            // store new config",
+					"            configs.push(utils.copyJsonObj(bodyTemplate));",
+					"        }",
+					"    };",
 					"",
 					"    utils.createConfig = function(body) {",
-					"        pm.sendRequest({",
+					"         pm.sendRequest({",
 					"            url: utils.buildOkapiUrl(\"/configurations/entries\"),",
 					"            method: \"POST\",",
 					"            header: {",
@@ -17600,6 +18171,7 @@
 					"            pm.test(\"Config created\", function() {",
 					"                pm.expect(response.code).to.eql(201);",
 					"            });",
+					"      ",
 					"        });",
 					"    };",
 					"",
@@ -17773,31 +18345,31 @@
 	],
 	"variable": [
 		{
-			"id": "8f934152-3bd4-45b5-8d1b-43cf0484aa40",
+			"id": "4ded260b-745f-4ba3-89fd-e7ccc61b77d7",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "46cdea95-d38b-402a-ad5c-fe47e9c1aed6",
+			"id": "cad9b278-8308-4ed5-b226-f6bfd9a40c00",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "48782206-715f-4587-9a39-568b16817d78",
+			"id": "0cb3a858-9a6d-4dd5-bfcb-6ff888d309aa",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "468b05ea-04d9-44ed-aa51-62ad4a4d6fc9",
+			"id": "8ceb94bd-e089-42b9-8e17-a8dca091ee0e",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "fdc8d9cd-d6e4-4fce-a74c-88b678589b80",
+			"id": "d67f467b-d56c-40f3-9b2f-3045bfa744cf",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"


### PR DESCRIPTION
- added negative tests to verify that the correct errors is returned
- added a request to the cleanup section that will delete the created inventory records (instances, holdings, items) by `identifierTypeId` from Setup/Prepare inventory types/Get or create Identifier Type request

Collection run on folio-testing:
![image](https://user-images.githubusercontent.com/41672277/58242235-16d20480-7d57-11e9-8eea-5f5986dbc489.png)
