### PR TITLE
MODORDSTOR-79 Remove associated piece records when removing POLine

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -19782,7 +19782,6 @@
 					"",
 					"            Promise.all(promises)",
 					"                .then(success => {",
-					"                    console.log(\"deletedLineIds112\" + deletedLineIds)",
 					"                    pm.globals.set(\"deletedLineIds\", JSON.stringify(deletedLineIds));",
 					"",
 					"                    return verifyRecordsDeletion ? utils.verifyInventoryRecordsDeleted(order) : success;",

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -11223,16 +11223,19 @@
 										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
+											"",
 											"pm.test(\"Open order created\", function () {",
+											"    let order = pm.response.json();",
+											"",
 											"    pm.response.to.have.status(201);",
 											"",
-											"    var order = pm.response.json();",
 											"    pm.globals.set(\"negativeTestsOpenOrderId\", order.id);",
 											"",
 											"    pm.expect(order.workflowStatus).to.equal(\"Open\");",
 											"    utils.validatePoLines(order, 1);",
+											"    utils.validateWorkflowStatus(order);",
 											"});",
-											"utils.validateWorkflowStatus(order);"
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -11285,6 +11288,7 @@
 											"",
 											"let line = utils.buildPoLineWithMinContent(null);",
 											"line.receiptStatus = \"Receipt Not Required\";",
+											"line.paymentStatus = \"Fully Paid\";",
 											"order.compositePoLines = [line];",
 											"pm.variables.set(\"orderBody\", JSON.stringify(order));"
 										],
@@ -11297,16 +11301,19 @@
 										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
+											"",
 											"pm.test(\"Closed order created\", function () {",
+											"    let order = pm.response.json();",
+											"",
 											"    pm.response.to.have.status(201);",
 											"",
-											"    var order = pm.response.json();",
 											"    pm.globals.set(\"negativeTestsClosedOrderId\", order.id);",
 											"",
 											"    pm.expect(order.workflowStatus).to.equal(\"Closed\");",
 											"    utils.validatePoLines(order, 1);",
+											"    utils.validateWorkflowStatus(order);",
 											"});",
-											"utils.validateWorkflowStatus(order);"
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -11370,7 +11377,7 @@
 											"pm.test(\"Pending order created\", function () {",
 											"    pm.response.to.have.status(201);",
 											"",
-											"    var order = pm.response.json();",
+											"    let order = pm.response.json();",
 											"    pm.globals.set(\"negativeTestsPendingOrderId\", order.id);",
 											"",
 											"    pm.expect(order.workflowStatus).to.equal(\"Pending\");",
@@ -15659,7 +15666,10 @@
 												"exec": [
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
-													"});"
+													"});",
+													"",
+													"let utils = eval(globals.loadUtils);",
+													"utils.verifyAllPieceRecordsDeleted();"
 												],
 												"type": "text/javascript"
 											}
@@ -15724,7 +15734,11 @@
 												"exec": [
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
-													"});"
+													"});",
+													"",
+													"",
+													"let utils = eval(globals.loadUtils);",
+													"utils.verifyAllPieceRecordsDeleted();"
 												],
 												"type": "text/javascript"
 											}
@@ -15789,7 +15803,10 @@
 												"exec": [
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
-													"});"
+													"});",
+													"",
+													"let utils = eval(globals.loadUtils);",
+													"utils.verifyAllPieceRecordsDeleted();"
 												],
 												"type": "text/javascript"
 											}
@@ -15919,7 +15936,10 @@
 												"exec": [
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
-													"});"
+													"});",
+													"",
+													"let utils = eval(globals.loadUtils);",
+													"utils.verifyAllPieceRecordsDeleted();"
 												],
 												"type": "text/javascript"
 											}
@@ -15984,7 +16004,10 @@
 												"exec": [
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
-													"});"
+													"});",
+													"",
+													"let utils = eval(globals.loadUtils);",
+													"utils.verifyAllPieceRecordsDeleted();"
 												],
 												"type": "text/javascript"
 											}
@@ -16049,7 +16072,10 @@
 												"exec": [
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
-													"});"
+													"});",
+													"",
+													"let utils = eval(globals.loadUtils);",
+													"utils.verifyAllPieceRecordsDeleted();"
 												],
 												"type": "text/javascript"
 											}
@@ -16115,7 +16141,10 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16181,7 +16210,10 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16246,7 +16278,9 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16312,7 +16346,9 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16377,7 +16413,10 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16440,7 +16479,10 @@
 										"exec": [
 											"pm.test(\"Status code is 204\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16495,7 +16537,10 @@
 										"exec": [
 											"pm.test(\"Status code is 204\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16561,12 +16606,15 @@
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
 											"});",
-											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();",
 											"// Clean-Up",
 											"pm.globals.unset(\"poLineIdPEMix\");",
 											"pm.globals.unset(\"poLine2IdPEMix\");",
 											"pm.globals.unset(\"orderIdPEMix\");",
-											"pm.globals.unset(\"requestBodyToBeUpdated\");"
+											"pm.globals.unset(\"requestBodyToBeUpdated\");",
+											"",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -16632,7 +16680,8 @@
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
 											"});",
-											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();",
 											"// Clean-Up",
 											"pm.globals.unset(\"randomUUId\");",
 											"pm.globals.unset(\"poLineIdPhysical\");",
@@ -16702,7 +16751,9 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16767,7 +16818,9 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16829,7 +16882,9 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -16892,6 +16947,9 @@
 											"pm.test(\"Status code is 204\", function () {",
 											"    pm.response.to.have.status(204);",
 											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();",
 											"",
 											"// Clean-Up",
 											"pm.globals.unset(\"checkin_electronic_poLine\");",
@@ -16965,7 +17023,10 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -17028,7 +17089,10 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -17091,7 +17155,10 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
 										],
 										"type": "text/javascript"
 									}
