### PR TITLE
MODORDER-173 - API test to ensure receiptStatus consistency between piece and poLine

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -10805,6 +10805,283 @@
 								}
 							],
 							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Tags",
+							"item": [
+								{
+									"name": "Positive",
+									"item": [
+										{
+											"name": "update package tags",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "cfd8e1ba-9886-4d30-86d1-283899a48f28",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 200",
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageTags\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in response object', function() {",
+															"    pm.expect(response.data).to.include.all.keys(\"type\", \"attributes\");",
+															"});",
+															"",
+															"//Test that type is tags",
+															"pm.test('type is tags', function(){",
+															"    pm.expect(response.data.type).eq('tags');",
+															"});",
+															"    ",
+															"//Test that data.attributes has expected attributes",
+															"pm.test('expected data.attributes are present', function() {",
+															"    pm.expect(response.data.attributes).to.be.an('object');",
+															"    pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"name\", \"tags\");",
+															"});",
+															"",
+															"//Test that name matches name provided in request",
+															"pm.test('name matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.name).to.eq('custom-packages-' + pm.globals.get(\"custom-package-one-uuid\"));",
+															"});",
+															"",
+															"//Test that contentType matches as provided in request",
+															"pm.test('contentType matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.contentType).eq('Print');",
+															"});",
+															"",
+															"//Check that tagList contains correct tags",
+															"pm.test('Existing tags', function(){",
+															"    pm.expect(response.data.attributes.tags.tagList.size) === 2;",
+															"    pm.expect(response.data.attributes.tags.tagList[0]).eq(\"foo-tag\");",
+															"    pm.expect(response.data.attributes.tags.tagList[1]).eq(\"another-tag\");",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"tags\",\n    \"attributes\": {\n      \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n      \"contentType\": \"Print\",\n      \"tags\": {\n    \t\t\"tagList\": [\n    \t\t\"foo-tag\",\n    \t\t\"another-tag\"\n\t\t\t]\n\t\t}\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}/tags",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}",
+														"tags"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								},
+								{
+									"name": "Negative",
+									"item": [
+										{
+											"name": "update package tags without name",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "cfd8e1ba-9886-4d30-86d1-283899a48f28",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Invalid name');",
+															"        pm.expect(response.errors[0].detail).to.eq('name must not be empty');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"tags\",\n    \"attributes\": {\n      \"name\": \"\",\n      \"contentType\": \"Print\",\n      \"tags\": {\n    \t\t\"tagList\": [\n    \t\t\"foo-tag\",\n    \t\t\"another-tag\"\n\t\t\t]\n\t\t}\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}/tags",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}",
+														"tags"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "update package tags without contentType",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "1257c13b-620f-4ee0-a1d3-e90bc6acba18",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.eq('Invalid contentType');",
+															"        pm.expect(response.errors[0].detail).to.eq('contentType must not be null');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"data\": {\n    \"type\": \"tags\",\n    \"attributes\": {\n      \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n      \"contentType\": null,\n      \"tags\": {\n    \t\t\"tagList\": [\n    \t\t\"foo-tag\",\n    \t\t\"another-tag\"\n\t\t\t]\n\t\t}\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}/tags",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{custom-package-id-created-in-post}}",
+														"tags"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"_postman_isSubFolder": true
+								}
+							],
+							"_postman_isSubFolder": true
 						}
 					],
 					"_postman_isSubFolder": true
@@ -11118,6 +11395,8 @@
 						"exec": [
 							"tv4.addSchema(\"schema_packageCollectionItem.json\", JSON.parse(pm.variables.get(\"schema_packageCollectionItem\")));",
 							"tv4.addSchema(\"schema_packageDataAttributes.json\", JSON.parse(pm.variables.get(\"schema_packageDataAttributes\")));",
+							"tv4.addSchema(\"schema_packageTagsItem.json\", JSON.parse(pm.variables.get(\"schema_packageTagsItem\")));",
+							"tv4.addSchema(\"schema_packageTagsDataAttributes.json\", JSON.parse(pm.variables.get(\"schema_packageTagsDataAttributes\")));",
 							"tv4.addSchema(\"schema_contentTypeEnum.json\", JSON.parse(pm.variables.get(\"schema_contentTypeEnum\")));",
 							"tv4.addSchema(\"schema_coverage.json\", JSON.parse(pm.variables.get(\"schema_coverage\")));",
 							"tv4.addSchema(\"schema_visibilityData.json\", JSON.parse(pm.variables.get(\"schema_visibilityData\")));",

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ffc2be7f-dfc3-440b-ba22-0d77b433e42b",
+		"_postman_id": "e2cddc08-7ba1-4fb8-b5d4-5bfee384b4a3",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -5004,6 +5004,723 @@
 									]
 								},
 								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Pieces event handling",
