### PR TITLE
MODORDERS-250 - Implement basic CRUD for /acquisitions-units/memberships

### DIFF
--- a/mod-orders/acquisitions-units.postman_collection.json
+++ b/mod-orders/acquisitions-units.postman_collection.json
@@ -823,6 +823,394 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Memberships",
+					"item": [
+						{
+							"name": "Create membership",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = {};",
+											"",
+											"body.userId = globals.testData.user.id;",
+											"body.acquisitionsUnitId = pm.environment.get(\"unit1Id\");",
+											"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"",
+											"    pm.test(\"Verify membership\", () => {",
+											"        // Id is presented",
+											"        pm.expect(jsonData.id).to.exist;",
+											"        // Metadata is presented",
+											"        pm.expect(jsonData.metadata).to.exist;",
+											"        // MembershipId is the same",
+											"        pm.environment.set(\"membershipId\", jsonData.id);",
+											"        ",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{membershipBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get created membership",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"",
+											"    pm.test(\"Verify membership has correct values\", () => {",
+											"    ",
+											"        // Verify that metadata is presented",
+											"        pm.expect(jsonData.metadata).to.exist;",
+											"        ",
+											"        // Verify if id exists",
+											"        pm.expect(jsonData.id).to.exist;",
+											"",
+											"        // Verify ",
+											"        let userId = globals.testData.user.id;",
+											"        pm.expect(jsonData.userId).to.eql(userId);",
+											"        ",
+											"        // Verify acquisitionsUnitId == unitId ",
+											"        let acquisitionsUnitId = pm.environment.get(\"unit1Id\");",
+											"        pm.expect(jsonData.acquisitionsUnitId).to.eql(acquisitionsUnitId);",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{membershipId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships",
+										"{{membershipId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get created membership by acquisitionsUnitId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "0b40992e-c024-4a88-82d3-e8646f49f5ae",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    var jsonData = pm.response.json();",
+											"",
+											"    pm.test(\"Verify unit\", () => {",
+											"        pm.expect(jsonData.totalRecords).to.eql(1);",
+											"        pm.expect(jsonData.acquisitionsUnitMemberships).to.have.lengthOf(1);",
+											"        ",
+											"        let membership = jsonData.acquisitionsUnitMemberships[0];",
+											"",
+											"        // Verify that metadata is presented",
+											"        pm.expect(membership.metadata).to.exist;",
+											"        ",
+											"        // Verify if id exists",
+											"        pm.expect(membership.id).to.exist;",
+											"",
+											"        // Verify ",
+											"        let userId = globals.testData.user.id;",
+											"        pm.expect(membership.userId).to.eql(userId);",
+											"        ",
+											"        // Verify acquisitionsUnitId == unitId ",
+											"        let acquisitionsUnitId = pm.environment.get(\"unit1Id\");",
+											"        pm.expect(membership.acquisitionsUnitId).to.eql(acquisitionsUnitId);",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "1e05adb9-0839-419e-b220-db821a3ff022",
+										"exec": [
+											"pm.variables.set(\"acqName\", globals.testData.unit.name);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships?query=acquisitionsUnitId={{unit1Id}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "acquisitionsUnitId={{unit1Id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update membership",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = {};",
+											"",
+											"body.userId = globals.testData.user.id;",
+											"body.acquisitionsUnitId = pm.environment.get(\"unit2Id\");",
+											"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{membershipBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{membershipId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships",
+										"{{membershipId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get updated membership",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"",
+											"    pm.test(\"Verify membership has correct values\", () => {",
+											"        ",
+											"        // Verify that metadata is presented",
+											"        pm.expect(jsonData.metadata).to.exist;",
+											"        ",
+											"        // Verify if id exists",
+											"        pm.expect(jsonData.id).to.exist;",
+											"",
+											"        // Verify ",
+											"        let userId = globals.testData.user.id;",
+											"        pm.expect(jsonData.userId).to.eql(userId);",
+											"        ",
+											"        // Verify acquisitionsUnitId == unitId ",
+											"        let acquisitionsUnitId = pm.environment.get(\"unit2Id\");",
+											"        pm.expect(jsonData.acquisitionsUnitId).to.eql(acquisitionsUnitId);",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{membershipId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships",
+										"{{membershipId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -1056,12 +1444,218 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Memberships",
+					"item": [
+						{
+							"name": "Create membership without acquisitionsUnitId",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = {};",
+											"",
+											"body.userId = globals.testData.user.id;",
+											"",
+											"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 422\", function () {",
+											"    pm.response.to.have.status(422);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{membershipBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update membership removing acquisitionUnitId",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = {};",
+											"",
+											"body.userId = globals.testData.user.id;",
+											"",
+											"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 422\", function () {",
+											"    pm.response.to.have.status(422);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{membershipBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{membershipId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships",
+										"{{membershipId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			]
 		},
 		{
 			"name": "Cleanup",
 			"item": [
+				{
+					"name": "Delete memberships",
+					"item": [
+						{
+							"name": "Delete membership",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.environment.unset(\"membershipId\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{membershipId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships",
+										"{{membershipId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
 				{
 					"name": "Delete units",
 					"item": [
@@ -1438,7 +2032,7 @@
 					"    },",
 					"    permissions: {",
 					"        \"userId\": \"00010001-1111-5555-9999-999999999999\",",
-					"        \"permissions\": [\"acquisitions-units.units.all\"]",
+					"        \"permissions\": [\"acquisitions-units.units.all\", \"acquisitions-units.memberships.all\"]",
 					"    }",
 					"};",
 					"",


### PR DESCRIPTION
[MODORDERS-250](https://issues.folio.org/browse/MODORDERS-250) - Implement basic CRUD for /acquisitions-units/memberships

API tests form CRUD memberships.
![memberships-tree](https://user-images.githubusercontent.com/42964285/60343558-eb2ce480-99bc-11e9-9775-cdd7fb3f1339.png)

Verified on localhost:
![memberships-api](https://user-images.githubusercontent.com/42964285/60343550-e9632100-99bc-11e9-8cd6-f07f2ec87a28.png)

