### PR TITLE
MODINVOICE-36 Mark voucher as paid on transition to invoice status "Paid"

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -23,7 +23,7 @@
 											"    pm.response.to.have.status(201);",
 											"});",
 											"",
-											"pm.environment.set(\"xokapitoken\", postman.getResponseHeader(\"x-okapi-token\"));"
+											"pm.environment.set(\"xokapitoken-admin\", postman.getResponseHeader(\"x-okapi-token\"));"
 										],
 										"type": "text/javascript"
 									}
@@ -115,7 +115,7 @@
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"url": {
@@ -190,7 +190,7 @@
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"url": {
@@ -282,7 +282,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"url": {
@@ -367,7 +367,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"url": {
@@ -443,11 +443,15 @@
 											"\r",
 											"    var promises = schemas.map(path => fetchSchema(path));\r",
 											"    Promise.all(promises)\r",
-											"        .then(result => clearTimeout(timerId))\r",
-											"        .catch((err, req) => {\r",
+											"        .then(result => {\r",
+											"            let failedSchemas = schemas.filter(path => !result.includes(path));\r",
+											"            pm.test(\"All json schemas are loaded\", () => pm.expect(failedSchemas, failedSchemas.join()).to.be.empty);\r",
 											"            clearTimeout(timerId);\r",
-											"            console.log(err);\r",
-											"            console.log(req);\r",
+											"        })\r",
+											"        .catch((err, path) => {\r",
+											"            clearTimeout(timerId);\r",
+											"            pm.test(\"One or more schema could not be loaded: \" + err, () => pm.expect.fail());\r",
+											"            console.log(\"Failure to load \" + path, err);\r",
 											"        });\r",
 											"}\r",
 											"\r",
@@ -455,15 +459,18 @@
 											"    let getRequest = buildGetSchemaRequest(path);\r",
 											"    return new Promise((resolve, reject) => {\r",
 											"        pm.sendRequest(getRequest, (err, response) => {\r",
-											"            pm.test(\"Schema content loaded: \" + path, () => pm.expect(err).to.equal(null));\r",
 											"\r",
 											"            if (!err) {\r",
-											"                let content = replaceResponseRefWithName(response.text());\r",
-											"                let name = extractName(path);\r",
-											"                setEnvironmentVariable(name, content);\r",
-											"                resolve();\r",
+											"                if (response.code === 200) {\r",
+											"                    let content = replaceResponseRefWithName(response.text());\r",
+											"                    let name = extractName(path);\r",
+											"                    setEnvironmentVariable(name, content);\r",
+											"                    resolve(path);\r",
+											"                } else {\r",
+											"                    resolve();\r",
+											"                }\r",
 											"            } else {\r",
-											"                reject(err, getRequest);\r",
+											"                reject(err);\r",
 											"            }\r",
 											"        });\r",
 											"    });\r",
@@ -629,7 +636,7 @@
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -649,6 +656,213 @@
 									]
 								},
 								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Prepare finance data",
+					"item": [
+						{
+							"name": "Get or create ledger",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"GET ledger response is ok\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let jsonData = pm.response.json();",
+											"    if (jsonData.ledgers.length == 1) {",
+											"        useAlreadyExistingType(jsonData.ledgers[0]);",
+											"    } else {",
+											"        createNewRecord();",
+											"    }",
+											"});  ",
+											"",
+											"function useAlreadyExistingType(identifierType) {",
+											"    pm.test(\"Ledger already exists\", function () {",
+											"        pm.expect(identifierType.id).to.exist;",
+											"        rememberId(identifierType.id);",
+											"    });",
+											"}",
+											"",
+											"function createNewRecord() {",
+											"    const type = {",
+											"        \"name\": \"Ledger for invoicing API Tests\",",
+											"        \"code\": pm.variables.get(\"finance-ledgerCode\"),",
+											"        \"description\": \"Ledger for invoicing API Tests\"",
+											"    };",
+											"",
+											"    eval(globals.loadUtils).sendPostRequest(\"/finance-storage/ledgers\", type, (err, res) => {",
+											"        pm.test(\"Ledger created\", () => {",
+											"            pm.expect(err).to.equal(null);",
+											"            pm.expect(res).to.have.property('code', 201);",
+											"            rememberId(res.json().id);",
+											"        });",
+											"    });",
+											"}",
+											"",
+											"function rememberId(id) {",
+											"    pm.environment.set(\"ledgerId\", id);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers?query=code=={{finance-ledgerCode}}&limit=1",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"ledgers"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "code=={{finance-ledgerCode}}"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								},
+								"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						},
+						{
+							"name": "Get or create fund",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"GET funds response is ok\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let jsonData = pm.response.json();",
+											"    if (jsonData.funds.length == 1) {",
+											"        useAlreadyExistingType(jsonData.funds[0]);",
+											"    } else {",
+											"        createNewRecord();",
+											"    }",
+											"});  ",
+											"",
+											"function useAlreadyExistingType(identifierType) {",
+											"    pm.test(\"Fund already exists\", function () {",
+											"        pm.expect(identifierType.id).to.exist;",
+											"        rememberId(identifierType.id);",
+											"    });",
+											"}",
+											"",
+											"function createNewRecord() {",
+											"    const type = {",
+											"      \"code\": pm.variables.get(\"finance-fundCode\"),",
+											"      \"description\": \"Fund for invoicing API Tests\",",
+											"      \"externalAccountNo\": \"11111122211111111\",",
+											"      \"fundStatus\": \"Active\",",
+											"      \"ledgerId\": pm.variables.get(\"ledgerId\"),",
+											"      \"name\": \"Fund for invoicing API Tests\"",
+											"    };",
+											"",
+											"    eval(globals.loadUtils).sendPostRequest(\"/finance-storage/funds\", type, (err, res) => {",
+											"        pm.test(\"Fund created\", () => {",
+											"            pm.expect(err).to.equal(null);",
+											"            pm.expect(res).to.have.property('code', 201);",
+											"            rememberId(res.json().id);",
+											"        });",
+											"    });",
+											"}",
+											"",
+											"function rememberId(id) {",
+											"    pm.environment.set(\"fundId\", id);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds?query=code=={{finance-fundCode}}&limit=1",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"funds"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "code=={{finance-fundCode}}"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								},
+								"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
 							},
 							"response": []
 						}
@@ -722,7 +936,7 @@
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}",
+										"value": "{{xokapitoken-admin}}",
 										"type": "text"
 									}
 								],