+					"item": [
+						{
+							"name": "Create 1st Piece",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.globals.set(\"poLineId\", utils.getLastPoLineId());",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
+											"    let piece = res.json();",
+											"    piece.poLineId = pm.variables.get(\"poLineId\");",
+											"    pm.globals.set(\"pieceRecord\", JSON.stringify(piece));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											"jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.globals.set(\"pieceId1ToUpdate\", jsonData.id);",
+											"    utils.validatePiece(jsonData);",
+											"});",
+											"",
+											"pm.test(\"Each piece has these optional fields\", function() {",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.expect(jsonData.caption).to.exist;",
+											"    pm.expect(jsonData.comment).to.exist;",
+											"    pm.expect(jsonData.itemId).to.exist;",
+											"    pm.expect(jsonData.locationId).to.exist;",
+											"    pm.expect(jsonData.supplement).to.exist;",
+											"    pm.expect(jsonData.receivedDate).to.exist;",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{pieceRecord}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces"
+									]
+								},
+								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
+							},
+							"response": []
+						},
+						{
+							"name": "Create 2nd Piece",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											"jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.globals.set(\"pieceId2ToUpdate\", jsonData.id);",
+											"    utils.validatePiece(jsonData);",
+											"});",
+											"",
+											"pm.test(\"Each piece has these optional fields\", function() {",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.expect(jsonData.caption).to.exist;",
+											"    pm.expect(jsonData.comment).to.exist;",
+											"    pm.expect(jsonData.itemId).to.exist;",
+											"    pm.expect(jsonData.locationId).to.exist;",
+											"    pm.expect(jsonData.supplement).to.exist;",
+											"    pm.expect(jsonData.receivedDate).to.exist;",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"caption\": \"Tutorial Volume 99\",\n    \"comment\": \"Special Edition II\",\n    \"format\": \"Physical\",\n    \"itemId\": \"522a501a-56b5-48d9-b28a-3a8f02482d97\",\n    \"locationId\": \"53cf956f-c1df-410b-8bea-27f712cca7c0\",\n    \"poLineId\": \"{{poLineId}}\",\n    \"receivingStatus\": \"Expected\",\n    \"supplement\": true,\n    \"receivedDate\": \"2018-10-10T00:00:00.000+0000\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces"
+									]
+								},
+								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
+							},
+							"response": []
+						},
+						{
+							"name": "Edit 1st piece",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "f4d22769-3016-4e46-81ea-e42044dac59e",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let pieceBeforeUpdate = {};",
+											"let pieceId1ToUpdate = pm.globals.get(\"pieceId1ToUpdate\");",
+											"utils.sendGetRequest(\"/orders-storage/pieces/\" + pieceId1ToUpdate, function(err, res) {",
+											"    piece = res.json();",
+											"    let receivingStatus = piece.receivingStatus;",
+											"    console.log(\"receivingStatus storage: \" + receivingStatus);",
+											"});",
+											"",
+											"console.log(\"piece before writing to storage: \" + JSON.stringify(pieceBeforeUpdate));",
+											"",
+											"var piece1 = {};",
+											"piece1 = JSON.parse(pm.globals.get(\"pieceRecord\"));",
+											"",
+											"// Update piece1 receivingStatus to Expected",
+											"piece1.receivingStatus = \"Expected\"; // Received -> Expected",
+											"",
+											"// store poline id",
+											"pm.globals.set(\"poLineIdReceiptStatusEvent\", piece1.poLineId);",
+											"",
+											"// Use this pieceIdToUpdate to delete in next delete request",
+											"pm.variables.set(\"updatedPiece\", JSON.stringify(piece1));",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "78dbb04b-c21b-4ca4-aee9-a498911da327",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.response.to.have.status(\"No Content\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Url",
+										"type": "text",
+										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "text/plain",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedPiece}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceId1ToUpdate}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces",
+										"{{pieceId1ToUpdate}}"
+									]
+								},
+								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+							},
+							"response": []
+						},
+						{
+							"name": "Get all pieces by poLineId",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											" ",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    jsonData = pm.response.json();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/pieces?query=poLineId=={{poLineIdReceiptStatusEvent}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders-storage",
+										"pieces"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "poLineId=={{poLineIdReceiptStatusEvent}}"
+										}
+									]
+								},
+								"description": "GET /orders/order-lines/id requests that return 200"
+							},
+							"response": []
+						},
+						{
+							"name": "Get PoLine by poLineId",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											" ",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    jsonData = pm.response.json();",
+											"    ",
+											"    pm.expect(jsonData.receiptStatus).to.equal(\"Awaiting Receipt\"); // test fails?",
+											"    ",
+											"    pm.globals.set(\"poIdToDelete\", jsonData.purchaseOrderId);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineIdReceiptStatusEvent}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{poLineIdReceiptStatusEvent}}"
+									]
+								},
+								"description": "GET /orders/order-lines/id requests that return 200"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete first piece",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											" ",
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Url",
+										"type": "text",
+										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "text/plain",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces",
+										"{{pieceIdToUpdate}}"
+									]
+								},
+								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete second piece",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											" ",
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Url",
+										"type": "text",
+										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "text/plain",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceId2ToUpdate}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces",
+										"{{pieceId2ToUpdate}}"
+									]
+								},
+								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete last line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"// let utils = eval(globals.loadUtils);",
+											"// pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineIdReceiptStatusEvent}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{poLineIdReceiptStatusEvent}}"
+									]
+								},
+								"description": "GET /orders/order-lines/id requests that return 204"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete purchase order",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{poIdToDelete}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{poIdToDelete}}"
+									]
+								},
+								"description": "GET /orders/order-lines/id requests that return 204"
 							},
 							"response": []
 						}

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c662cc58-f280-43c4-989e-230d4994d29b",
+		"_postman_id": "d10e7202-50c3-4fa8-ae61-b763abeab6f1",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -2559,7 +2559,7 @@
 													"",
 													"pm.test(\"Each order has these optional fields\", function() {",
 													"    pm.expect(jsonData.id).to.exist;",
-													"    pm.globals.set(\"completeOrderId\", jsonData.id);",
+													"    pm.globals.set(\"completeOrderId\", jsonData.id); ",
 													"    pm.expect(jsonData.approved).to.exist;",
 													"    pm.expect(jsonData.poNumber).to.exist;",
 													"    pm.globals.set(\"completeOrderPoNumber\",\"\\\"\"+jsonData.poNumber+\"\\\"\");",
@@ -4841,6 +4841,278 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "Pieces",
+					"item": [
+						{
+							"name": "Create Piece",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"poLineId\", utils.getLastPoLineId());",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
+											"    let piece = res.json();",
+											"    piece.poLineId = pm.variables.get(\"poLineId\");",
+											"    pm.globals.set(\"pieceRecord\", JSON.stringify(piece));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											"jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.globals.set(\"pieceIdToUpdate\", jsonData.id);",
+											"    utils.validatePiece(jsonData);",
+											"});",
+											"",
+											"pm.test(\"Each piece has these optional fields\", function() {",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.expect(jsonData.caption).to.exist;",
+											"    pm.expect(jsonData.comment).to.exist;",
+											"    pm.expect(jsonData.itemId).to.exist;",
+											"    pm.expect(jsonData.locationId).to.exist;",
+											"    pm.expect(jsonData.supplement).to.exist;",
+											"    pm.expect(jsonData.receivedDate).to.exist;",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{pieceRecord}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces"
+									]
+								},
+								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
+							},
+							"response": []
+						},
+						{
+							"name": "Edit piece by id",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let piece = pm.globals.get(\"pieceRecord\");",
+											"",
+											"// Update piece format to Electronic",
+											"piece.format = \"Electronic\";",
+											"// Use this pieceIdToUpdate to delete in next delete request",
+											"pm.variables.set(\"updatedPiece\", piece);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.response.to.have.status(\"No Content\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Url",
+										"type": "text",
+										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "text/plain",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedPiece}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces",
+										"{{pieceIdToUpdate}}"
+									]
+								},
+								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete piece by id",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											" ",
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Url",
+										"type": "text",
+										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "text/plain",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces",
+										"{{pieceIdToUpdate}}"
+									]
+								},
+								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "Ensure receiptStatus consistency between Pieces PoLine",
 					"item": [
 						{
@@ -5024,7 +5296,8 @@
 												"orders",
 												"pieces"
 											]
-										}
+										},
+										"description": "Create another piece"
 									},
 									"response": []
 								},
@@ -5343,7 +5616,7 @@
 												"{{pieceId1ToUpdate}}"
 											]
 										},
-										"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+										"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257) - DELETE /orders/pieces/id"
 									},
 									"response": []
 								},
@@ -5432,7 +5705,7 @@
 												"{{pieceId2ToUpdate}}"
 											]
 										},
-										"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+										"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257) - DELETE /orders/pieces/id"
 									},
 									"response": []
 								}
