### PR TITLE
MODKBEKBJ-243: Update package api tests

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "15da3488-3b2b-4d6f-9a12-547cdf115637",
+		"_postman_id": "7e694d23-1168-4362-bf76-8c2943e25a55",
 		"name": "mod-kb-ebsco-java copy",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1254,7 +1254,7 @@
 									"    ",
 									"    //Test that name matches value passed in",
 									"    pm.test('name matches value passed in', function() {",
-									"        pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.variables.get(\"custom-package-one-uuid\"));",
+									"        pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.globals.get(\"custom-package-one-uuid\"));",
 									"    });",
 									"    ",
 									"    //Test that package type is custom",
@@ -1280,7 +1280,7 @@
 								"id": "e1884122-c31a-406d-a50f-acfac0fb3298",
 								"exec": [
 									"var uuid = require('uuid');",
-									"pm.variables.set(\"custom-package-one-uuid\", uuid.v4());"
+									"pm.globals.set(\"custom-package-one-uuid\", uuid.v4());"
 								],
 								"type": "text/javascript"
 							}
@@ -1359,7 +1359,7 @@
 									"",
 									"    //Test that name matches value passed in",
 									"    pm.test('name matches value passed in', function() {",
-									"        pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.variables.get(\"custom-package-two-uuid\"));",
+									"        pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.globals.get(\"custom-package-two-uuid\"));",
 									"    });",
 									"    ",
 									"    //Test that package type is custom",
@@ -1394,7 +1394,7 @@
 								"id": "cf165d11-165f-4f3b-8ffd-11c238778635",
 								"exec": [
 									"var uuid = require('uuid');",
-									"pm.variables.set(\"custom-package-two-uuid\", uuid.v4());"
+									"pm.globals.set(\"custom-package-two-uuid\", uuid.v4());"
 								],
 								"type": "text/javascript"
 							}
@@ -8985,7 +8985,7 @@
 															"",
 															"//Test that name matches name provided in request",
 															"pm.test('name matches as provided in request', function() {",
-															"    pm.expect(response.data.attributes.name).eq('new sample package one');",
+															"    pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.globals.get(\"custom-package-one-uuid\"));",
 															"});",
 															"",
 															"//Test that contentType matches as provided in request",
@@ -9054,7 +9054,7 @@
 												],
 												"body": {
 													"mode": "raw",
-													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"new sample package one\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"isCustom\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"tags\": {\n    \t\t\"tagList\": [\n    \t\t\"foo-tag\",\n    \t\t\"another-tag\"\n\t\t\t]\n\t\t}\n    }\n  }\n}"
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"isCustom\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"tags\": {\n    \t\t\"tagList\": [\n    \t\t\"foo-tag\",\n    \t\t\"another-tag\"\n\t\t\t]\n\t\t}\n    }\n  }\n}"
 												},
 												"url": {
 													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
@@ -9120,7 +9120,7 @@
 															"",
 															"//Test that name matches name provided in request",
 															"pm.test('name matches as provided in request', function() {",
-															"    pm.expect(response.data.attributes.name).eq('new sample package two');",
+															"    pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.globals.get(\"custom-package-one-uuid\"));",
 															"});",
 															"",
 															"//Test that contentType matches as provided in request",
@@ -9173,7 +9173,7 @@
 												],
 												"body": {
 													"mode": "raw",
-													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"new sample package two\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2004-01-01\",\n        \"endCoverage\": \"2004-12-01\"\n      },\n      \"isSelected\": true,\n      \"isCustom\": true,\n      \"visibilityData\": {\n        \"isHidden\": false\n      }\n    }\n  }\n}"
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2004-01-01\",\n        \"endCoverage\": \"2004-12-01\"\n      },\n      \"isSelected\": true,\n      \"isCustom\": true,\n      \"visibilityData\": {\n        \"isHidden\": false\n      }\n    }\n  }\n}"
 												},
 												"url": {
 													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
@@ -9245,7 +9245,7 @@
 												],
 												"body": {
 													"mode": "raw",
-													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"new sample package one\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"isCustom\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"tags\": {\n    \t\t\"tagList\": [\n\t\t\t]\n\t\t}\n    }\n  }\n}"
+													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isSelected\": true,\n      \"isCustom\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"tags\": {\n    \t\t\"tagList\": [\n\t\t\t]\n\t\t}\n    }\n  }\n}"
 												},
 												"url": {
 													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",


### PR DESCRIPTION
The following tests were failing in FSE: 
packages / PUT package by packageId / Custom Package / Positive / update custom package
packages / PUT package by packageId / Custom Package / Positive / update custom package with empty tagList

While issuing a PUT request, we are giving the package a constant name all the time and since that package already exists, we are getting back a 400 response from RM API. Instead of updating the package name with a constant name all the time, use the name with a uuid.