@@ -797,7 +1011,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -872,7 +1086,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -1424,260 +1638,6 @@
 							"_postman_isSubFolder": true
 						},
 						{
-							"name": "Transition to Paid",
-							"item": [
-								{
-									"name": "Create approved invoice",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"let invoice = {};",
-													"",
-													"pm.test(\"Invoice is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    invoice = pm.response.json();",
-													"});",
-													"",
-													"pm.test(\"Invoice content is valid\", function() {",
-													"    pm.environment.set(\"approvedToPaidInvoice\", invoice.id);",
-													"    pm.globals.set(\"approvedToPaidInvoiceContent\", JSON.stringify(invoice));",
-													"    ",
-													"    utils.validateInvoice(invoice);",
-													"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(0);",
-													"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(0);",
-													"    pm.expect(invoice.total, \"total\").to.equal(0);",
-													"});",
-													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-													"    let invoiceLine = res.json();",
-													"    invoiceLine.invoiceId = pm.environment.get(\"approvedToPaidInvoice\");",
-													"    delete invoiceLine.id;",
-													"    delete invoiceLine.metadata;",
-													"    ",
-													"    for(let i = 1; i < 5; i++) {",
-													"        invoiceLine.poLineId = i % 2 === 0 ? pm.globals.get(\"poLine1Id\") : pm.globals.get(\"poLine2Id\");",
-													"        invoiceLine.releaseEncumbrance = i % 4 === 0;",
-													"        ",
-													"        utils.postRequest(\"/invoice/invoice-lines\", invoiceLine, function(err,response){",
-													"            pm.test(\"Invoice line is created in storage\", function(){",
-													"              pm.expect(err).to.equal(null);",
-													"              pm.expect(response).to.have.property('code', 201);",
-													"            });",
-													"        });",
-													"    }",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-													"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
-													"",
-													"    invoice.note += \" - transition to Paid\";",
-													"    invoice.status = \"Approved\";",
-													"",
-													"    pm.globals.set(\"approvedToPaidInvoiceContent\", JSON.stringify(invoice));",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{approvedToPaidInvoiceContent}}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"invoice",
-												"invoices"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Update invoice with status Paid",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let invoice = JSON.parse(globals.approvedToPaidInvoiceContent);",
-													"invoice.status = \"Paid\";",
-													"delete invoice.subTotal;",
-													"delete invoice.total;",
-													"pm.globals.set(\"approvedToPaidInvoiceContent\", JSON.stringify(invoice));",
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(\"No Content\");",
-													"",
-													"    // The test can be run only if update succeded",
-													"    utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"approvedToPaidInvoice\"), (err, res) => {",
-													"        pm.test(\"Invoice status changed\", function () {",
-													"            pm.expect(res.json().status).to.equal(\"Paid\");",
-													"        });",
-													"    });",
-													"});",
-													"",
-													"pm.globals.unset(\"approvedToPaidInvoiceContent\");"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "PUT",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{approvedToPaidInvoiceContent}}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{approvedToPaidInvoice}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"invoice",
-												"invoices",
-												"{{approvedToPaidInvoice}}"
-											]
-										},
-										"description": "Verify [MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) - the order can be updated if created without workflow status"
-									},
-									"response": []
-								},
-								{
-									"name": "Get empty order by order id and validate totalItems",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"let order = {}; ",
-													"pm.test(\"Status code is 200\", function () {",
-													"    pm.response.to.have.status(200);",
-													"});",
-													"",
-													"pm.test(\"Validate PO Lines paymentStatus\", function () {",
-													"    order = pm.response.json();",
-													"    let poLines = order.compositePoLines;",
-													"    for(let i = 0; i < poLines.length; i++) {",
-													"        if (poLines[i].id === globals.poLine1Id) {",
-													"            pm.expect(poLines[i].paymentStatus).to.equal(\"Fully Paid\");",
-													"        } else {",
-													"            pm.expect(poLines[i].paymentStatus).to.equal(\"Partially Paid\");",
-													"        }",
-													"    }",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "GET",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{admintoken}}"
-											}
-										],
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{completeOrderId}}"
-											]
-										},
-										"description": "GET /orders/composite-orders/id requests that return 200"
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
-						{
 							"name": "Delete Invoice and associated lines",
 							"item": [
 								{
@@ -2045,6 +2005,29 @@
 								"description": "Verify [MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) - the order can be updated if created without workflow status"
 							},
 							"response": []
+						}
+					],
+					"description": "Tests to verify basic operations with invoices",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "58fc2db4-96f3-4a4e-907b-b35d8146fe27",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "267e3a92-c3eb-4121-a453-6794b54fa4bf",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						}
 					],
 					"_postman_isSubFolder": true
@@ -2826,6 +2809,29 @@
 							"_postman_isSubFolder": true
 						}
 					],
+					"description": "Tests to verify basic operations with invoice lines. The invoices are used from `Invoices` tests",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "040edfaf-65d3-49da-be89-a5f39397e711",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "7cf5818f-ba3a-4bcb-98ca-a1f41b456703",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
 					"_postman_isSubFolder": true
 				},
 				{
@@ -3565,6 +3571,29 @@
 							"response": []
 						}
 					],
+					"description": "Tests to verify calculated totals of the invoice: [MODINVOICE-52](https://issues.folio.org/browse/MODINVOICE-52).",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "61adedba-139f-4efa-8528-d068d3d3126a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "01dd4754-df98-4635-94a1-6e33d23d3d63",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
 					"_postman_isSubFolder": true
 				},
 				{
@@ -3607,7 +3636,7 @@
 											"    delete voucher.metadata;",
 											"    voucher.voucherNumber = \"APITESTS\";",
 											"    ",
-											"  utils.postRequest(\"/voucher-storage/vouchers\", voucher, function(err,response){",
+											"  utils.sendPostRequest(\"/voucher-storage/vouchers\", voucher, function(err,response){",
 											"      pm.test(\"voucher is created in storage\", function(){",
 											"          pm.expect(err).to.equal(null);",
 											"          pm.environment.set(\"voucherId\", response.json().id);",
@@ -3735,6 +3764,29 @@
 							"response": []
 						}
 					],