@@ -5482,278 +5755,6 @@
 									""
 								]
 							}
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Pieces",
-					"item": [
-						{
-							"name": "Create Piece",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.variables.set(\"poLineId\", utils.getLastPoLineId());",
-											"",
-											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
-											"    let piece = res.json();",
-											"    piece.poLineId = pm.variables.get(\"poLineId\");",
-											"    pm.globals.set(\"pieceRecord\", JSON.stringify(piece));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"var jsonData = {};",
-											"jsonData = pm.response.json();",
-											"",
-											"pm.test(\"Status code is 201\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    pm.globals.set(\"pieceIdToUpdate\", jsonData.id);",
-											"    utils.validatePiece(jsonData);",
-											"});",
-											"",
-											"pm.test(\"Each piece has these optional fields\", function() {",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.expect(jsonData.caption).to.exist;",
-											"    pm.expect(jsonData.comment).to.exist;",
-											"    pm.expect(jsonData.itemId).to.exist;",
-											"    pm.expect(jsonData.locationId).to.exist;",
-											"    pm.expect(jsonData.supplement).to.exist;",
-											"    pm.expect(jsonData.receivedDate).to.exist;",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{pieceRecord}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces"
-									]
-								},
-								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
-							},
-							"response": []
-						},
-						{
-							"name": "Edit piece by id",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let piece = pm.globals.get(\"pieceRecord\");",
-											"",
-											"// Update piece format to Electronic",
-											"piece.format = \"Electronic\";",
-											"// Use this pieceIdToUpdate to delete in next delete request",
-											"pm.variables.set(\"updatedPiece\", piece);",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"    pm.response.to.have.status(\"No Content\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{updatedPiece}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces",
-										"{{pieceIdToUpdate}}"
-									]
-								},
-								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete piece by id",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											" ",
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces",
-										"{{pieceIdToUpdate}}"
-									]
-								},
-								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
-							},
-							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -12689,6 +12690,334 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Acquisitions unit assignments",
+					"item": [
+						{
+							"name": "Create assignment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    jsonData = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Each unit-assignments has these optional fields\", function() {",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"assignmentId\", jsonData.id); ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"assignmentBody\", JSON.stringify(utils.buildAssignmentContent()));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{assignmentBody}}\r\n"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update recordId for assignment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(\"No Content\");",
+											"",
+											"    // The test can be run only if update succeded",
+											"    utils.sendGetRequest(\"/orders-storage/acquisitions-unit-assignments/\" + environment.assignmentId, (err, res) => {",
+											"        pm.test(\"Verify updated assignment with new recordId\", () => pm.expect(res.json().recordId).to.equal(pm.variables.get(\"updatedAssignmentRecordId\")));",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "d1116217-372f-46f3-9223-ecd764bcbfad",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let assignment = utils.buildAssignmentContent();",
+											"let recordId= \"589a6016-3463-49f6-8aa2-dc315d0665fd\";",
+											"",
+											"assignment.recordId = recordId;",
+											"pm.variables.set(\"updatedAssignmentRecordId\", recordId);",
+											"pm.variables.set(\"updatedAssignment\", JSON.stringify(assignment));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedAssignment}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{assignmentId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{assignmentId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Recive created assignment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let assignment = {};",
+											"",
+											"pm.test(\"Assignment found\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    assignment = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Assignment content is valid\", function() {",
+											"    pm.expect(assignment.id).to.eql(pm.environment.get(\"assignmentId\"));",
+											"    utils.validateAssignmentAgainstSchema(assignment);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"recordId\": \"55b97a4a-6601-4488-84e1-8b0d47a3f523\",\r\n  \"acquisitionsUnitId\": \"0ebb1f7d-983f-3026-8a4c-5318e0ebc041\"\r\n}\r\n"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{assignmentId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{assignmentId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Recive created assignments",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let assignments = [];",
+											"",
+											"pm.test(\"Assignment found\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    assignments = pm.response.json().acquisitionsUnitAssignments;",
+											"});",
+											"",
+											"pm.test(\"Assignments content is valid\", function() {",
+											"    pm.expect(pm.response.json().totalRecords).to.be.above(0);",
+											"    assignments.forEach(assignment => utils.validateAssignmentAgainstSchema(assignment));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments?query=recordId==589a6016-3463-49f6-8aa2-dc315d0665fd",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "recordId==589a6016-3463-49f6-8aa2-dc315d0665fd"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete created assignment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Assignment has been successfully deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{assignmentId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{assignmentId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -17593,6 +17922,484 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Acquisitions unit assignments",
+					"item": [
+						{
+							"name": "Get assignment - bad ID 400",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "0d97ca96-4b98-49d2-aa71-5c524905cc80",
+										"exec": [
+											"pm.test(\"Status code is 400 - resource does not exist\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Error string in response body\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"parameter is incorrect\");",
+											"    pm.expect(pm.response.text()).to.include(\"bad-id\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/bad-id",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"bad-id"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get assignment - valid token, invalid tenant - 400",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "de7e87e3-83dd-4c97-9ea4-8b5d310cc605",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"empty instance ID returns error message\", function () {",
+											"     pm.expect(pm.response.text()).to.include(\"No such Tenant fs12345678\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "fs12345678"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{assignmentId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{assignmentId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get assignment - bad token format",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "7383726d-6b23-483b-9c6b-e6ee2af74213",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "bad-token"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{assignmentId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{assignmentId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get assignment - invalid token - 401",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "bdef6c41-4588-48db-89cc-4339b5c10ac0",
+										"exec": [
+											"pm.test(\"Status code is 401\", function () {",
+											"    pm.response.to.have.status(401);",
+											"});",
+											"",
+											"pm.test(\"empty instance ID returns error message\", function () {",
+											"     pm.expect(pm.response.text()).to.include(\"Invalid token\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "eyJhbGciOiJIUzUxMiJ999999.eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiJlZjY3NmRiOS1kMjMxLTQ3OWEtYWE5MS1mNjVlYjRiMTc4NzIiLCJ0ZW5hbnQiOiJmczAwMDAwMDAwIn2.KC0RbgafcMmR5Mc3-I7a6SQPKeDSr0SkJlLMcqQz3nwI0lwPTlxw0wJgidxDq-qjCR0wurFRn5ugd9_SVadSxg",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{assignmentId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{assignmentId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create assignment with invalid ID",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "18b13f93-34ab-4597-84f0-030e1d5a6f02",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let assignment = JSON.stringify(utils.buildAssignmentContent());",
+											"let add = JSON.parse(assignment);",
+											"add.id = \"123-345\"",
+											"",
+											"pm.variables.set(\"assignmentContent\", JSON.stringify(add));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "cab16de5-7348-40ce-9b12-f34c1f81c199",
+										"exec": [
+											"pm.test(\"Status code is 422\", function () {",
+											"    pm.response.to.have.status(422);",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{assignmentContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update assignment - bad ID 400",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5e653a4c-2d7a-4f58-a6f8-0f63c2e6bc7e",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"updatedAssignment\", JSON.stringify(utils.buildAssignmentContent()));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "24056b69-f204-4c32-985a-573f81411624",
+										"exec": [
+											"pm.test(\"Status code is 400 - resource does not exist\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Error string in response body\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"parameter is incorrect\");",
+											"    pm.expect(pm.response.text()).to.include(\"bad-id\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedAssignment}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/bad-id",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"bad-id"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete assignment - bad ID 400",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "be8660fd-3caf-4230-afa7-f48f5b6c07b2",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "58b49b0d-631e-4905-a714-14609b278a35",
+										"exec": [
+											"pm.test(\"Status code is 400 - resource does not exist\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Error string in response body\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"parameter is incorrect\");",
+											"    pm.expect(pm.response.text()).to.include(\"bad-id\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/bad-id",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"bad-id"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete already deleted assignment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "a55e3253-5f71-4674-97ff-7142376e2aea",
+										"exec": [
+											"pm.test(\"Assignment is not found\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{assignmentId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{assignmentId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete assignment by random ID",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "34fcdba4-e7c4-4991-8bbe-8b9b9bd4f627",
+										"exec": [
+											"pm.test(\"Assignment is not found\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments/{{$guid}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"acquisitions-unit-assignments",
+										"{{$guid}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			]
 		},
@@ -20780,6 +21587,16 @@
 					"    };",
 					"",
 					"    /**",
+					"     * Build Unit assignment",
+					"     */",
+					"    utils.buildAssignmentContent = function() {",
+					"        return {",
+					"            \"recordId\": \"05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33\",",
+					"            \"acquisitionsUnitId\": \"0ebb1f7d-983f-3026-8a4c-5318e0ebc041\"",
+					"        };",
+					"    };",
+					"",
+					"    /**",
 					"     * Build Order with minimal required fields.",
 					"     */",
 					"    utils.buildOrderWithMinContent = function() {",
@@ -21597,6 +22414,13 @@
 					"    utils.validateOrderAgainstSchema = function(jsonData) {",
 					"        utils._validateAgainstSchema(jsonData, JSON.parse(pm.environment.get(utils.schemaPrefix + \"composite_purchase_order.json\")));",
 					"    };",
+					"    ",
+					"    /**",
+					"     * Validates the Unit Assignment against schemas",
+					"     */",
+					"    utils.validateAssignmentAgainstSchema = function(jsonData) {",
+					"        utils._validateAgainstSchema(jsonData, JSON.parse(pm.environment.get(utils.schemaPrefix + \"acquisitions_unit_assignment.json\")));",
+					"    };",
 					"",
 					"    /**",
 					"     * Validates the PO Lines number",
@@ -22309,6 +23133,8 @@
 					"        pm.environment.unset(\"uniqueProductId\");",
 					"        pm.environment.unset(\"ledgerId\");",
 					"        pm.environment.unset(\"fundId\");",
+					"        pm.environment.unset(\"assignmentId\");",
+					"        ",
 					"    };",
 					"",
 					"    /**",
@@ -22376,55 +23202,55 @@
 	],
 	"variable": [
 		{
-			"id": "0c513acc-347f-4447-b659-b6e83f1ad056",
+			"id": "f77313d7-9438-48ef-b7d6-e01f90d7a644",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "50982b50-96ab-4665-8681-3b7d07d750e8",
+			"id": "1c7d9e40-e058-4579-802a-2b128e502fbc",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "37f155ff-047d-4f9f-bba6-b7c5214430d8",
+			"id": "4e51b9c1-ee59-4650-88b3-05652bfb856d",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "290f7e99-853a-4eb8-855c-4ca320c714e6",
+			"id": "289542cd-b333-43d9-9aec-e1df55222a3b",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "0d1fd495-8563-4ac6-8539-17085cfc5104",
+			"id": "a2921a6d-a651-4d6e-81bd-e96fa06a2033",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "e0f3b796-c4d9-475f-bfcc-b704c9f211d9",
+			"id": "55e91b33-c574-4b0d-b6fe-66b8c3664b2e",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "f7699ea4-f4b6-417a-82e2-daceeea91a4b",
+			"id": "b7f851ff-39a5-4b77-99c7-7cce3b61e52c",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "039ef680-3dff-4eba-9cb6-a34c9084d8ab",
+			"id": "899fa2fd-3224-4d99-bda7-d3061df5e2ce",
 			"key": "finance-ledgerCode",
 			"value": "ordersApiTestsLedgerCode",
 			"type": "string"
 		},
 		{
-			"id": "24e9c4aa-a683-448d-bc88-4bec8ba8f704",
+			"id": "dfbc0c78-11dc-4eef-a9a0-ddbb33bef223",
 			"key": "finance-fundCode",
 			"value": "ordersApiTestsFundCode",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -5280,8 +5280,6 @@
 											"script": {
 												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													" ",
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
 													"});",
@@ -5367,14 +5365,15 @@
 											"script": {
 												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													" ",
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
 													"});",
 													"",
 													"pm.globals.unset(\"pieceId2ToUpdate\");",
-													"pm.globals.unset(\"poLineIdToCreatePiece\");"
+													"pm.globals.unset(\"poLineIdToCreatePiece\");",
+													"pm.globals.unset(\"pieceRecordAwaiting1\");",
+													"pm.globals.unset(\"pieceRecordAwaiting2\");",
+													"pm.globals.unset(\"updatedPieceRecordAwaiting1\");"
 												],
 												"type": "text/javascript"
 											}
@@ -22377,55 +22376,55 @@
 	],
 	"variable": [
 		{
-			"id": "dc8be404-45bb-42ee-8529-1dc75e43f653",
+			"id": "0c513acc-347f-4447-b659-b6e83f1ad056",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "ea0cbc59-a454-4036-9484-067cc897a5c9",
+			"id": "50982b50-96ab-4665-8681-3b7d07d750e8",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "96799433-20fa-47e6-b6d0-ef1421a9e76b",
+			"id": "37f155ff-047d-4f9f-bba6-b7c5214430d8",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "535ab671-5e72-4143-a6ec-3a9ddbebb71c",
+			"id": "290f7e99-853a-4eb8-855c-4ca320c714e6",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "a727c9cb-5f16-4742-85f8-723494bb3f8c",
+			"id": "0d1fd495-8563-4ac6-8539-17085cfc5104",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "d295e53c-3406-4ed2-8392-47b4da195668",
+			"id": "e0f3b796-c4d9-475f-bfcc-b704c9f211d9",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "908aeaa7-0faf-444c-a4c9-edd65ddeee72",
+			"id": "f7699ea4-f4b6-417a-82e2-daceeea91a4b",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "e185fdc1-710e-41f9-8c30-4bfa14931719",
+			"id": "039ef680-3dff-4eba-9cb6-a34c9084d8ab",
 			"key": "finance-ledgerCode",
 			"value": "ordersApiTestsLedgerCode",
 			"type": "string"
 		},
 		{
-			"id": "a9d2e20a-6bd0-453f-a992-c6f489c981c6",
+			"id": "24e9c4aa-a683-448d-bc88-4bec8ba8f704",
 			"key": "finance-fundCode",
 			"value": "ordersApiTestsFundCode",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "e2cddc08-7ba1-4fb8-b5d4-5bfee384b4a3",
-		"name": "mod-orders",
+		"_postman_id": "132a9e0b-c226-40ff-9220-c489c998d0ca",
+		"name": "mod-orders contributorNameTypeId",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1464,6 +1464,108 @@
 										{
 											"key": "query",
 											"value": "name=={{materialTypeName}}"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								},
+								"description": "Gets or creates if not yet exists test meterial type to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						},
+						{
+							"name": "Get or create Contributor name type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"GET Contributor Name types response is ok\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let jsonData = pm.response.json();",
+											"    if (jsonData.contributorNameTypes.length == 1) {",
+											"        useAlreadyExistingType(jsonData.contributorNameTypes[0]);",
+											"    } else {",
+											"        createNewType();",
+											"    }",
+											"});  ",
+											"",
+											"function useAlreadyExistingType(materialType) {",
+											"    pm.test(\"Contributor Name Type already exists\", function () {",
+											"        pm.expect(materialType.id).to.exist;",
+											"        setIdAsGlobalVariable(materialType.id);",
+											"    });",
+											"}",
+											"",
+											"function createNewType() {",
+											"    const nameType = {",
+											"        \"id\": \"6d6f642d-0005-1111-aaaa-6f7264657273\",",
+											"        \"name\": pm.variables.get(\"contributorNameType\")",
+											"    };",
+											"",
+											"    eval(globals.loadUtils).postRequest(\"/contributor-name-types\", nameType, (err, res) => {",
+											"        pm.test(\"Contributor Name Type created\", () => {",
+											"            pm.expect(err).to.equal(null);",
+											"            pm.expect(res).to.have.property('code', 201);",
+											"            setIdAsGlobalVariable(res.json().id);",
+											"        });",
+											"    });",
+											"}",
+											"",
+											"function setIdAsGlobalVariable(id) {",
+											"    pm.environment.set(\"contributorNameTypeId\", id);",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											"pm.variables.set(\"contributorNameType\", \"Orders API Tests type\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/contributor-name-types?query=name=={{contributorNameType}}&limit=1",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"contributor-name-types"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "name=={{contributorNameType}}"
 										},
 										{
 											"key": "limit",
@@ -3823,7 +3925,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": \"268758test2\",\n  \"reEncumber\": false,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poLineId}}\",\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"{{currencyUpdate}}\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityElectronic\": 0,\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": \"268758test2\",\n  \"reEncumber\": false,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poLineId}}\",\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"{{currencyUpdate}}\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityElectronic\": 0,\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
@@ -3932,7 +4034,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": {{completeOrderPoNumber}},\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"additionalCost\": {{additionalCostUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"USD\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": {{completeOrderPoNumber}},\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"additionalCost\": {{additionalCostUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"USD\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"percentage\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": {\n        \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n        \"description\": \"ABCDEFGHIJKLMNO\"\n      },\n      \"tags\": [\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFG\",\n        \"ABCDEFGHIJKLMNOPQRSTU\",\n        \"ABCDEFGHIJKLMNO\"\n      ],\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
@@ -4739,278 +4841,6 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"name": "Pieces",
-					"item": [
-						{
-							"name": "Create Piece",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.variables.set(\"poLineId\", utils.getLastPoLineId());",
-											"",
-											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
-											"    let piece = res.json();",
-											"    piece.poLineId = pm.variables.get(\"poLineId\");",
-											"    pm.globals.set(\"pieceRecord\", JSON.stringify(piece));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"var jsonData = {};",
-											"jsonData = pm.response.json();",
-											"",
-											"pm.test(\"Status code is 201\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    pm.globals.set(\"pieceIdToUpdate\", jsonData.id);",
-											"    utils.validatePiece(jsonData);",
-											"});",
-											"",
-											"pm.test(\"Each piece has these optional fields\", function() {",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.expect(jsonData.caption).to.exist;",
-											"    pm.expect(jsonData.comment).to.exist;",
-											"    pm.expect(jsonData.itemId).to.exist;",
-											"    pm.expect(jsonData.locationId).to.exist;",
-											"    pm.expect(jsonData.supplement).to.exist;",
-											"    pm.expect(jsonData.receivedDate).to.exist;",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{pieceRecord}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces"
-									]
-								},
-								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
-							},
-							"response": []
-						},
-						{
-							"name": "Edit piece by id",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let piece = pm.globals.get(\"pieceRecord\");",
-											"",
-											"// Update piece format to Electronic",
-											"piece.format = \"Electronic\";",
-											"// Use this pieceIdToUpdate to delete in next delete request",
-											"pm.variables.set(\"updatedPiece\", piece);",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"    pm.response.to.have.status(\"No Content\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{updatedPiece}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces",
-										"{{pieceIdToUpdate}}"
-									]
-								},
-								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete piece by id",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											" ",
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces",
-										"{{pieceIdToUpdate}}"
-									]
-								},
-								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
 					"name": "Pieces event handling",
 					"item": [
 						{
@@ -5721,6 +5551,278 @@
 									]
 								},
 								"description": "GET /orders/order-lines/id requests that return 204"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Pieces",
+					"item": [
+						{
+							"name": "Create Piece",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"poLineId\", utils.getLastPoLineId());",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
+											"    let piece = res.json();",
+											"    piece.poLineId = pm.variables.get(\"poLineId\");",
+											"    pm.globals.set(\"pieceRecord\", JSON.stringify(piece));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											"jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.globals.set(\"pieceIdToUpdate\", jsonData.id);",
+											"    utils.validatePiece(jsonData);",
+											"});",
+											"",
+											"pm.test(\"Each piece has these optional fields\", function() {",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.expect(jsonData.caption).to.exist;",
+											"    pm.expect(jsonData.comment).to.exist;",
+											"    pm.expect(jsonData.itemId).to.exist;",
+											"    pm.expect(jsonData.locationId).to.exist;",
+											"    pm.expect(jsonData.supplement).to.exist;",
+											"    pm.expect(jsonData.receivedDate).to.exist;",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{pieceRecord}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces"
+									]
+								},
+								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
+							},
+							"response": []
+						},
+						{
+							"name": "Edit piece by id",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let piece = pm.globals.get(\"pieceRecord\");",
+											"",
+											"// Update piece format to Electronic",
+											"piece.format = \"Electronic\";",
+											"// Use this pieceIdToUpdate to delete in next delete request",
+											"pm.variables.set(\"updatedPiece\", piece);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.response.to.have.status(\"No Content\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Url",
+										"type": "text",
+										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "text/plain",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedPiece}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces",
+										"{{pieceIdToUpdate}}"
+									]
+								},
+								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete piece by id",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											" ",
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "X-Okapi-Url",
+										"type": "text",
+										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "text/plain",
+										"disabled": true
+									},
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces",
+										"{{pieceIdToUpdate}}"
+									]
+								},
+								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
 							},
 							"response": []
 						}
@@ -9858,7 +9960,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"vendor\": \"{{activeVendorId}}\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorType\": \"fbdd42a8-e47d-4694-b448-cc571d1b44c3\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"{{identifierTypeId}}\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"f34d27c6-a8eb-461b-acd6-5dea81771e70\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialTypeId}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": {\n                \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n                \"description\": \"ABCDEFGHIJKLMNO\"\n            },\n            \"tags\": [\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFG\",\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFGHIJKLMNO\"\n            ],\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
+											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"vendor\": \"{{activeVendorId}}\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"{{identifierTypeId}}\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"f34d27c6-a8eb-461b-acd6-5dea81771e70\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialTypeId}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": {\n                \"code\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZABC\",\n                \"description\": \"ABCDEFGHIJKLMNO\"\n            },\n            \"tags\": [\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFG\",\n                \"ABCDEFGHIJKLMNOPQRSTU\",\n                \"ABCDEFGHIJKLMNO\"\n            ],\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -19907,6 +20009,59 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Delete contributor name type",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Contributor name type deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/contributor-name-types/{{contributorNameTypeId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"contributor-name-types",
+										"{{contributorNameTypeId}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -20492,7 +20647,11 @@
 					"        \"permissions\": [",
 					"            \"orders.all\",",
 					"            \"inventory-storage.items.collection.get\",",
-					"            \"inventory-storage.items.item.get\"",
+					"            \"inventory-storage.items.item.get\",",
+					"            \"orders-storage.pieces.item.get\",",
+					"            \"orders-storage.pieces.collection.get\",",
+					"            \"orders-storage.po-lines.collection.get\",",
+					"            \"orders-storage.po-lines.item.get\"",
 					"        ]",
 					"    },",
 					"    receiving: {",
@@ -20666,6 +20825,11 @@
 					"            poLine.fundDistribution.forEach(distrib => {",
 					"                delete distrib.encumbrance;",
 					"                distrib.fundId = pm.environment.get(\"fundId\");",
+					"            });",
+					"        }",
+					"        if (poLine.hasOwnProperty(\"contributors\")) {",
+					"            poLine.contributors.forEach(contributor => {",
+					"                contributor.contributorNameTypeId = pm.environment.get(\"contributorNameTypeId\");",
 					"            });",
 					"        }",
 					"",
@@ -22209,6 +22373,7 @@
 					"        pm.environment.unset(\"mod-orders-configs\");",
 					"        pm.environment.unset(\"receivingItemBarcode\");",
 					"        pm.environment.unset(\"activeVendorId\");",
+					"        pm.environment.unset(\"contributorNameTypeId\");",
 					"        pm.environment.unset(\"inactiveVendorId\");",
 					"        pm.environment.unset(\"identifierTypeId\");",
 					"        pm.environment.unset(\"instanceTypeId\");",
@@ -22285,55 +22450,55 @@
 	],
 	"variable": [
 		{
-			"id": "63553ed3-7eef-470e-95e7-e00dee2ad36b",
+			"id": "8002d71d-4bdb-4741-be68-e3ba760b9275",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "5d18c3b8-691f-481b-8041-377aee514e08",
+			"id": "4736da8b-7094-4142-be74-1bc96b8c6f45",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "7cd49aa8-5979-4f19-b26a-6d7cc4f42bf2",
+			"id": "9351fac9-7e6e-4f67-82c2-fa0537f11c8f",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "9d19815b-2bee-4dee-a886-eb19039b5439",
+			"id": "96d536bd-8ac7-4a90-af72-a6c765ad94da",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "469cba9b-e397-4cfa-af87-5102078b5a72",
+			"id": "9297e319-d389-4dd8-af4a-59b9659d972d",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "58b925c6-de6f-481c-a841-8969b4a1d5d8",
+			"id": "d543cb22-15b1-49bf-8d68-07ea30f7c047",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "fa7d99f6-1fc1-4628-942a-e4a610a40ebf",
+			"id": "6f28e30b-9136-4be8-a417-3d771ca6730a",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "efc13c7b-833e-4e0c-a708-431c3b1cbc42",
+			"id": "866ef3a0-dcd0-4ba2-8b68-09f39f66d43a",
 			"key": "finance-ledgerCode",
 			"value": "ordersApiTestsLedgerCode",
 			"type": "string"
 		},
 		{
-			"id": "8e3f3e35-aa86-46c8-bb39-a14830cc8ba0",
+			"id": "f1ecf9b8-b576-4654-8173-01d42a0eedc3",
 			"key": "finance-fundCode",
 			"value": "ordersApiTestsFundCode",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "132a9e0b-c226-40ff-9220-c489c998d0ca",
-		"name": "mod-orders contributorNameTypeId",
+		"_postman_id": "c662cc58-f280-43c4-989e-230d4994d29b",
+		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -2559,7 +2559,7 @@
 													"",
 													"pm.test(\"Each order has these optional fields\", function() {",
 													"    pm.expect(jsonData.id).to.exist;",
-													"    pm.globals.set(\"completeOrderId\", jsonData.id); ",
+													"    pm.globals.set(\"completeOrderId\", jsonData.id);",
 													"    pm.expect(jsonData.approved).to.exist;",
 													"    pm.expect(jsonData.poNumber).to.exist;",
 													"    pm.globals.set(\"completeOrderPoNumber\",\"\\\"\"+jsonData.poNumber+\"\\\"\");",
@@ -4841,718 +4841,648 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"name": "Pieces event handling",
+					"name": "Ensure receiptStatus consistency between Pieces PoLine",
 					"item": [
 						{
-							"name": "Create 1st Piece",
-							"event": [
+							"name": "Verify PoLine Awaiting ReceiptStatus",
+							"item": [
 								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.globals.set(\"poLineId\", utils.getLastPoLineId());",
-											"",
-											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
-											"    let piece = res.json();",
-											"    piece.poLineId = pm.variables.get(\"poLineId\");",
-											"    pm.globals.set(\"pieceRecord\", JSON.stringify(piece));",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"var jsonData = {};",
-											"jsonData = pm.response.json();",
-											"",
-											"pm.test(\"Status code is 201\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    pm.globals.set(\"pieceId1ToUpdate\", jsonData.id);",
-											"    utils.validatePiece(jsonData);",
-											"});",
-											"",
-											"pm.test(\"Each piece has these optional fields\", function() {",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.expect(jsonData.caption).to.exist;",
-											"    pm.expect(jsonData.comment).to.exist;",
-											"    pm.expect(jsonData.itemId).to.exist;",
-											"    pm.expect(jsonData.locationId).to.exist;",
-											"    pm.expect(jsonData.supplement).to.exist;",
-											"    pm.expect(jsonData.receivedDate).to.exist;",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{pieceRecord}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces"
-									]
-								},
-								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
-							},
-							"response": []
-						},
-						{
-							"name": "Create 2nd Piece",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"var jsonData = {};",
-											"jsonData = pm.response.json();",
-											"",
-											"pm.test(\"Status code is 201\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    pm.globals.set(\"pieceId2ToUpdate\", jsonData.id);",
-											"    utils.validatePiece(jsonData);",
-											"});",
-											"",
-											"pm.test(\"Each piece has these optional fields\", function() {",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.expect(jsonData.caption).to.exist;",
-											"    pm.expect(jsonData.comment).to.exist;",
-											"    pm.expect(jsonData.itemId).to.exist;",
-											"    pm.expect(jsonData.locationId).to.exist;",
-											"    pm.expect(jsonData.supplement).to.exist;",
-											"    pm.expect(jsonData.receivedDate).to.exist;",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"caption\": \"Tutorial Volume 99\",\n    \"comment\": \"Special Edition II\",\n    \"format\": \"Physical\",\n    \"itemId\": \"522a501a-56b5-48d9-b28a-3a8f02482d97\",\n    \"locationId\": \"53cf956f-c1df-410b-8bea-27f712cca7c0\",\n    \"poLineId\": \"{{poLineId}}\",\n    \"receivingStatus\": \"Expected\",\n    \"supplement\": true,\n    \"receivedDate\": \"2018-10-10T00:00:00.000+0000\"\n}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces"
-									]
-								},
-								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders.\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `false`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
-							},
-							"response": []
-						},
-						{
-							"name": "Edit 1st piece",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "f4d22769-3016-4e46-81ea-e42044dac59e",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let pieceBeforeUpdate = {};",
-											"let pieceId1ToUpdate = pm.globals.get(\"pieceId1ToUpdate\");",
-											"utils.sendGetRequest(\"/orders-storage/pieces/\" + pieceId1ToUpdate, function(err, res) {",
-											"    piece = res.json();",
-											"    let receivingStatus = piece.receivingStatus;",
-											"    console.log(\"receivingStatus storage: \" + receivingStatus);",
-											"});",
-											"",
-											"console.log(\"piece before writing to storage: \" + JSON.stringify(pieceBeforeUpdate));",
-											"",
-											"var piece1 = {};",
-											"piece1 = JSON.parse(pm.globals.get(\"pieceRecord\"));",
-											"",
-											"// Update piece1 receivingStatus to Expected",
-											"piece1.receivingStatus = \"Expected\"; // Received -> Expected",
-											"",
-											"// store poline id",
-											"pm.globals.set(\"poLineIdReceiptStatusEvent\", piece1.poLineId);",
-											"",
-											"// Use this pieceIdToUpdate to delete in next delete request",
-											"pm.variables.set(\"updatedPiece\", JSON.stringify(piece1));",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "78dbb04b-c21b-4ca4-aee9-a498911da327",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"    pm.response.to.have.status(\"No Content\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{updatedPiece}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceId1ToUpdate}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces",
-										"{{pieceId1ToUpdate}}"
-									]
-								},
-								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
-							},
-							"response": []
-						},
-						{
-							"name": "Get all pieces by poLineId",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"var jsonData = {};",
-											" ",
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"    jsonData = pm.response.json();",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/pieces?query=poLineId=={{poLineIdReceiptStatusEvent}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders-storage",
-										"pieces"
-									],
-									"query": [
+									"name": "Create 1st Piece - Received",
+									"event": [
 										{
-											"key": "query",
-											"value": "poLineId=={{poLineIdReceiptStatusEvent}}"
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.globals.set(\"poLineIdToCreatePiece\", utils.getLastPoLineId());",
+													"",
+													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
+													"    let piece = res.json();",
+													"    piece.poLineId = pm.globals.get(\"poLineIdToCreatePiece\");",
+													"    pm.globals.set(\"pieceRecordAwaiting1\", JSON.stringify(piece));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"var jsonData = {};",
+													"jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    pm.globals.set(\"pieceId1ToUpdate\", jsonData.id);",
+													"    utils.validatePiece(jsonData);",
+													"});",
+													"",
+													"pm.test(\"Each piece has these optional fields\", function() {",
+													"    pm.expect(jsonData.id).to.exist;",
+													"    pm.expect(jsonData.caption).to.exist;",
+													"    pm.expect(jsonData.comment).to.exist;",
+													"    pm.expect(jsonData.itemId).to.exist;",
+													"    pm.expect(jsonData.locationId).to.exist;",
+													"    pm.expect(jsonData.supplement).to.exist;",
+													"    pm.expect(jsonData.receivedDate).to.exist;",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
 										}
-									]
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{pieceRecordAwaiting1}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"pieces"
+											]
+										},
+										"description": "MODORDERS-173 - ensure receiptStatus consistency between piece and poLine"
+									},
+									"response": []
 								},
-								"description": "GET /orders/order-lines/id requests that return 200"
-							},
-							"response": []
-						},
-						{
-							"name": "Get PoLine by poLineId",
+								{
+									"name": "Create 2nd Piece - Expected",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
+													"    let piece = res.json();",
+													"    piece.poLineId = pm.globals.get(\"poLineIdToCreatePiece\");",
+													"    piece.caption = \"Tutorial Volume 99\";",
+													"    piece.comment = \"Special Edition II\";",
+													"    piece.format = \"Physical\";",
+													"    piece.itemId = \"522a501a-56b5-48d9-b28a-3a8f02482d97\";",
+													"    piece.locationId = \"53cf956f-c1df-410b-8bea-27f712cca7c0\";",
+													"    piece.receivingStatus = \"Expected\";",
+													"    piece.supplement = true;",
+													"    piece.receivedDate = \"2018-10-10T00:00:00.000+0000\";",
+													"    ",
+													"    pm.globals.set(\"pieceRecordAwaiting2\", JSON.stringify(piece));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"var jsonData = {};",
+													"jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    pm.globals.set(\"pieceId2ToUpdate\", jsonData.id);",
+													"    utils.validatePiece(jsonData);",
+													"});",
+													"",
+													"pm.test(\"Each piece has these optional fields\", function() {",
+													"    pm.expect(jsonData.id).to.exist;",
+													"    pm.expect(jsonData.caption).to.exist;",
+													"    pm.expect(jsonData.comment).to.exist;",
+													"    pm.expect(jsonData.itemId).to.exist;",
+													"    pm.expect(jsonData.locationId).to.exist;",
+													"    pm.expect(jsonData.supplement).to.exist;",
+													"    pm.expect(jsonData.receivedDate).to.exist;",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{pieceRecordAwaiting2}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"pieces"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update 1st piece - to Expected",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "f4d22769-3016-4e46-81ea-e42044dac59e",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let pieceId1ToUpdate = pm.globals.get(\"pieceId1ToUpdate\");",
+													"utils.sendGetRequest(\"/orders-storage/pieces/\" + pieceId1ToUpdate, function(err, res) {",
+													"    piece = res.json();",
+													"    let receivingStatus = piece.receivingStatus;",
+													"    console.log(\"receivingStatus storage: \" + receivingStatus);",
+													"});",
+													"",
+													"var piece1 = {};",
+													"piece1 = JSON.parse(pm.globals.get(\"pieceRecordAwaiting1\"));",
+													"",
+													"// Update piece1 receivingStatus to Expected",
+													"piece1.receivingStatus = \"Expected\"; // Received -> Expected will trigger event",
+													"",
+													"// Use this pieceIdToUpdate to delete in next delete request",
+													"pm.variables.set(\"updatedPieceRecordAwaiting1\", JSON.stringify(piece1));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "78dbb04b-c21b-4ca4-aee9-a498911da327",
+												"exec": [
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    pm.response.to.have.status(\"No Content\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Url",
+												"type": "text",
+												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+												"disabled": true
+											},
+											{
+												"key": "Accept",
+												"type": "text",
+												"value": "text/plain",
+												"disabled": true
+											},
+											{
+												"key": "Accept",
+												"type": "text",
+												"value": "application/json",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedPieceRecordAwaiting1}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceId1ToUpdate}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"pieces",
+												"{{pieceId1ToUpdate}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get all pieces by poLineId",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"var jsonData = {};",
+													" ",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"    jsonData = pm.response.json();",
+													"    pm.expect(jsonData.pieces[0].receivingStatus).to.equal(\"Expected\");",
+													"    pm.expect(jsonData.pieces[1].receivingStatus).to.equal(\"Expected\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/pieces?query=poLineId=={{poLineIdToCreatePiece}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders-storage",
+												"pieces"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "poLineId=={{poLineIdToCreatePiece}}"
+												}
+											]
+										},
+										"description": "GET /orders-storage/pieces requests that return 200"
+									},
+									"response": []
+								},
+								{
+									"name": "Get PoLine by poLineId",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"var jsonData = {};",
+													" ",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"    jsonData = pm.response.json();",
+													"    ",
+													"    // All pieces receiving status is \"Expected\" so receiptStatus should be \"Awaiting Receipt\"",
+													"    pm.expect(jsonData.receiptStatus).to.equal(\"Awaiting Receipt\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineIdToCreatePiece}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"order-lines",
+												"{{poLineIdToCreatePiece}}"
+											]
+										},
+										"description": "GET /orders/order-lines/id requests that return 200"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete first piece",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													" ",
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													"",
+													"pm.globals.unset(\"pieceId1ToUpdate\");"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Url",
+												"type": "text",
+												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+												"disabled": true
+											},
+											{
+												"key": "Accept",
+												"type": "text",
+												"value": "text/plain",
+												"disabled": true
+											},
+											{
+												"key": "Accept",
+												"type": "text",
+												"value": "application/json",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceId1ToUpdate}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"pieces",
+												"{{pieceId1ToUpdate}}"
+											]
+										},
+										"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete second piece",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													" ",
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													"",
+													"pm.globals.unset(\"pieceId2ToUpdate\");",
+													"pm.globals.unset(\"poLineIdToCreatePiece\");"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "X-Okapi-Url",
+												"type": "text",
+												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
+												"disabled": true
+											},
+											{
+												"key": "Accept",
+												"type": "text",
+												"value": "text/plain",
+												"disabled": true
+											},
+											{
+												"key": "Accept",
+												"type": "text",
+												"value": "application/json",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceId2ToUpdate}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"pieces",
+												"{{pieceId2ToUpdate}}"
+											]
+										},
+										"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
+									},
+									"response": []
+								}
+							],
 							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"id": "7bf8e56f-d149-49e8-ae7b-2f4a9d19e6a5",