@@ -19635,6 +19702,37 @@
 					"            });",
 					"        });",
 					"    };",
+					"    ",
+					"    utils.verifyAllPieceRecordsDeleted = function() {",
+					"        let promises = [];",
+					"",
+					"        let lineIds = JSON.parse(pm.globals.get(\"deletedLineIds\"));",
+					"        console.log(\"deletedLineIds = \" + lineIds)",
+					"        lineIds.forEach(lineId => {",
+					"            promises.push(utils.verifyPiecesQuantity(\"/orders-storage/pieces?limit=1000&query=poLineId==\" + lineId, lineId));",
+					"        });",
+					"        Promise.all(promises)",
+					"            .then(getCodes => {",
+					"                resolve(getCodes);",
+					"            })",
+					"            .catch(err => {",
+					"                console.log(\"Error happened on Piece Records deletion:\", err);",
+					"                resolve([]);",
+					"            });",
+					"    }; ",
+					"    ",
+					"    utils.verifyPiecesQuantity = function(path, lineId) {",
+					"        return new Promise((resolve) => {",
+					"            utils.sendGetRequest(path, (err, response) => {",
+					"                    let pieces = response.json().pieces;",
+					"                    pm.test(\"No pieces found for poline \" + lineId, ()=> {",
+					"                        pm.expect(pieces).to.exist;",
+					"                        pm.expect(pieces.length).to.eql(0);",
+					"                    }); ",
+					"                resolve(response.code);",
+					"            });",
+					"        });",
+					"    };",
 					"",
 					"    /**",
 					"     * Cascasde Deletes Inventory Records and Pieces created for PO lines",
@@ -19651,12 +19749,12 @@
 					"            }",
 					"",
 					"            const timerId = setTimeout(() => {}, 60000);",
+					"            let deletedLineIds = [];",
 					"",
 					"            let promises = [];",
 					"            order.compositePoLines.forEach(line => {",
-					"",
+					"                deletedLineIds.push(line.id);",
 					"                // The function returns Promise",
-					"                promises.push(utils.deletePieceRecords(line));",
 					"                promises.push(",
 					"                    utils.deleteInventoryItemRecords(line)",
 					"                    .then(holdingsIds => {",
@@ -19684,6 +19782,9 @@
 					"",
 					"            Promise.all(promises)",
 					"                .then(success => {",
+					"                    console.log(\"deletedLineIds112\" + deletedLineIds)",
+					"                    pm.globals.set(\"deletedLineIds\", JSON.stringify(deletedLineIds));",
+					"",
 					"                    return verifyRecordsDeletion ? utils.verifyInventoryRecordsDeleted(order) : success;",
 					"                })",
 					"                .then(result => clearTimeout(timerId))",
@@ -20029,37 +20130,37 @@
 	],
 	"variable": [
 		{
-			"id": "d3118bdf-33c7-4f95-99f4-ec023f3ec08f",
+			"id": "63553ed3-7eef-470e-95e7-e00dee2ad36b",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "4bb0ef79-e0c5-4cbb-ada4-5faa0f6ebb0e",
+			"id": "5d18c3b8-691f-481b-8041-377aee514e08",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "313c30f4-ed34-4dfb-ba39-da3786356389",
+			"id": "9d19815b-2bee-4dee-a886-eb19039b5439",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "e080ec2a-90cc-4db3-856f-70ff3627d648",
+			"id": "469cba9b-e397-4cfa-af87-5102078b5a72",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "9c3510b1-dac7-493b-bb90-72835d8d43e2",
+			"id": "58b925c6-de6f-481c-a841-8969b4a1d5d8",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "fd3883d3-9e30-4547-92f4-9a1014af60a2",
+			"id": "fa7d99f6-1fc1-4628-942a-e4a610a40ebf",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDSTOR-79

### Purpose
https://issues.folio.org/browse/MODORDSTOR-79

### Approach
* Removed script that deletes pieces associated with PO and POLines 
* Added script to verify that all associated pieces are deleted

verifyAllPieceRecordsDeleted
![image](https://user-images.githubusercontent.com/45555481/58962328-9d550000-87b3-11e9-9a33-48bb5e902ba9.png)

Verified on folio testing
![image](https://user-images.githubusercontent.com/45555481/58962403-c4133680-87b3-11e9-970c-7771259c0d61.png)