+					"description": "Tests to verify basic operations with vouchers which are created manually",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b5769560-003e-459c-86c4-38dc723e684d",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "e0df604e-ce2e-4d39-be8f-525ac5c80359",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
 					"_postman_isSubFolder": true
 				},
 				{
@@ -3757,7 +3809,7 @@
 													"    voucherLine.voucherId = pm.environment.get(\"voucherId\");",
 													"    delete voucherLine.id;",
 													"    ",
-													"  utils.postRequest(\"/voucher-storage/voucher-lines\", voucherLine, function(err,response){",
+													"  utils.sendPostRequest(\"/voucher-storage/voucher-lines\", voucherLine, function(err,response){",
 													"      pm.test(\"voucherLine is created in storage\", function(){",
 													"          pm.expect(err).to.equal(null);",
 													"          pm.environment.set(\"voucherLineId\", response.json().id);",
@@ -3905,6 +3957,29 @@
 							"_postman_isSubFolder": true
 						}
 					],
+					"description": "Tests to verify basic operations with voucher lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "1060aa45-dd34-4730-8486-898332b79b3f",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "e799c366-94f7-48fb-9557-1f3f7acae482",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
 					"_postman_isSubFolder": true
 				},
 				{
@@ -4021,6 +4096,7 @@
 							"response": []
 						}
 					],
+					"description": "Tests to verify basic operations with voucher number configuration",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -4043,6 +4119,322 @@
 							}
 						}
 					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Workflows",
