### PR TITLE
MODKBEKBJ-245 - API Tests: Update providers (search within packages )…

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "7e694d23-1168-4362-bf76-8c2943e25a55",
-		"name": "mod-kb-ebsco-java copy",
+		"_postman_id": "19cb6b17-d6b0-4172-8448-f3e31fe1e905",
+		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -1019,8 +1019,8 @@
 									"",
 									"//Check if we get a collection of packages in response",
 									"if(response.data) {",
-									"    pm.environment.set(\"tag-name-for-multiply-adding-a\", response.data.attributes.tags.tagList[0]);",
-									"    pm.environment.set(\"tag-name-for-multiply-adding-b\", response.data.attributes.tags.tagList[1]);",
+									"    pm.environment.set(\"tag-name-for-multiple-adding-a\", response.data.attributes.tags.tagList[0]);",
+									"    pm.environment.set(\"tag-name-for-multiple-adding-b\", response.data.attributes.tags.tagList[1]);",
 									"    if(response.data.id) {",
 									"        pm.environment.set(\"custom-package-created-for-tags-id\", response.data.id);",
 									"    }",
@@ -3826,6 +3826,112 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "with valid providerId and filtered by tags ",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "538799ae-0b40-4376-966a-333c2e8021a3",
+												"exec": [
+													"var packageId = pm.environment.get(\"custom-package-to-filter-by-tags\");",
+													"var providerId = packageId.split(\"-\")[0];",
+													"pm.environment.set(\"provider-id\", providerId);"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "c625d97b-c2db-4973-b74b-3460cfe8082d",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageCollection\")))).to.equal(true, \"Schema validation error: \" ",
+													"    + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in response object', function() {",
+													"    pm.expect(response.data[0]).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\")",
+													"});",
+													"",
+													"",
+													"//Test that tags matches value passed in",
+													"pm.test('name matches value passed in', function() {",
+													"    var responseTags = response.data[0].attributes.tags.tagList;",
+													"    var tagOne = pm.environment.get(\"tag-name-for-multiple-adding-a\");",
+													"    var tagTwo = pm.environment.get(\"tag-name-for-multiple-adding-b\");",
+													"    pm.expect(_.includes(responseTags,tagOne)).to.eq(true);",
+													"    pm.expect(_.includes(responseTags,tagTwo)).to.eq(true);",
+													"});",
+													"",
+													"//Test that all package tags included in response",
+													"pm.test('package tags included in responce', function() {",
+													"    pm.expect(response.data[0].attributes.tags.tagList.length).to.eql(2); ",
+													"});",
+													"",
+													"",
+													"//Test that total records value as expected",
+													"pm.test('total records as expected', function() {",
+													"    pm.expect(response.meta.totalResults).to.eql(1);",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/{{provider-id}}/packages?filter[tags]={{tag-name-for-multiple-adding-a}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"{{provider-id}}",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "filter[tags]",
+													"value": "{{tag-name-for-multiple-adding-a}}"
+												}
+											]
+										}
+									},
+									"response": []
 								}
 							],
 							"_postman_isSubFolder": true
@@ -4019,6 +4125,91 @@
 												{
 													"key": "include",
 													"value": ""
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with valid providerId and non existing tags",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "538799ae-0b40-4376-966a-333c2e8021a3",
+												"exec": [
+													"var packageId = pm.environment.get(\"custom-package-to-filter-by-tags\");",
+													"var providerId = packageId.split(\"-\")[0];",
+													"pm.environment.set(\"provider-id\", providerId);"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "c625d97b-c2db-4973-b74b-3460cfe8082d",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageCollection\")))).to.equal(true, \"Schema validation error: \" ",
+													"    + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that total records value as expected",
+													"pm.test('total records as expected', function() {",
+													"    pm.expect(response.meta.totalResults).to.eql(0);",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/{{provider-id}}/packages?filter[tags]=non-existing-tag",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"{{provider-id}}",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "filter[tags]",
+													"value": "non-existing-tag"
 												}
 											]
 										}
@@ -6830,7 +7021,7 @@
 									"response": []
 								},
 								{
-									"name": "valid filter[tags] multiply param",
+									"name": "valid filter[tags] multiple param",
 									"event": [
 										{
 											"listen": "test",
@@ -6888,8 +7079,8 @@
 													"}, function(err, res) {",
 													"    pm.test(\"Check name of tag\", function () {",
 													"        var response = res.json();",
-													"        pm.expect(response.data.attributes.tags.tagList[0]).to.eq(pm.environment.get(\"tag-name-for-multiply-adding-a\"));",
-													"        pm.expect(response.data.attributes.tags.tagList[1]).to.eq(pm.environment.get(\"tag-name-for-multiply-adding-b\"));",
+													"        pm.expect(response.data.attributes.tags.tagList[0]).to.eq(pm.environment.get(\"tag-name-for-multiple-adding-a\"));",
+													"        pm.expect(response.data.attributes.tags.tagList[1]).to.eq(pm.environment.get(\"tag-name-for-multiple-adding-b\"));",
 													"    });",
 													"});",
 													""
@@ -6911,7 +7102,7 @@
 											}
 										],
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?filter[tags]={{tag-name-for-multiply-adding-a}},{{tag-name-for-multiply-adding-b}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?filter[tags]={{tag-name-for-multiple-adding-a}},{{tag-name-for-multiple-adding-b}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -6924,7 +7115,7 @@
 											"query": [
 												{
 													"key": "filter[tags]",
-													"value": "{{tag-name-for-multiply-adding-a}},{{tag-name-for-multiply-adding-b}}"
+													"value": "{{tag-name-for-multiple-adding-a}},{{tag-name-for-multiple-adding-b}}"
 												}
 											]
 										}
@@ -19865,7 +20056,7 @@
 									"name": "Delete Configuration",
 									"item": [
 										{
-											"name": "/configurations/entries - POST RM API URL Copy",
+											"name": "/configurations/entries - POST RM API URL",
 											"event": [
 												{
 													"listen": "prerequest",


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEKBJ-245 we want to cover filtering packages inside provider and tags  by API tests
## Approach 
* covered GET /eholdings/providers/{provider-id}/packages?filter[tags]= {tags} endpoint.
Checked that all package tags included in a response.

Run postman collection against testing vagrant environment