### PR TITLE
MODORDERS-243 Create encumbrance upon order transition to "Open"

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -757,6 +757,213 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "Prepare finance data",
+					"item": [
+						{
+							"name": "Get or create ledger",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"GET ledger response is ok\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let jsonData = pm.response.json();",
+											"    if (jsonData.ledgers.length == 1) {",
+											"        useAlreadyExistingType(jsonData.ledgers[0]);",
+											"    } else {",
+											"        createNewRecord();",
+											"    }",
+											"});  ",
+											"",
+											"function useAlreadyExistingType(identifierType) {",
+											"    pm.test(\"Ledger already exists\", function () {",
+											"        pm.expect(identifierType.id).to.exist;",
+											"        rememberId(identifierType.id);",
+											"    });",
+											"}",
+											"",
+											"function createNewRecord() {",
+											"    const type = {",
+											"        \"name\": \"Ledger for orders API Tests\",",
+											"        \"code\": pm.variables.get(\"finance-ledgerCode\"),",
+											"        \"description\": \"Ledger for orders API Tests\"",
+											"    };",
+											"",
+											"    eval(globals.loadUtils).postRequest(\"/finance-storage/ledgers\", type, (err, res) => {",
+											"        pm.test(\"Ledger created\", () => {",
+											"            pm.expect(err).to.equal(null);",
+											"            pm.expect(res).to.have.property('code', 201);",
+											"            rememberId(res.json().id);",
+											"        });",
+											"    });",
+											"}",
+											"",
+											"function rememberId(id) {",
+											"    pm.environment.set(\"ledgerId\", id);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers?query=code=={{finance-ledgerCode}}&limit=1",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"ledgers"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "code=={{finance-ledgerCode}}"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								},
+								"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						},
+						{
+							"name": "Get or create fund",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"GET funds response is ok\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let jsonData = pm.response.json();",
+											"    if (jsonData.funds.length == 1) {",
+											"        useAlreadyExistingType(jsonData.funds[0]);",
+											"    } else {",
+											"        createNewRecord();",
+											"    }",
+											"});  ",
+											"",
+											"function useAlreadyExistingType(identifierType) {",
+											"    pm.test(\"Fund already exists\", function () {",
+											"        pm.expect(identifierType.id).to.exist;",
+											"        rememberId(identifierType.id);",
+											"    });",
+											"}",
+											"",
+											"function createNewRecord() {",
+											"    const type = {",
+											"      \"code\": pm.variables.get(\"finance-fundCode\"),",
+											"      \"description\": \"Fund for orders API Tests\",",
+											"      \"externalAccountNo\": \"1111111111111111111111111\",",
+											"      \"fundStatus\": \"Active\",",
+											"      \"ledgerId\": pm.variables.get(\"ledgerId\"),",
+											"      \"name\": \"Fund for orders API Tests\"",
+											"    };",
+											"",
+											"    eval(globals.loadUtils).postRequest(\"/finance-storage/funds\", type, (err, res) => {",
+											"        pm.test(\"Fund created\", () => {",
+											"            pm.expect(err).to.equal(null);",
+											"            pm.expect(res).to.have.property('code', 201);",
+											"            rememberId(res.json().id);",
+											"        });",
+											"    });",
+											"}",
+											"",
+											"function rememberId(id) {",
+											"    pm.environment.set(\"fundId\", id);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds?query=code=={{finance-fundCode}}&limit=1",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"funds"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "code=={{finance-fundCode}}"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								},
+								"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "Prepare inventory types",
 					"item": [
 						{
@@ -12954,6 +13161,104 @@
 							"_postman_isSubFolder": true
 						},
 						{
+							"name": "Encumbrance creation failure",
+							"item": [
+								{
+									"name": "Create Open order with lines pointing to unexisting fund",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"var uuid = require('uuid');",
+													"",
+													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", (err, res) => {",
+													"    let order  = utils.prepareOrder(res.json());",
+													"    order.workflowStatus = \"Open\";",
+													"    // Setting specific PO Number to delete this order in cleanup",
+													"    order.poNumber = \"APIFAILENCUMB1\";",
+													"    order.compositePoLines.forEach(poLine => {",
+													"        poLine.receiptStatus = \"Receipt Not Required\";",
+													"        // Setting random fund id",
+													"        poLine.fundDistribution.forEach(distrib => distrib.fundId = uuid.v4());",
+													"    });",
+													"    pm.variables.set(\"order_with_unexisting_fund\", JSON.stringify(order));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Server error is expected: encumbranceCreationFailure\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors).to.have.lengthOf(1);",
+													"    pm.expect(errors[0].code).to.equal(\"encumbranceCreationFailure\");",
+													"});",
+													"",
+													"utils.sendGetRequest(\"/orders/order-lines?query=poNumber==APIFAILENCUMB1\", function (err, res) {",
+													"    pm.expect(err).to.equal(null);",
+													"",
+													"    res.json().poLines.forEach(poLine => {",
+													"        utils.validateEncumbranceRecords(poLine, \"Pending\");",
+													"        pm.globals.set(\"negativeTestsFailedEncumbrances\", poLine.purchaseOrderId);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{order_with_unexisting_fund}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"composite-orders"
+											]
+										},
+										"description": "Create a purchase order in Open status based on `po_listed_print_monograph.json` from mod-orders. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117)).\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `true`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
 							"name": "Get list of Open order - bad sorting query",
 							"event": [
 								{
@@ -16467,7 +16772,7 @@
 									"script": {
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
-											""
+											"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.orderWithoutInventoryRecordsId, true);"
 										],
 										"type": "text/javascript"
 									}
@@ -17195,6 +17500,72 @@
 										"orders",
 										"composite-orders",
 										"{{negativeTestsClosedOrderId}}"
+									]
+								},
+								"description": "GET /orders/composite-orders/id requests that return 204"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Pending order (encumbrance creation failure)",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order has been successfully deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											"",
+											"let utils = eval(globals.loadUtils);",
+											"utils.verifyAllPieceRecordsDeleted();"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsFailedEncumbrances}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{negativeTestsFailedEncumbrances}}"
 									]
 								},
 								"description": "GET /orders/composite-orders/id requests that return 204"