+					"item": [
+						{
+							"name": "Create Open invoices",
+							"item": [
+								{
+									"name": "Create invoice with 4 lines",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"",
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    invoice = pm.response.json();",
+													"});",
+													"",
+													"pm.test(\"Invoice content is valid\", function() {",
+													"    pm.environment.set(\"workflow-invoiceWith4LinesId\", invoice.id);",
+													"    pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
+													"",
+													"    utils.validateInvoice(invoice);",
+													"    createLines(invoice.id);",
+													"",
+													"    pm.expect(invoice.status, \"status\").to.eql(\"Open\");",
+													"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(0);",
+													"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(0);",
+													"    pm.expect(invoice.total, \"total\").to.equal(0);",
+													"",
+													"    // Verify that voucher has not been created",
+													"    utils.getVouchersForInvoice(invoice.id, (err, res) => {",
+													"        pm.test(\"No voucher created\", () => pm.expect(res.json().vouchers).to.be.empty);",
+													"    });",
+													"});",
+													"",
+													"function createLines(invoiceId) {",
+													"    pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", (err, res) => {",
+													"        let invoiceLine = utils.prepareInvoiceLine(res.json(), invoiceId);",
+													"",
+													"        // Now creating 4 invoice lines",
+													"        for (let i = 1; i < 5; i++) {",
+													"            invoiceLine.poLineId = i % 2 === 0 ? pm.globals.get(\"poLine1Id\") : pm.globals.get(\"poLine2Id\");",
+													"            invoiceLine.releaseEncumbrance = i === 4;",
+													"            ",
+													"            utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
+													"                pm.test(\"Invoice line #\" + i + \" is created in storage\", () => {",
+													"                  pm.expect(err).to.equal(null);",
+													"                  pm.expect(response).to.have.property('code', 201);",
+													"                });",
+													"            });",
+													"        }",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
+													"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
+													"",
+													"    invoice.note += \" - with 4 lines for transition through workflow\";",
+													"    invoice.status = \"Open\";",
+													"    delete invoice.adjustments;",
+													"",
+													"    pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{workflow-invoiceWith4LinesContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Transition to Approved",
+							"item": [
+								{
+									"name": "Approve invoice with 4 lines",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let invoice = JSON.parse(pm.environment.get(\"workflow-invoiceWith4LinesContent\"));",
+													"invoice.status = \"Approved\";",
+													"pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(\"No Content\");",
+													"",
+													"    // The test can be run only if update succeded",
+													"    utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"workflow-invoiceWith4LinesId\"), (err, res) => {",
+													"        pm.test(\"Invoice status updated\", function () {",
+													"            let invoice = res.json();",
+													"            pm.expect(invoice.status).to.equal(\"Approved\");",
+													"",
+													"            // Remember updated invoice",
+													"            pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
+													"",
+													"            // Verify that voucher has been created",
+													"            utils.getVouchersForInvoice(invoice.id, (err, res) => {",
+													"                pm.test(\"One voucher created\", () => {",
+													"                    pm.expect(res.json().vouchers).to.have.lengthOf(1);",
+													"                    pm.expect(res.json().vouchers[0].status).to.eql(\"Awaiting payment\");",
+													"                });",
+													"            });",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{workflow-invoiceWith4LinesContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{workflow-invoiceWith4LinesId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{workflow-invoiceWith4LinesId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Transition to Paid",
+							"item": [
+								{
+									"name": "Pay invoice with 4 lines",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let invoice = JSON.parse(pm.environment.get(\"workflow-invoiceWith4LinesContent\"));",
+													"invoice.status = \"Paid\";",
+													"pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(\"No Content\");",
+													"",
+													"    // The test can be run only if update succeded",
+													"    utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"workflow-invoiceWith4LinesId\"), (err, res) => {",
+													"        pm.test(\"Invoice status updated\", function () {",
+													"            let invoice = res.json();",
+													"            pm.expect(invoice.status).to.equal(\"Paid\");",
+													"",
+													"            // Remember updated invoice",
+													"            pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
+													"",
+													"            // Validate voucher",
+													"            utils.getVouchersForInvoice(invoice.id, (err, res) => {",
+													"                pm.test(\"Still only one voucher but already Paid\", () => {",
+													"                    pm.expect(res.json().vouchers).to.have.lengthOf(1);",
+													"                    pm.expect(res.json().vouchers[0].status).to.eql(\"Paid\");",
+													"                });",
+													"            });",
+													"",
+													"            // Validate order lines",
+													"            utils.sendGetRequest(\"/orders/composite-orders/\" + globals.completeOrderId, (err, res) => {",
+													"                pm.test(\"Associated order lines payment status updated\", function () {",
+													"                    res.json().compositePoLines.forEach(poLine => {",
+													"                        let expectedStatus = (poLine.id === globals.poLine1Id) ? \"Fully Paid\" : \"Partially Paid\";",
+													"                        pm.expect(poLine.paymentStatus).to.equal(expectedStatus);",
+													"                    });",
+													"                });",
+													"            });",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{workflow-invoiceWith4LinesContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{workflow-invoiceWith4LinesId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{workflow-invoiceWith4LinesId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"description": "This directory contains various tests related to transition of the invoices/vouchers through the workflow",
 					"_postman_isSubFolder": true
 				}
 			],
@@ -4073,198 +4465,260 @@
 			"name": "Negative Tests",
 			"item": [
 				{
-					"name": "Invoices",
+					"name": "Create invoices for negative tests",
 					"item": [
 						{
-							"name": "Create invoices for negative tests",
-							"item": [
+							"name": "Create approved invoice",
+							"event": [
 								{
-									"name": "Create approved invoice",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"let invoice = {};",
-													"",
-													"pm.test(\"Invoice is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    invoice = pm.response.json();",
-													"});",
-													"",
-													"pm.test(\"Invoice content is valid\", function() {",
-													"    pm.environment.set(\"negativeApprovedToPaidInvoice\", invoice.id);",
-													"    pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
-													"    utils.validateInvoice(invoice);",
-													"    ",
-													"});",
-													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-													"    let invoiceLine = res.json();",
-													"    invoiceLine.invoiceId = pm.environment.get(\"negativeApprovedToPaidInvoice\");",
-													"    delete invoiceLine.id;",
-													"    delete invoiceLine.metadata;",
-													"    var uuid = require('uuid');",
-													"    invoiceLine.poLineId = uuid.v4();",
-													"    ",
-													"    utils.postRequest(\"/invoice/invoice-lines\", invoiceLine, function(err,response){",
-													"        pm.test(\"Invoice line is created in storage\", function(){",
-													"          pm.expect(err).to.equal(null);",
-													"        });",
-													"    });",
-													"",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-													"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
-													"",
-													"    invoice.note += \" - transition to Paid\";",
-													"    invoice.status = \"Approved\";",
-													"",
-													"    pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"Invoice is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    invoice = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Invoice content is valid\", function() {",
+											"    pm.environment.set(\"negativeApprovedToPaidInvoice\", invoice.id);",
+											"    pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
+											"    utils.validateInvoice(invoice);",
+											"    ",
+											"});",
+											"",
+											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
+											"    let invoiceLine = res.json();",
+											"    invoiceLine.invoiceId = pm.environment.get(\"negativeApprovedToPaidInvoice\");",
+											"    invoiceLine.fundDistributions.forEach(distro => distro.fundId = pm.environment.get(\"fundId\"));",
+											"    delete invoiceLine.id;",
+											"    delete invoiceLine.metadata;",
+											"    var uuid = require('uuid');",
+											"    invoiceLine.poLineId = uuid.v4();",
+											"    ",
+											"    utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, function(err,response){",
+											"        pm.test(\"Invoice line is created in storage\", function(){",
+											"          pm.expect(err).to.equal(null);",
+											"        });",
+											"    });",
+											"",
+											"});"
 										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{negativeApprovedToPaidInvoiceContent}}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"invoice",
-												"invoices"
-											]
-										}
-									},
-									"response": []
+										"type": "text/javascript"
+									}
 								},
 								{
-									"name": "Create approved invoice with locked total",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-													"    let invoice = utils.prepareInvoice(res.json().invoices[0]);",
-													"",
-													"    invoice.lockTotal = true;",
-													"    invoice.total = 12.34;",
-													"    invoice.note += \" - locked total\";",
-													"    invoice.status = \"Open\";",
-													"",
-													"    pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "d30a0dbb-bd13-400b-9f39-687730665090",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"let invoice = {};",
-													"",
-													"pm.test(\"Invoice is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    invoice = pm.response.json();",
-													"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalId\", invoice.id);",
-													"    utils.validateInvoice(invoice);",
-													"    addLine(invoice);",
-													"});",
-													"",
-													"function addLine(invoice) {",
-													"    pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-													"        let invoiceLine = res.json();",
-													"        invoiceLine.invoiceId = invoice.id;",
-													"        delete invoiceLine.id;",
-													"    ",
-													"        utils.postRequest(\"/invoice/invoice-lines\", invoiceLine, function(err,response){",
-													"            pm.test(\"Invoice line is created in storage\", function(){",
-													"              pm.expect(err).to.equal(null);",
-													"              pm.expect(response).to.have.property('code', 201);",
-													"              utils.updateInvoiceStatus(invoice, \"Approved\");",
-													"            });",
-													"        });",
-													"    });",
-													"}"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
+											"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
+											"",
+											"    invoice.note += \" - transition to Paid\";",
+											"    invoice.status = \"Approved\";",
+											"",
+											"    pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
+											"});"
 										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{invoiceContentLockedTotal}}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"invoice",
-												"invoices"
-											]
-										}
-									},
-									"response": []
+										"type": "text/javascript"
+									}
 								}
 							],
-							"_postman_isSubFolder": true
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{negativeApprovedToPaidInvoiceContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									]
+								}
+							},
+							"response": []
 						},
+						{
+							"name": "Create approved invoice with locked total",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
+											"    let invoice = utils.prepareInvoice(res.json().invoices[0]);",
+											"",
+											"    invoice.lockTotal = true;",
+											"    invoice.total = 12.34;",
+											"    invoice.note += \" - locked total\";",
+											"    invoice.status = \"Open\";",
+											"",
+											"    pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d30a0dbb-bd13-400b-9f39-687730665090",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"Invoice is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    invoice = pm.response.json();",
+											"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalId\", invoice.id);",
+											"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalContent\", JSON.stringify(invoice));",
+											"    utils.validateInvoice(invoice);",
+											"    addLine(invoice);",
+											"});",
+											"",
+											"function addLine(invoice) {",
+											"    pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
+											"        let invoiceLine = utils.prepareInvoiceLine(res.json(), invoice.id);",
+											"        invoiceLine.poLineId = pm.globals.get(\"poLine1Id\");",
+											"",
+											"        utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, function(err,response){",
+											"            pm.test(\"Invoice line is created in storage\", function(){",
+											"              pm.expect(err).to.equal(null);",
+											"              pm.expect(response).to.have.property('code', 201);",
+											"              utils.updateInvoiceStatus(invoice, \"Approved\");",
+											"            });",
+											"        });",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{invoiceContentLockedTotal}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice with locked total and delete voucher",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d30a0dbb-bd13-400b-9f39-687730665090",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"Invoice is Approved\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    invoice = pm.response.json();",
+											"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalContent\", JSON.stringify(invoice));",
+											"    pm.expect(invoice).to.have.property('status', \"Approved\");",
+											"    utils.deleteVouchersForInvoice(invoice.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativeApprovedInvoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{negativeApprovedInvoiceWithLockedTotalId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Invoices",
+					"item": [
 						{
 							"name": "Protected Fields Modification",
 							"item": [
@@ -6645,7 +7099,7 @@
 										"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"let line = utils.buildVoucherLineWithMinContent(pm.environment.get(\"voucherLineId\"));",
+											"let line = utils.buildVoucherLineWithMinContent();",
 											"line.id = \"bad-id\";",
 											"pm.variables.set(\"line_body\", JSON.stringify(line));"
 										],
@@ -6891,6 +7345,100 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Workflows",
+					"item": [
+						{
+							"name": "Transition to Paid",
+							"item": [
+								{
+									"name": "Pay invoice with locked total (no voucher)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let invoice = JSON.parse(pm.environment.get(\"negativeApprovedInvoiceWithLockedTotalContent\"));",
+													"invoice.status = \"Paid\";",
+													"pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalContent\", JSON.stringify(invoice));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Error expected: voucher is not available\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    pm.expect(pm.response.json().errors[0]).to.have.property(\"code\", \"voucherNotFound\");",
+													"",
+													"    // The test can be run only if update succeded",
+													"    utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativeApprovedInvoiceWithLockedTotalId\"), (err, res) => {",
+													"        pm.test(\"Invoice status updated\", function () {",
+													"            let invoice = res.json();",
+													"            pm.expect(invoice.status).to.equal(\"Approved\");",
+													"",
+													"            // Validate voucher",
+													"            utils.getVouchersForInvoice(invoice.id, (err, res) => {",
+													"                pm.test(\"Still no voucher\", () => pm.expect(res.json().vouchers).to.be.empty);",
+													"            });",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{negativeApprovedInvoiceWithLockedTotalContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativeApprovedInvoiceWithLockedTotalId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativeApprovedInvoiceWithLockedTotalId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			]
 		},
@@ -6931,11 +7479,7 @@
 								"header": [
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -7017,11 +7561,7 @@
 								"header": [
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -7084,10 +7624,6 @@
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
 									}
 								],
 								"body": {
@@ -7165,7 +7701,7 @@
 							"response": []
 						},
 						{
-							"name": "Delete Approved to Paid invoice",
+							"name": "Delete invoice with 4 lines",
 							"event": [
 								{
 									"listen": "test",
@@ -7174,6 +7710,8 @@
 										"exec": [
 											"pm.test(\"Invoice is deleted\", function () {",
 											"    pm.response.to.have.status(204);",
+											"    pm.environment.unset(\"workflow-invoiceWith4LinesId\");",
+											"    pm.environment.unset(\"workflow-invoiceWith4LinesContent\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -7184,7 +7722,7 @@
 									"script": {
 										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
 										"exec": [
-											""
+											"eval(globals.loadUtils).deleteVouchersForInvoice(pm.variables.get(\"workflow-invoiceWith4LinesId\"));"
 										],
 										"type": "text/javascript"
 									}
@@ -7203,7 +7741,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{approvedToPaidInvoice}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{workflow-invoiceWith4LinesId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -7212,7 +7750,7 @@
 									"path": [
 										"invoice",
 										"invoices",
-										"{{approvedToPaidInvoice}}"
+										"{{workflow-invoiceWith4LinesId}}"
 									]
 								}
 							},
@@ -7364,6 +7902,8 @@
 										"exec": [
 											"pm.test(\"Invoice line is deleted\", function () {",
 											"    pm.response.to.have.status(204);",
+											"    pm.environment.unset(\"negativeApprovedInvoiceWithLockedTotalId\");",
+											"    pm.environment.unset(\"negativeApprovedInvoiceWithLockedTotalContent\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -7491,55 +8031,6 @@
 					"name": "Delete user with mod-invoice permissions only",
 					"item": [
 						{
-							"name": "Login by admin to delete test user",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-										"exec": [
-											"pm.test(\"Status code is 201\", function () {",
-											"    pm.response.to.have.status(201);",
-											"});",
-											"",
-											"pm.environment.set(\"xokapitoken\", postman.getResponseHeader(\"x-okapi-token\"));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "x-okapi-tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{  \r\n   \"username\":\"{{username}}\",\r\n   \"password\":\"{{password}}\"\r\n}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"authn",
-										"login"
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "Delete user's credentials",
 							"event": [
 								{
@@ -7578,7 +8069,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -7640,7 +8131,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -7693,19 +8184,9 @@
 								"method": "DELETE",
 								"header": [
 									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "X-Okapi-Token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -7795,7 +8276,7 @@
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"url": {
@@ -7849,7 +8330,7 @@
 					"name": "Delete orders",
 					"item": [
 						{
-							"name": "Delete Pending order",
+							"name": "Delete order with 2 lines",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -7868,6 +8349,9 @@
 										"exec": [
 											"pm.test(\"Order has been successfully deleted\", function () {",
 											"    pm.response.to.have.status(204);",
+											"    pm.globals.unset(\"completeOrderId\"); ",
+											"    pm.globals.unset(\"poLine1Id\");",
+											"    pm.globals.unset(\"poLine2Id\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -7887,7 +8371,7 @@
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"body": {
@@ -7908,6 +8392,122 @@
 									]
 								},
 								"description": "GET /orders/composite-orders/id requests that return 204"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Finance data",
+					"item": [
+						{
+							"name": "Delete fund",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Test fund deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.environment.unset(\"fundId\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds/{{fundId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"funds",
+										"{{fundId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete ledger",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Test ledger deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.environment.unset(\"ledgerId\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers/{{ledgerId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"ledgers",
+										"{{ledgerId}}"
+									]
+								}
 							},
 							"response": []
 						}
@@ -7973,7 +8573,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"url": {
@@ -8053,7 +8653,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}"
 									}
 								],
 								"url": {
@@ -8130,7 +8730,7 @@
 					"    },",
 					"    permissions: {",
 					"        \"userId\": \"00000000-1111-5555-9999-999999999999\",",
-					"        \"permissions\": [\"invoice.all\",\"voucher-storage.vouchers.item.post\",\"voucher-storage.vouchers.item.delete\", \"voucher-storage.voucher-lines.item.post\", \"voucher-storage.voucher-lines.item.put\", \"voucher-storage.voucher-lines.item.delete\", \"voucher-storage.voucher-lines.collection.get\", \"voucher-storage.vouchers.collection.get\"]",
+					"        \"permissions\": [\"invoice.all\"]",
 					"    }",
 					"};",
 					"",
@@ -8153,6 +8753,17 @@
 					"        return invoice;",
 					"    };",
 					"",
+					"    utils.prepareInvoiceLine = function(invoiceLine, invoiceId) {",
+					"        invoiceLine.invoiceId = invoiceId;",
+					"",
+					"        delete invoiceLine.id;",
+					"        delete invoiceLine.metadata;",
+					"",
+					"        invoiceLine.fundDistributions.forEach(distro => distro.fundId = pm.environment.get(\"fundId\"));",
+					"",
+					"        return invoiceLine;",
+					"    };",
+					"",
 					"    utils.copyJsonObj = function(obj) {",
 					"        return JSON.parse(JSON.stringify(obj));",
 					"    };",
@@ -8163,55 +8774,44 @@
 					"    utils.buildOkapiUrl = function(path) {",
 					"        return pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + path;",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Validates sequence number against schema",
 					"     */",
 					"    utils.validateSequenceNumber = function(jsonData) {",
 					"        utils._validateAgainstSchema(jsonData, utils.getSchema(\"sequence_number.json\"));",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Gets schema as json object",
 					"     */",
 					"    utils.getSchema = function(name) {",
 					"        return JSON.parse(pm.environment.get(utils.schemaPrefix + name));",
 					"    };",
-					"    ",
+					"",
 					"",
 					"    /**",
 					"     * Sends delete request based on specified path.",
 					"     * The Promise is returned as a result of the operation holding the http code of the response once completed.",
 					"     */",
 					"    utils.processDeleteRequest = function(path) {",
-					"        return new Promise((resolve) => {",
-					"            pm.sendRequest({",
-					"                url: utils.buildOkapiUrl(path),",
-					"                method: \"DELETE\",",
-					"                header: {",
-					"                    \"X-Okapi-Tenant\": pm.variables.get(\"xokapitenant\"),",
-					"                    \"X-Okapi-Token\": pm.variables.get(\"xokapitoken\")",
-					"                }",
-					"            }, function(err, response) {",
-					"                resolve(response.code);",
-					"            });",
-					"        });",
+					"        return new Promise((resolve) => utils.sendDeleteRequest(path, (err, res) => resolve(res.code)));",
 					"    };",
-					"    ",
-					"     /**",
+					"",
+					"    /**",
 					"     * Updates PO json removing ids and updating PO lines.",
 					"     */",
 					"    utils.prepareOrder = function(order) {",
 					"        delete order.id;",
 					"        delete order.totalItems;",
-					"  ",
+					"",
 					"        for (var i = 0; i < order.compositePoLines.length; i++) {",
 					"            utils.preparePoLine(order.compositePoLines[i]);",
 					"        }",
 					"",
 					"        return order;",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Updates sub-objects of the PO Line removing ids and adding missing data.",
 					"     */",
@@ -8227,7 +8827,7 @@
 					"    /**",
 					"     * Adds Invoice line id to `completeInvoicelineIds` array and stores as global variable.",
 					"     */",
-					"     utils.rememberInvoiceLineId = function(invoiceLine) {",
+					"    utils.rememberInvoiceLineId = function(invoiceLine) {",
 					"        if (invoiceLine && invoiceLine.id) {",
 					"            let completeInvoicelineIds = pm.environment.get(\"completeInvoicelineIds\") ? JSON.parse(pm.environment.get(\"completeInvoicelineIds\")) : [];",
 					"            completeInvoicelineIds.push(invoiceLine.id);",
@@ -8251,10 +8851,10 @@
 					"        }",
 					"        return null;",
 					"    };",
-					"    ",
-					"     /**",
+					"",
+					"    /**",
 					"     * Validates the Invoice line is empty except line and order ids",
-					"    */",
+					"     */",
 					"    utils.validateInvoiceLineWithMinimalContent = function(invoiceLine) {",
 					"        let expectedLine = utils.buildInvoiceLineWithMinContent();",
 					"",
@@ -8289,16 +8889,16 @@
 					"        pm.expect(invoiceLine.total, \"Invoice line: total expected\").to.exist;",
 					"        pm.expect(invoiceLine.vendorRefNo, \"Invoice line: vendorRefNo not expected\").to.not.exist;",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Build Invoice line with minimal required fields.",
-					"    */",
+					"     */",
 					"    utils.buildInvoiceLineWithMinContent = function(invoiceId) {",
 					"        return {",
 					"            \"description\": \"Some description\",",
 					"            \"fundDistributions\": [",
 					"                {",
-					"                    \"fundId\": \"1d1574f1-9196-4a57-8d1f-3b2e4309eb81\",",
+					"                    \"fundId\": pm.environment.get(\"fundId\"),",
 					"                    \"percentage\": 50",
 					"                }",
 					"            ],",
@@ -8309,40 +8909,94 @@
 					"            \"releaseEncumbrance\": false",
 					"        };",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Build Voucher line with minimal required fields.",
-					"    */",
-					"    utils.buildVoucherLineWithMinContent = function(voucherLineId) {",
+					"     */",
+					"    utils.buildVoucherLineWithMinContent = function() {",
 					"        return {",
-					"            \"id\": voucherLineId,",
+					"            \"amount\": 33.55,",
 					"            \"externalAccountNumber\": \"54321099\",",
-					"            \"voucherLineAmount\": 33.55,",
-					"            \"sourceId\": \"0726fc17-38c3-4249-81d3-97ffddada92b\",",
-					"            \"fundId\": \"f951ec3a-19a0-42ea-85d1-ae987caf5e4d\",",
-					"            \"fundDistributions\": \"9c28ec73-ea09-47e2-b12f-5c7ef98c7a9f\",",
-					"            \"subTransactionId\": \"d384a4c2-9f85-4072-a305-800b3f6f5143\"",
+					"            \"fundDistributions\": [",
+					"                {",
+					"                    \"fundId\": pm.environment.get(\"fundId\"),",
+					"                    \"percentage\": 50",
+					"                }",
+					"            ],",
+					"            \"sourceIds\": [\"0726fc17-38c3-4249-81d3-97ffddada92b\"],",
+					"            \"voucherId\": \"d384a4c2-9f85-4072-a305-800b3f6f5143\"",
 					"        };",
 					"    };",
-					"    ",
+					"",
 					"    utils.buildAdjustmentObject = function(amount, type){",
 					"        return {",
-					"             \"description\":\"adjustment API test\",",
-					"             \"type\": type || \"Amount\",",
-					"             \"value\": amount || 10,",
-					"             \"prorate\":\"Not prorated\",",
-					"             \"relationToTotal\":\"In addition to\"",
+					"            \"description\":\"adjustment API test\",",
+					"            \"type\": type || \"Amount\",",
+					"            \"value\": amount || 10,",
+					"            \"prorate\":\"Not prorated\",",
+					"            \"relationToTotal\":\"In addition to\"",
 					"        };",
 					"    };",
 					"",
 					"    utils.updateInvoiceStatus = function(invoice, status) {",
 					"        invoice.status = status;",
-					"        utils.putRequest(\"/invoice/invoices/\" + invoice.id, invoice, (err,response) => {",
+					"        utils.sendPutRequest(\"/invoice/invoices/\" + invoice.id, invoice, (err,response) => {",
 					"            pm.test(\"Invoice is now \" + status, () => {",
-					"              pm.expect(err).to.equal(null);",
-					"              pm.expect(response).to.have.property('code', 204);",
+					"                pm.expect(err).to.equal(null);",
+					"                pm.expect(response).to.have.property('code', 204);",
 					"            });",
 					"        });",
+					"    };",
+					"",
+					"",
+					"    utils.deleteVouchersForInvoice = function(invoiceId) {",
+					"        utils.getVouchersForInvoice(invoiceId, (err, res) => {",
+					"            utils.deleteVouchers(res.json().vouchers);",
+					"        });",
+					"    };",
+					"",
+					"    utils.deleteVouchers = function(vouchers) {",
+					"        if (vouchers.length !== 0) {",
+					"            const timerId = setTimeout(() => {}, 60000);",
+					"    ",
+					"            let promises = vouchers.map(voucher => utils.deleteVoucherLines(voucher.id).then(ok => utils.deleteVoucher(voucher.id)));",
+					"    ",
+					"            Promise.all(promises)",
+					"                .then(result => clearTimeout(timerId))",
+					"                .catch(err => {",
+					"                    console.log(\"Error happened on voucher record(s) deletion:\", err);",
+					"                    clearTimeout(timerId);",
+					"                });",
+					"        }",
+					"    };",
+					"",
+					"    utils.deleteVoucher = function(voucherId) {",
+					"        return utils.processDeleteRequest(\"/voucher-storage/vouchers/\" + voucherId);",
+					"    };",
+					"",
+					"    utils.deleteVoucherLines = function(voucherId) {",
+					"        return new Promise((resolve) => {",
+					"            utils.getVoucherLines(voucherId, (err, res) => {",
+					"                let promises = [];",
+					"                res.json().voucherLines.forEach(line => {",
+					"                    promises.push(utils.processDeleteRequest(\"/voucher-storage/voucher-lines/\" + line.id));",
+					"                });",
+					"                Promise.all(promises)",
+					"                    .then(ok => resolve())",
+					"                    .catch(err => {",
+					"                        console.log(\"Error happened on voucher line record(s) deletion:\", err);",
+					"                        resolve();",
+					"                    });",
+					"            });",
+					"        });",
+					"    };",
+					"",
+					"    utils.getVouchersForInvoice = function(invoiceId, handler) {",
+					"        utils.sendGetRequest(\"/voucher-storage/vouchers?query=invoiceId==\" + invoiceId, handler);",
+					"    };",
+					"",
+					"    utils.getVoucherLines = function(voucherId, handler) {",
+					"        utils.sendGetRequest(\"/voucher-storage/voucher-lines?query=voucherId==\" + voucherId, handler);",
 					"    };",
 					"",
 					"    /**",
@@ -8361,19 +9015,8 @@
 					"    };",
 					"",
 					"    utils.createConfig = function(body) {",
-					"        pm.sendRequest({",
-					"            url: utils.buildOkapiUrl(\"/configurations/entries\"),",
-					"            method: \"POST\",",
-					"            header: {",
-					"                \"X-Okapi-Token\": pm.variables.get(\"xokapitoken\"),",
-					"                \"Content-type\": \"application/json\",",
-					"                \"Accept-Encoding\": \"identity\"",
-					"            },",
-					"            body: JSON.stringify(body)",
-					"        }, function(err, response) {",
-					"            pm.test(\"Config created\", function() {",
-					"                pm.expect(response.code).to.eql(201);",
-					"            });",
+					"        utils.sendPostRequest(\"/configurations/entries\", body, (err, res) => {",
+					"            pm.test(\"Config created\", () => pm.expect(res.code).to.eql(201));",
 					"        });",
 					"    };",
 					"",
@@ -8381,8 +9024,8 @@
 					"     * @param body with updated data",
 					"     */",
 					"    utils.updateConfig = function(body) {",
-					"        utils.putRequest(\"/configurations/entries/\" + body.id, body, (err, response) => {",
-					"            pm.test(\"Config updated. Config name = \" + body.configName, function() {",
+					"        utils.sendPutRequest(\"/configurations/entries/\" + body.id, body, (err, response) => {",
+					"            pm.test(\"Config updated. Config name = \" + body.configName, () => {",
 					"                pm.expect(response.code).to.eql(204);",
 					"            });",
 					"        });",
@@ -8398,7 +9041,7 @@
 					"                clearTimeout(timerId);",
 					"            });",
 					"    };",
-					"    ",
+					"",
 					"    utils.deleteRecord = function(path) {",
 					"        const timerId = setTimeout(() => {}, 60000);",
 					"        utils.processDeleteRequest(path)",
@@ -8415,33 +9058,14 @@
 					"     * Sends GET request and uses passed handler to handle result",
 					"     */",
 					"    utils.sendGetRequest = function(path, handler) {",
-					"        pm.sendRequest({",
-					"                url: utils.buildOkapiUrl(path),",
-					"                method: \"GET\",",
-					"                header: {",
-					"                    \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-					"                    \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\")",
-					"                }",
-					"            },",
-					"            handler",
-					"        );",
+					"        pm.sendRequest(utils.buildPmRequest(path, \"GET\"), handler);",
 					"    };",
 					"",
 					"    /**",
 					"     * Sends DELETE request and uses passed handler to handle result",
 					"     */",
 					"    utils.sendDeleteRequest = function(path, handler) {",
-					"        pm.sendRequest(",
-					"            {",
-					"                url: utils.buildOkapiUrl(path),",
-					"                method: \"DELETE\",",
-					"                header: {",
-					"                    \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-					"                    \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\")",
-					"                }",
-					"            },",
-					"            handler",
-					"        );",
+					"        pm.sendRequest(utils.buildPmRequest(path, \"DELETE\"), handler);",
 					"    };",
 					"",
 					"    /**",
@@ -8459,20 +9083,17 @@
 					"        pm.environment.unset(\"minInvoiceId\");",
 					"        pm.environment.unset(\"completeInvoicelineIds\");",
 					"        pm.environment.unset(\"xokapitoken\");",
+					"        pm.environment.unset(\"xokapitoken-admin\");",
 					"        pm.environment.unset(\"mod-invoices-configs\");",
 					"        pm.environment.unset(\"voucherId\");",
 					"        pm.environment.unset(\"voucherLineId\");",
 					"        pm.environment.unset(\"negativeApprovedToPaidInvoice\");",
-					"        pm.environment.unset(\"approvedToPaidInvoice\");",
 					"        pm.environment.unset(\"mod-orders-configs\");",
 					"        pm.environment.unset(\"current-orders-configs\");",
 					"        pm.environment.unset(\"negativeAdjInLineId\");",
 					"        pm.environment.unset(\"negativeInvoiceLineContent\");",
 					"",
 					"        pm.globals.unset(\"testData\");",
-					"        pm.globals.unset(\"completeOrderId\");",
-					"        pm.globals.unset(\"poLine2Id\");",
-					"        pm.globals.unset(\"poLine1Id\");",
 					"        pm.globals.unset(\"loadUtils\");",
 					"",
 					"    };",
@@ -8511,7 +9132,7 @@
 					"    utils.getInvoiceLineSchema = function() {",
 					"        return JSON.parse(pm.environment.get(utils.schemaPrefix + \"invoice_line.json\"));",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Validates voucher against schema",
 					"     */",
@@ -8540,14 +9161,14 @@
 					"    utils.validateSequenceNumber = function(jsonData) {",
 					"        utils._validateAgainstSchema(jsonData, utils.getSchema(\"sequence_number.json\"));",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Gets schema as json object",
 					"     */",
 					"    utils.getSchema = function(name) {",
 					"        return JSON.parse(pm.environment.get(utils.schemaPrefix + name));",
 					"    };",
-					"    ",
+					"",
 					"    /**",
 					"     * Internal function to load schema defenitions to tv4",
 					"     */",
@@ -8567,7 +9188,7 @@
 					"            method: method,",
 					"            header: {",
 					"                \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\")",
+					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken-admin\")",
 					"            }",
 					"        };",
 					"    };",
@@ -8645,27 +9266,19 @@
 					"            data.forEach(obj => delete obj.id);",
 					"        }",
 					"    };",
-					"    ",
-					"    utils.postRequest = function (path, postBody, handler) {",
-					"        pm.sendRequest({",
-					"            url: utils.buildOkapiUrl(path),",
-					"            method: 'POST',",
-					"            header: {",
-					"                \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\"),",
-					"                \"Content-type\": \"application/json\"",
-					"            },",
-					"            body: {",
-					"                mode: 'raw',",
-					"                raw: JSON.stringify(postBody)",
-					"            }",
-					"        }, handler);",
+					"",
+					"    utils.sendPostRequest = function (path, body, handler) {",
+					"        let pmRq = utils.buildPmRequest(path, \"POST\");",
+					"        pmRq.header[\"Content-type\"] = \"application/json\";",
+					"        pmRq.body = JSON.stringify(body);",
+					"",
+					"        pm.sendRequest(pmRq, handler);",
 					"    };",
 					"",
 					"    /**",
 					"     * Sends PUT request and uses passed handler to handle result",
 					"     */",
-					"    utils.putRequest = function(path, body, handler) {",
+					"    utils.sendPutRequest = function(path, body, handler) {",
 					"        // Build request and add required header and body",
 					"        let pmRq = utils.buildPmRequest(path, \"PUT\");",
 					"        pmRq.header[\"Content-type\"] = \"application/json\";",
@@ -8708,6 +9321,18 @@
 			"id": "9716da39-44a1-47c5-8df9-9daa760c7782",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
+			"type": "string"
+		},
+		{
+			"id": "6f649c69-fe4a-411b-bf5e-42dd5b72484b",
+			"key": "finance-ledgerCode",
+			"value": "invoicingApiTests",
+			"type": "string"
+		},
+		{
+			"id": "7af0f78a-6166-498f-ba31-55cf20fa4c10",
+			"key": "finance-fundCode",
+			"value": "invoicingApiTests",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
- Adding requests to create testing ledger and fund (required for fund distributions)
- Moving tests related to workflow transition to separate directory (Workflows)
- Adding positive and negative tests to verify voucher status on invoice transition to Paid
- Separate test requests which can be made by user with invoicing permissions only and admin by different token variables
- Reducing number of tests for schemas (only one now checks if schemas loaded or any failed instead of per each schema)

Requests structure:
![image](https://user-images.githubusercontent.com/43410167/60176771-f4cd1580-981f-11e9-9ce6-a1fad1cd53fa.png)

Positive tests:
![image](https://user-images.githubusercontent.com/43410167/60176581-69ec1b00-981f-11e9-8a76-769af1c176f5.png)

Negative test:
![image](https://user-images.githubusercontent.com/43410167/60176594-77a1a080-981f-11e9-817a-cb6b282cccb0.png)