+										"type": "text/javascript",
 										"exec": [
 											""
-										],
-										"type": "text/javascript"
+										]
 									}
 								},
 								{
 									"listen": "test",
 									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"id": "58692dd1-3661-4e41-a56f-0c58334e17b9",
+										"type": "text/javascript",
 										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"var jsonData = {};",
-											" ",
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"    jsonData = pm.response.json();",
-											"    ",
-											"    pm.expect(jsonData.receiptStatus).to.equal(\"Awaiting Receipt\"); // test fails?",
-											"    ",
-											"    pm.globals.set(\"poIdToDelete\", jsonData.purchaseOrderId);",
-											"});"
-										],
-										"type": "text/javascript"
+											""
+										]
 									}
 								}
 							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineIdReceiptStatusEvent}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"order-lines",
-										"{{poLineIdReceiptStatusEvent}}"
-									]
-								},
-								"description": "GET /orders/order-lines/id requests that return 200"
-							},
-							"response": []
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fcba4c16-5473-4fdb-8774-ef24ac89fb2a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						},
 						{
-							"name": "Delete first piece",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											" ",
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceIdToUpdate}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces",
-										"{{pieceIdToUpdate}}"
-									]
-								},
-								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete second piece",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											" ",
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces/{{pieceId2ToUpdate}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"pieces",
-										"{{pieceId2ToUpdate}}"
-									]
-								},
-								"description": "[MODORDERS-257](https://issues.folio.org/browse/MODORDERS-257)"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete last line",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"// let utils = eval(globals.loadUtils);",
-											"// pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{poLineIdReceiptStatusEvent}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"order-lines",
-										"{{poLineIdReceiptStatusEvent}}"
-									]
-								},
-								"description": "GET /orders/order-lines/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete purchase order",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{poIdToDelete}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{poIdToDelete}}"
-									]
-								},
-								"description": "GET /orders/order-lines/id requests that return 204"
-							},
-							"response": []
+							"listen": "test",
+							"script": {
+								"id": "38647880-b894-44d4-8d9c-e70a8fa19a90",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
 						}
 					],
 					"_postman_isSubFolder": true