@@ -18060,6 +18431,120 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "Finance data",
+					"item": [
+						{
+							"name": "Delete fund",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Test fund deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds/{{fundId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"funds",
+										"{{fundId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete ledger",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Test ledger deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers/{{ledgerId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"ledgers",
+										"{{ledgerId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "Delete location",
 					"event": [
 						{
@@ -18496,6 +18981,18 @@
 					"        pm.expect(piece.receivingStatus, \"Piece receiving status expected\").to.exist;",
 					"    };",
 					"",
+					"    utils.validateEncumbrance = function(encumbrance, fundDistributions) {",
+					"        pm.expect(encumbrance.id, \"Encumbrance id expected\").to.exist;",
+					"        pm.expect(encumbrance.amountEncumbered, \"Amount encumbered expected\").to.exist;",
+					"        pm.expect(encumbrance.fundId, \"Encumbrance fund id expected\").to.exist;",
+					"        pm.expect(encumbrance.status, \"Encumbrance receiving status expected\").to.exist;",
+					"",
+					"        let filteredArray = fundDistributions.filter(fundDistribution => fundDistribution.encumbrance === encumbrance.id);",
+					"        pm.expect(filteredArray).to.have.lengthOf(1);",
+					"        let fundDistribution = filteredArray[0];",
+					"        pm.expect(encumbrance.fundId).to.eql(fundDistribution.fundId);",
+					"    };",
+					"",
 					"    /**",
 					"     * Sends GET request and uses passed handler to handle result",
 					"     */",
@@ -18541,6 +19038,12 @@
 					"        }",
 					"        if (poLine.hasOwnProperty(\"details\") && poLine.details.hasOwnProperty(\"productIds\")) {",
 					"            poLine.details.productIds.forEach(prod => utils.makeProductIdUnique(prod));",
+					"        }",
+					"        if (poLine.hasOwnProperty(\"fundDistribution\")) {",
+					"            poLine.fundDistribution.forEach(distrib => {",
+					"                delete distrib.encumbrance;",
+					"                distrib.fundId = pm.environment.get(\"fundId\");",
+					"            });",
 					"        }",
 					"",
 					"        delete poLine.id;",
@@ -18627,6 +19130,7 @@
 					"                }",
 					"                // Validate that expected piece quantity created of expected format",
 					"                utils.validatePieceRecords(poLine, checkInventory);",
+					"                utils.validateEncumbranceRecords(poLine, order.workflowStatus);",
 					"",
 					"                if (poLine.cost) {",
 					"                    pm.expect(poLine.cost.poLineEstimatedPrice).to.be.above(0);",
@@ -18785,8 +19289,25 @@
 					"    };",
 					"",
 					"    /**",
+					"     * Validate encumbrances for PO Line",
+					"     */",
+					"    utils.validateEncumbranceRecords = function(poLine, orderStatus) {",
+					"        let expectedQuantity = orderStatus === \"Pending\" ? 0 : poLine.fundDistribution.length;",
+					"        utils.sendGetRequest(\"/finance-storage/encumbrances?limit=\" + expectedQuantity + \"&query=poLineId==\" + poLine.id, (err, res) => {",
+					"            let testMsg = expectedQuantity > 0 ? expectedQuantity : \"No\";",
+					"            pm.test(testMsg + \" encumbrance record(s) found for PO Line with number=\" + poLine.poLineNumber, function() {",
+					"                pm.expect(res.code).to.eql(200);",
+					"                pm.expect(res.json().totalRecords, \"Number of created encumbrances does not match to expected\").to.eql(expectedQuantity);",
+					"                if (expectedQuantity > 0) {",
+					"                    res.json().encumbrances.forEach(encumbrance => utils.validateEncumbrance(encumbrance, poLine.fundDistribution));",
+					"                }",
+					"            });",
+					"        });",
+					"    };",
+					"",
+					"    /**",
 					"     * Validates that PO Line's receipt status updated to expected,",
-					"     * and incase of checkin the receipt date has to be validated ",
+					"     * and incase of checkin the receipt date has to be validated",
 					"     * if receipt status is partially received, as it is updated for first piece checkec-in",
 					"     */",
 					"    utils.validateReceiptStatus = function(poLine, receiptStatus) {",
@@ -19087,6 +19608,10 @@
 					"     * The logic is based on MODORDERS-178",
 					"     */",
 					"    utils.calculateExpectedItemsQuantity = function(poLine) {",
+					"        // MODORDERS-159: If receipt status is \"Receipt not Required\", no items are created",
+					"        if (poLine.receiptStatus === \"Receipt Not Required\") {",
+					"            return 0;",
+					"        }",
 					"        switch (poLine.orderFormat) {",
 					"            case \"P/E Mix\":",
 					"                let quantity = utils.isItemsUpdateRequiredForEresource(poLine) ? utils.getElectronicItemsQuantity(poLine) : 0;",
@@ -19704,34 +20229,16 @@
 					"    };",
 					"    ",
 					"    utils.verifyAllPieceRecordsDeleted = function() {",
-					"        let promises = [];",
-					"",
-					"        let lineIds = JSON.parse(pm.globals.get(\"deletedLineIds\"));",
-					"        console.log(\"deletedLineIds = \" + lineIds)",
+					"        let lineIds = pm.globals.get(\"deletedLineIds\") || [];",
+					"        console.log(\"deletedLineIds = \" + lineIds);",
 					"        lineIds.forEach(lineId => {",
-					"            promises.push(utils.verifyPiecesQuantity(\"/orders-storage/pieces?limit=1000&query=poLineId==\" + lineId, lineId));",
-					"        });",
-					"        Promise.all(promises)",
-					"            .then(getCodes => {",
-					"                resolve(getCodes);",
-					"            })",
-					"            .catch(err => {",
-					"                console.log(\"Error happened on Piece Records deletion:\", err);",
-					"                resolve([]);",
-					"            });",
-					"    }; ",
-					"    ",
-					"    utils.verifyPiecesQuantity = function(path, lineId) {",
-					"        return new Promise((resolve) => {",
+					"            let path = \"/orders-storage/pieces?limit=0&query=poLineId==\" + lineId;",
 					"            utils.sendGetRequest(path, (err, response) => {",
-					"                    let pieces = response.json().pieces;",
-					"                    pm.test(\"No pieces found for poline \" + lineId, ()=> {",
-					"                        pm.expect(pieces).to.exist;",
-					"                        pm.expect(pieces.length).to.eql(0);",
-					"                    }); ",
-					"                resolve(response.code);",
+					"                let pieces = response.json().totalRecords;",
+					"                pm.test(\"No pieces found for poline \" + lineId, ()=> pm.expect(pieces).to.eql(0));",
 					"            });",
 					"        });",
+					"        pm.globals.unset(\"deletedLineIds\");",
 					"    };",
 					"",
 					"    /**",
@@ -19754,6 +20261,7 @@
 					"            let promises = [];",
 					"            order.compositePoLines.forEach(line => {",
 					"                deletedLineIds.push(line.id);",
+					"                promises.push(utils.deleteEncumbranceRecords(line));",
 					"                // The function returns Promise",
 					"                promises.push(",
 					"                    utils.deleteInventoryItemRecords(line)",
@@ -19782,7 +20290,7 @@
 					"",
 					"            Promise.all(promises)",
 					"                .then(success => {",
-					"                    pm.globals.set(\"deletedLineIds\", JSON.stringify(deletedLineIds));",
+					"                    pm.globals.set(\"deletedLineIds\", deletedLineIds);",
 					"",
 					"                    return verifyRecordsDeletion ? utils.verifyInventoryRecordsDeleted(order) : success;",
 					"                })",
@@ -19889,6 +20397,28 @@
 					"    };",
 					"",
 					"    /**",
+					"     * Delete encumbrances related to PoLine in order",
+					"     */",
+					"    utils.deleteEncumbranceRecords = function(line) {",
+					"        return new Promise((resolve) => {",
+					"            utils.sendGetRequest(\"/finance-storage/encumbrances?limit=1000&query=poLineId==\" + line.id, (err, res) => {",
+					"                let promises = [];",
+					"                res.json().encumbrances.forEach(encumbrance => {",
+					"                    promises.push(utils.processDeleteRequest(\"/finance-storage/encumbrances/\" + encumbrance.id));",
+					"                });",
+					"                Promise.all(promises)",
+					"                    .then(deletionCodes => {",
+					"                        resolve(deletionCodes);",
+					"                    })",
+					"                    .catch(err => {",
+					"                        console.log(\"Error happened on encumbrance records deletion:\", err);",
+					"                        resolve([]);",
+					"                    });",
+					"            });",
+					"        });",
+					"    };",
+					"",
+					"    /**",
 					"     * Sends delete request based on specified path.",
 					"     * The Promise is returned as a result of the operation holding the http code of the response once completed.",
 					"     */",
@@ -19936,7 +20466,7 @@
 					"            body.configName = configName;",
 					"            body.value = value;",
 					"            utils.createConfig(body);",
-					"        ",
+					"",
 					"            // store new config",
 					"            configs.push(body);",
 					"        }",
@@ -20024,6 +20554,7 @@
 					"        pm.globals.unset(\"negativeTestsPendingOrderId\");",
 					"        pm.globals.unset(\"negativeTestsOpenOrderId\");",
 					"        pm.globals.unset(\"negativeTestsClosedOrderId\");",
+					"        pm.globals.unset(\"negativeTestsFailedEncumbrances\");",
 					"        pm.globals.unset(\"anotherCompleteOrderId\");",
 					"        pm.globals.unset(\"completeOpenOrderId\");",
 					"        pm.globals.unset(\"poLineForNegativeTests\");",
@@ -20062,6 +20593,8 @@
 					"        pm.environment.unset(\"loanTypeId\");",
 					"        pm.environment.unset(\"materialTypeId\");",
 					"        pm.environment.unset(\"uniqueProductId\");",
+					"        pm.environment.unset(\"ledgerId\");",
+					"        pm.environment.unset(\"fundId\");",
 					"    };",
 					"",
 					"    /**",
@@ -20162,6 +20695,18 @@
 			"id": "fa7d99f6-1fc1-4628-942a-e4a610a40ebf",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
+			"type": "string"
+		},
+		{
+			"id": "efc13c7b-833e-4e0c-a708-431c3b1cbc42",
+			"key": "finance-ledgerCode",
+			"value": "ordersApiTestsLedgerCode",
+			"type": "string"
+		},
+		{
+			"id": "8e3f3e35-aa86-46c8-bb39-a14830cc8ba0",
+			"key": "finance-fundCode",
+			"value": "ordersApiTestsFundCode",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
## Purpose
[MODORDERS-243](https://issues.folio.org/browse/MODORDERS-243) Create encumbrance upon order transition to "Open"

## Approach
- Setup: Create test ledger and fund
  ![image](https://user-images.githubusercontent.com/43410167/59097538-7ec34600-8926-11e9-9989-51a5a7df4ea0.png)
- Utility functions:
  - validateEncumbranceRecords(poLine, orderStatus) - checks how many encumbrances have been created based on POL's fundDistribution count. The function is called by `utils.validatePoLines`
  ![image](https://user-images.githubusercontent.com/43410167/59097604-ad412100-8926-11e9-992d-8bed615c469c.png)
  ![image](https://user-images.githubusercontent.com/43410167/59097442-3b68d780-8926-11e9-9eb6-c83399635c51.png)
  ![image](https://user-images.githubusercontent.com/43410167/59097471-520f2e80-8926-11e9-8243-50e5ca9024c7.png)
  - deleteEncumbranceRecords(poLine) - deletes all the encumbrance records associated with PO Line id
- Negative test: Encumbrance creation failure
  ![image](https://user-images.githubusercontent.com/43410167/59097362-05c3ee80-8926-11e9-8d1d-c0d3b5fbcb4b.png)
- Cleanup:
  - Delete Pending order (encumbrance creation failure)
  - 2 requests to delete test fund and ledger (if these tests fail, it means there are some not deleted encumbrances)