### PR TITLE
MODCXMUX-52: Correct mux text to check for body text contains

### DIFF
--- a/mod-codex-mux/mod-codex-mux.postman_collection.json
+++ b/mod-codex-mux/mod-codex-mux.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4e1a5ee0-b9dc-430e-9b34-1b93c7824023",
+		"_postman_id": "76f80957-718e-46e3-b8e0-dc3405aa006a",
 		"name": "mod-codex-mux",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -123,10 +123,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.url)",
 							"protocol": "{{protocol}}",
@@ -284,10 +280,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.customerId)",
 							"protocol": "{{protocol}}",
@@ -439,10 +431,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.apiKey)",
 							"protocol": "{{protocol}}",
@@ -675,10 +663,6 @@
 								"type": "text"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{xokapitenant}}/interfaces/codex",
 							"protocol": "{{protocol}}",
@@ -795,10 +779,6 @@
 								"type": "text"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas",
 							"protocol": "{{protocol}}",
@@ -895,10 +875,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances",
 											"protocol": "{{protocol}}",
@@ -979,10 +955,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(publisher=BMJ)",
 											"protocol": "{{protocol}}",
@@ -1060,10 +1032,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(publisher=abc)&limit=10",
 											"protocol": "{{protocol}}",
@@ -1140,10 +1108,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(publisher=abc)&lang=en",
 											"protocol": "{{protocol}}",
@@ -1249,10 +1213,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(id={{id}})",
 											"protocol": "{{protocol}}",
@@ -1336,10 +1296,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(id=123)",
 											"protocol": "{{protocol}}",
@@ -1423,10 +1379,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(title=American or publisher=University)",
 											"protocol": "{{protocol}}",
@@ -1497,10 +1449,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?query=(publisher=abc)&limit=-1",
 											"protocol": "{{protocol}}",
@@ -1569,10 +1517,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?limit=2147483648",
 											"protocol": "{{protocol}}",
@@ -1638,10 +1582,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?offset=2147483648",
 											"protocol": "{{protocol}}",
@@ -1706,10 +1646,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?offset=-1",
 											"protocol": "{{protocol}}",
@@ -1774,10 +1710,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances?lang=123",
 											"protocol": "{{protocol}}",
@@ -1888,10 +1820,6 @@
 												"value": "{{xokapitenant}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances/{{id}}",
 											"protocol": "{{protocol}}",
@@ -1957,10 +1885,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-instances/1",
 											"protocol": "{{protocol}}",
@@ -2091,10 +2015,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages",
 											"protocol": "{{protocol}}",
@@ -2180,10 +2100,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?query=(name=Academic)",
 											"protocol": "{{protocol}}",
@@ -2266,10 +2182,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?query=(name=Academic)&limit=14",
 											"protocol": "{{protocol}}",
@@ -2376,10 +2288,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?query=(id={{packagesId}})",
 											"protocol": "{{protocol}}",
@@ -2463,10 +2371,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?query=(id=123-123)",
 											"protocol": "{{protocol}}",
@@ -2546,10 +2450,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?query=(name=Academic) and type=ejournal",
 											"protocol": "{{protocol}}",
@@ -2620,10 +2520,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?limit=-1",
 											"protocol": "{{protocol}}",
@@ -2688,10 +2584,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?limit=2147483648",
 											"protocol": "{{protocol}}",
@@ -2757,10 +2649,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?offset=2147483648",
 											"protocol": "{{protocol}}",
@@ -2825,10 +2713,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?offset=-1",
 											"protocol": "{{protocol}}",
@@ -2893,10 +2777,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages?lang=123",
 											"protocol": "{{protocol}}",
@@ -3010,10 +2890,6 @@
 												"value": "{{xokapitoken}}"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages/{{packagesId}}",
 											"protocol": "{{protocol}}",
@@ -3081,10 +2957,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages/{{wrongId}}",
 											"protocol": "{{protocol}}",
@@ -3125,7 +2997,7 @@
 													"",
 													"pm.test(\"Response having error message\", function () {",
 													"    pm.response.to.be.withBody;",
-													"    pm.response.to.have.body('No suitable module found for path /codex-packages/');",
+													"    pm.expect(pm.response.text()).to.include(\"No suitable module found for path /codex-packages/\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -3146,10 +3018,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages/",
 											"protocol": "{{protocol}}",
@@ -3279,10 +3147,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/codex-packages-sources",
 							"protocol": "{{protocol}}",
@@ -3368,10 +3232,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.url)",
 							"protocol": "{{protocol}}",
@@ -3503,10 +3363,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.customerId)",
 							"protocol": "{{protocol}}",
@@ -3637,10 +3493,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=(module==EKB and configName==api_access and code==kb.ebsco.apiKey)",
 							"protocol": "{{protocol}}",


### PR DESCRIPTION
Per https://issues.folio.org/browse/MODCXMUX-52 -- we are seeing an api test failure on MUX release.

Correct API test to check for body which includes the indicated text

"No suitable module found for path /codex-packages/"

Since text now includes tenant information

'No suitable module found for path /codex-packages/ for tenant fs00000000'