@@ -20648,10 +20578,7 @@
 					"            \"orders.all\",",
 					"            \"inventory-storage.items.collection.get\",",
 					"            \"inventory-storage.items.item.get\",",
-					"            \"orders-storage.pieces.item.get\",",
-					"            \"orders-storage.pieces.collection.get\",",
-					"            \"orders-storage.po-lines.collection.get\",",
-					"            \"orders-storage.po-lines.item.get\"",
+					"            \"orders-storage.pieces.collection.get\"",
 					"        ]",
 					"    },",
 					"    receiving: {",
@@ -22450,55 +22377,55 @@
 	],
 	"variable": [
 		{
-			"id": "8002d71d-4bdb-4741-be68-e3ba760b9275",
+			"id": "dc8be404-45bb-42ee-8529-1dc75e43f653",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "4736da8b-7094-4142-be74-1bc96b8c6f45",
+			"id": "ea0cbc59-a454-4036-9484-067cc897a5c9",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "9351fac9-7e6e-4f67-82c2-fa0537f11c8f",
+			"id": "96799433-20fa-47e6-b6d0-ef1421a9e76b",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "96d536bd-8ac7-4a90-af72-a6c765ad94da",
+			"id": "535ab671-5e72-4143-a6ec-3a9ddbebb71c",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "9297e319-d389-4dd8-af4a-59b9659d972d",
+			"id": "a727c9cb-5f16-4742-85f8-723494bb3f8c",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "d543cb22-15b1-49bf-8d68-07ea30f7c047",
+			"id": "d295e53c-3406-4ed2-8392-47b4da195668",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "6f28e30b-9136-4be8-a417-3d771ca6730a",
+			"id": "908aeaa7-0faf-444c-a4c9-edd65ddeee72",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "866ef3a0-dcd0-4ba2-8b68-09f39f66d43a",
+			"id": "e185fdc1-710e-41f9-8c30-4bfa14931719",
 			"key": "finance-ledgerCode",
 			"value": "ordersApiTestsLedgerCode",
 			"type": "string"
 		},
 		{
-			"id": "f1ecf9b8-b576-4654-8173-01d42a0eedc3",
+			"id": "a9d2e20a-6bd0-453f-a992-c6f489c981c6",
 			"key": "finance-fundCode",
 			"value": "ordersApiTestsFundCode",
 			"type": "string"


### PR DESCRIPTION
## Purpose
[MODORDERS-173](https://issues.folio.org/browse/MODORDERS-173) ensure receiptStatus consistency between piece and poLine

## Approach
1. Assume an order exists with a poLine whose receiptStatus is not `Awaiting Receipt`
2. Create 2 pieces associated with poLine with Receiving Status:
   a) `Received`
   b) `Expected`
2. Update one piece from `Receiving` -> `Expected` which should trigger an event to update poLine receiptStatus
3. Get all pieces by poLineId
4. Verify that poLine receiptStatus is updated to `Awaiting Receipt`
5. Cleanup

Verified locally in folio/testing:
![image](https://user-images.githubusercontent.com/17807360/60932210-ec96c080-a28a-11e9-9f75-9ba9936e76fa.png)

![image](https://user-images.githubusercontent.com/17807360/60932187-d7219680-a28a-11e9-92c3-9ad65ab640fc.png)

