### PR TITLE
MODINVOICE-66 Shouldn't be allowed to add invoiceLines to an "approved" or "paid" invoice

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c37b0a82-3538-4271-94c6-fd2bcdd17d8b",
+		"_postman_id": "a48cab24-cc7b-4095-8df1-2d95d966c75e",
 		"name": "mod-invoice",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1441,6 +1441,7 @@
 													"let utils = eval(globals.loadUtils);",
 													"",
 													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
+													"    pm.globals.set(\"mock-invoices\",  JSON.stringify(res.json()));",
 													"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
 													"",
 													"    invoice.note += \" - filtering\";",
@@ -2477,9 +2478,9 @@
 													"let utils = eval(globals.loadUtils);",
 													"let adjustmentsArray = [];",
 													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
+													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/e0d08448-343b-118a-8c2f-4fb50248d672.json\", function (err, res) {",
 													"    let invoiceLine = res.json();",
-													"",
+													"    pm.globals.set(\"mock-invoiceLine\",  JSON.stringify(invoiceLine));",
 													"    delete invoiceLine.id;",
 													"    delete invoiceLine.invoiceLineNumber;",
 													"    delete invoiceLine.adjustments;",
@@ -2578,27 +2579,26 @@
 													"let utils = eval(globals.loadUtils);",
 													"let adjustmentsArray = [];",
 													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-													"    let invoiceLine = res.json();",
 													"",
-													"    delete invoiceLine.id;",
-													"    delete invoiceLine.invoiceLineNumber;",
-													"    delete invoiceLine.adjustments;",
-													"    invoiceLine.comment = \"Adding line for API testing adjustment\";",
-													"    invoiceLine.invoiceId = pm.environment.get(\"invoiceId\");",
+													"let invoiceLine = utils.getMockInvoiceLine();",
+													"delete invoiceLine.id;",
+													"delete invoiceLine.invoiceLineNumber;",
+													"delete invoiceLine.adjustments;",
+													"invoiceLine.comment = \"Adding line for API testing adjustment\";",
+													"invoiceLine.invoiceId = pm.environment.get(\"invoiceId\");",
 													"",
-													"    let adjustment1 = utils.buildAdjustmentObject();",
-													"    adjustment1.value = -13.88;",
-													"    adjustmentsArray.push(adjustment1);",
-													"    ",
-													"    let adjustment2 = utils.buildAdjustmentObject();",
-													"    adjustment2.value = -14.33;",
-													"    adjustmentsArray.push(adjustment2);",
-													"    ",
-													"    invoiceLine.adjustments = adjustmentsArray;",
+													"let adjustment1 = utils.buildAdjustmentObject();",
+													"adjustment1.value = -13.88;",
+													"adjustmentsArray.push(adjustment1);",
 													"",
-													"     pm.environment.set(\"negativeInvoiceLineContent\", JSON.stringify(invoiceLine));",
-													"});"
+													"let adjustment2 = utils.buildAdjustmentObject();",
+													"adjustment2.value = -14.33;",
+													"adjustmentsArray.push(adjustment2);",
+													"",
+													"invoiceLine.adjustments = adjustmentsArray;",
+													"",
+													" pm.environment.set(\"negativeInvoiceLineContent\", JSON.stringify(invoiceLine));",
+													""
 												],
 												"type": "text/javascript"
 											}
@@ -2825,19 +2825,20 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-											"    let invoice = utils.prepareInvoice(res.json().invoices[0]);",
 											"",
-											"    invoice.lockTotal = true;",
-											"    invoice.total = 12.34;",
-											"    invoice.note += \" - locked total\";",
-											"    invoice.status = \"Open\";",
+											"let invoice = utils.prepareInvoice(utils.getMockInvoice(0));",
+											"delete invoice.approvedBy;",
+											"delete invoice.approvalDate;",
+											"invoice.lockTotal = true;",
+											"invoice.total = 12.34;",
+											"invoice.note += \" - locked total\";",
+											"invoice.status = \"Open\";",
 											"",
-											"    invoice.adjustments = [];",
-											"    invoice.adjustments.push(utils.buildAdjustmentObject(10));",
+											"invoice.adjustments = [];",
+											"invoice.adjustments.push(utils.buildAdjustmentObject(10));",
 											"",
-											"    pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));",
-											"});"
+											"pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -3078,29 +3079,28 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-											"    let invoiceLine = res.json();",
+											"let invoiceLine = utils.getMockInvoiceLine();",
 											"",
-											"    delete invoiceLine.id;",
-											"    delete invoiceLine.invoiceLineNumber;",
-											"    invoiceLine.adjustments = [];",
-											"    invoiceLine.comment = \"Adding line for API testing adjustment\";",
-											"    invoiceLine.invoiceId = pm.environment.get(\"invoiceWithLockedTotalId\");",
-											"    invoiceLine.subTotal = 54.32;",
+											"delete invoiceLine.id;",
+											"delete invoiceLine.invoiceLineNumber;",
+											"invoiceLine.adjustments = [];",
+											"invoiceLine.comment = \"Adding line for API testing adjustment\";",
+											"invoiceLine.invoiceId = pm.environment.get(\"invoiceWithLockedTotalId\");",
+											"invoiceLine.subTotal = 54.32;",
 											"",
-											"    let adjustment1 = utils.buildAdjustmentObject(21.35);",
-											"    invoiceLine.adjustments.push(adjustment1);",
+											"let adjustment1 = utils.buildAdjustmentObject(21.35);",
+											"invoiceLine.adjustments.push(adjustment1);",
 											"",
-											"    // Should no affect calculations",
-											"    let adjustment2 = utils.buildAdjustmentObject();",
-											"    adjustment2.relationToTotal = \"Included in\";",
-											"    invoiceLine.adjustments.push(adjustment2);",
+											"// Should no affect calculations",
+											"let adjustment2 = utils.buildAdjustmentObject();",
+											"adjustment2.relationToTotal = \"Included in\";",
+											"invoiceLine.adjustments.push(adjustment2);",
 											"",
-											"    let adjustment3 = utils.buildAdjustmentObject(-11, \"Percentage\");",
-											"    invoiceLine.adjustments.push(adjustment3);",
+											"let adjustment3 = utils.buildAdjustmentObject(-11, \"Percentage\");",
+											"invoiceLine.adjustments.push(adjustment3);",
 											"",
-											"    pm.variables.set(\"invoiceLineContent\", JSON.stringify(invoiceLine));",
-											"});"
+											"pm.variables.set(\"invoiceLineContent\", JSON.stringify(invoiceLine));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -3238,20 +3238,20 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-											"    let invoiceLine = res.json();",
 											"",
-											"    delete invoiceLine.id;",
-											"    delete invoiceLine.invoiceLineNumber;",
-											"    invoiceLine.adjustments = [];",
-											"    invoiceLine.comment = \"Adding line for API testing adjustment\";",
-											"    invoiceLine.invoiceId = pm.environment.get(\"invoiceWithLockedTotalId\");",
-											"    invoiceLine.subTotal = 15.87;",
+											"let invoiceLine = utils.getMockInvoiceLine();",
 											"",
-											"    invoiceLine.adjustments.push(utils.buildAdjustmentObject(6.65));",
+											"delete invoiceLine.id;",
+											"delete invoiceLine.invoiceLineNumber;",
+											"invoiceLine.adjustments = [];",
+											"invoiceLine.comment = \"Adding line for API testing adjustment\";",
+											"invoiceLine.invoiceId = pm.environment.get(\"invoiceWithLockedTotalId\");",
+											"invoiceLine.subTotal = 15.87;",
 											"",
-											"    pm.variables.set(\"invoiceLineContent\", JSON.stringify(invoiceLine));",
-											"});"
+											"invoiceLine.adjustments.push(utils.buildAdjustmentObject(6.65));",
+											"",
+											"pm.variables.set(\"invoiceLineContent\", JSON.stringify(invoiceLine));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -4143,22 +4143,21 @@
 															"});",
 															"",
 															"function createLines(invoiceId) {",
-															"    pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", (err, res) => {",
-															"        let invoiceLine = utils.prepareInvoiceLine(res.json(), invoiceId);",
+															" ",
+															"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoiceId);",
 															"",
-															"        // Now creating 4 invoice lines",
-															"        for (let i = 1; i < 5; i++) {",
-															"            invoiceLine.poLineId = i % 2 === 0 ? pm.globals.get(\"poLine1Id\") : pm.globals.get(\"poLine2Id\");",
-															"            invoiceLine.releaseEncumbrance = i === 4;",
-															"            ",
-															"            utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
-															"                pm.test(\"Invoice line #\" + i + \" is created in storage\", () => {",
-															"                  pm.expect(err).to.equal(null);",
-															"                  pm.expect(response).to.have.property('code', 201);",
-															"                });",
+															"    // Now creating 4 invoice lines",
+															"    for (let i = 1; i < 5; i++) {",
+															"        invoiceLine.poLineId = i % 2 === 0 ? pm.globals.get(\"poLine1Id\") : pm.globals.get(\"poLine2Id\");",
+															"        invoiceLine.releaseEncumbrance = i === 4;",
+															"        ",
+															"        utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
+															"            pm.test(\"Invoice line #\" + i + \" is created in storage\", () => {",
+															"              pm.expect(err).to.equal(null);",
+															"              pm.expect(response).to.have.property('code', 201);",
 															"            });",
-															"        }",
-															"    });",
+															"        });",
+															"    }",
 															"}"
 														],
 														"type": "text/javascript"
@@ -4171,16 +4170,18 @@
 														"exec": [
 															"let utils = eval(globals.loadUtils);",
 															"",
-															"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-															"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
+															"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
 															"",
-															"    invoice.note += \" - with 4 lines for transition through workflow\";",
-															"    invoice.status = \"Open\";",
-															"    invoice.currency=\"EUR\";",
-															"    delete invoice.adjustments;",
+															"invoice.note += \" - with 4 lines for transition through workflow\";",
+															"invoice.status = \"Open\";",
+															"invoice.currency=\"EUR\";",
 															"",
-															"    pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
-															"});"
+															"delete invoice.adjustments;",
+															"delete invoice.approvalDate;",
+															"delete invoice.approvedBy;",
+															"",
+															"pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
+															""
 														],
 														"type": "text/javascript"
 													}
@@ -4540,17 +4541,15 @@
 															"});",
 															"",
 															"function createLine(invoiceId) {",
-															"    pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", (err, res) => {",
-															"        let invoiceLine = utils.prepareInvoiceLine(res.json(), invoiceId);",
+															"   ",
+															"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoiceId);",
 															"",
-															"        // Now creating invoice line",
-															"        utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
-															"            pm.test(\"Invoice line is created in storage\", () => {",
-															"              pm.expect(err).to.equal(null);",
-															"              pm.expect(response).to.have.property('code', 201);",
-															"            });",
+															"    // Now creating invoice line",
+															"    utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
+															"        pm.test(\"Invoice line is created in storage\", () => {",
+															"          pm.expect(err).to.equal(null);",
+															"          pm.expect(response).to.have.property('code', 201);",
 															"        });",
-															"        ",
 															"    });",
 															"}"
 														],
@@ -4564,16 +4563,17 @@
 														"exec": [
 															"let utils = eval(globals.loadUtils);",
 															"",
-															"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-															"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
+															"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
 															"",
-															"    invoice.note += \" - with 1 line for transition through workflow\";",
-															"    invoice.status = \"Open\";",
-															"    delete invoice.voucherNumber;",
-															"    delete invoice.adjustments;",
+															"invoice.note += \" - with 1 line for transition through workflow\";",
+															"invoice.status = \"Open\";",
+															"delete invoice.voucherNumber;",
+															"delete invoice.adjustments;",
+															"delete invoice.approvalDate;",
+															"delete invoice.approvedBy;",
 															"",
-															"    pm.environment.set(\"emptyConfigWorkflow-invoiceWith1LineContent\", JSON.stringify(invoice));",
-															"});"
+															"pm.environment.set(\"emptyConfigWorkflow-invoiceWith1LineContent\", JSON.stringify(invoice));",
+															""
 														],
 														"type": "text/javascript"
 													}
@@ -4850,18 +4850,17 @@
 											"});",
 											"",
 											"function createLine(invoiceId) {",
-											"    pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", (err, res) => {",
-											"        let invoiceLine = utils.prepareInvoiceLine(res.json(), invoiceId);",
 											"",
-											"        // Now creating invoice line",
-											"        utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
-											"            pm.test(\"Invoice line is created in storage\", () => {",
-											"              pm.expect(err).to.equal(null);",
-											"              pm.expect(response).to.have.property('code', 201);",
-											"            });",
+											"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoiceId);",
+											"",
+											"    // Now creating invoice line",
+											"    utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
+											"        pm.test(\"Invoice line is created in storage\", () => {",
+											"          pm.expect(err).to.equal(null);",
+											"          pm.expect(response).to.have.property('code', 201);",
 											"        });",
-											"        ",
 											"    });",
+											"",
 											"}"
 										],
 										"type": "text/javascript"
@@ -4874,16 +4873,16 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-											"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
+											"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
 											"",
-											"    invoice.note += \" - transition to Approved\";",
-											"    invoice.status = \"Reviewed\";",
-											"    delete invoice.adjustments;",
-											"    delete invoice.voucherNumber;",
+											"invoice.note += \" - transition to Approved\";",
+											"invoice.status = \"Reviewed\";",
+											"delete invoice.adjustments;",
+											"delete invoice.voucherNumber;",
+											"delete invoice.approvalDate;",
+											"delete invoice.approvedBy;",
 											"",
-											"    pm.environment.set(\"negativeReviewedToApprovedInvoiceContent\", JSON.stringify(invoice));",
-											"});"
+											"pm.environment.set(\"negativeReviewedToApprovedInvoiceContent\", JSON.stringify(invoice));"
 										],
 										"type": "text/javascript"
 									}
@@ -4943,22 +4942,21 @@
 											"    ",
 											"});",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-											"    let invoiceLine = res.json();",
-											"    invoiceLine.invoiceId = pm.environment.get(\"negativeApprovedToPaidInvoice\");",
-											"    invoiceLine.fundDistributions.forEach(distro => distro.fundId = pm.environment.get(\"fundId\"));",
-											"    delete invoiceLine.id;",
-											"    delete invoiceLine.metadata;",
-											"    var uuid = require('uuid');",
-											"    invoiceLine.poLineId = uuid.v4();",
-											"    ",
-											"    utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, function(err,response){",
-											"        pm.test(\"Invoice line is created in storage\", function(){",
-											"          pm.expect(err).to.equal(null);",
-											"        });",
-											"    });",
 											"",
-											"});"
+											"let invoiceLine = utils.getMockInvoiceLine();",
+											"invoiceLine.invoiceId = pm.environment.get(\"negativeApprovedToPaidInvoice\");",
+											"invoiceLine.fundDistributions.forEach(distro => distro.fundId = pm.environment.get(\"fundId\"));",
+											"delete invoiceLine.id;",
+											"delete invoiceLine.metadata;",
+											"var uuid = require('uuid');",
+											"invoiceLine.poLineId = uuid.v4();",
+											"",
+											"utils.sendPostRequest(\"/invoice-storage/invoice-lines\", invoiceLine, function(err,response){",
+											"    pm.test(\"Invoice line is created in storage\", function(){",
+											"      pm.expect(err).to.equal(null);",
+											"    });",
+											"});",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -4970,14 +4968,13 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-											"    let invoice = utils.prepareInvoice(res.json().invoices[1]);",
+											"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
 											"",
-											"    invoice.note += \" - transition to Paid\";",
-											"    invoice.status = \"Approved\";",
+											"invoice.note += \" - transition to Paid\";",
+											"invoice.status = \"Approved\";",
 											"",
-											"    pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
-											"});"
+											"pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -5024,16 +5021,14 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-											"    let invoice = utils.prepareInvoice(res.json().invoices[0]);",
+											"let invoice = utils.prepareInvoice(utils.getMockInvoice(0));",
 											"",
-											"    invoice.lockTotal = true;",
-											"    invoice.total = 12.34;",
-											"    invoice.note += \" - locked total\";",
-											"    invoice.status = \"Open\";",
+											"invoice.lockTotal = true;",
+											"invoice.total = 12.34;",
+											"invoice.note += \" - locked total\";",
+											"invoice.status = \"Open\";",
 											"",
-											"    pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));",
-											"});"
+											"pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));"
 										],
 										"type": "text/javascript"
 									}
@@ -5056,16 +5051,14 @@
 											"});",
 											"",
 											"function addLine(invoice) {",
-											"    pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-											"        let invoiceLine = utils.prepareInvoiceLine(res.json(), invoice.id);",
-											"        invoiceLine.poLineId = pm.globals.get(\"poLine1Id\");",
+											"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoice.id);",
+											"    invoiceLine.poLineId = pm.globals.get(\"poLine1Id\");",
 											"",
-											"        utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, function(err,response){",
-											"            pm.test(\"Invoice line is created in storage\", function(){",
-											"              pm.expect(err).to.equal(null);",
-											"              pm.expect(response).to.have.property('code', 201);",
-											"              utils.updateInvoiceStatus(invoice, \"Approved\");",
-											"            });",
+											"    utils.sendPostRequest(\"/invoice-storage/invoice-lines\", invoiceLine, function(err,response){",
+											"        pm.test(\"Invoice line is created in storage\", function(){",
+											"          pm.expect(err).to.equal(null);",
+											"          pm.expect(response).to.have.property('code', 201);",
+											"          utils.updateInvoiceStatus(invoice, \"Approved\");",
 											"        });",
 											"    });",
 											"}"
@@ -5659,14 +5652,12 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoices/invoices.json\", function (err, res) {",
-											"    let invoice = utils.prepareInvoice(res.json().invoices[0]);",
+											"let invoice = utils.prepareInvoice(utils.getMockInvoice(0));",
 											"",
-											"    delete invoice.total;",
-											"    invoice.lockTotal = true;",
+											"delete invoice.total;",
+											"invoice.lockTotal = true;",
 											"",
-											"    pm.variables.set(\"invoiceBodyWithLockedTotal\", JSON.stringify(invoice));",
-											"});"
+											"pm.variables.set(\"invoiceBodyWithLockedTotal\", JSON.stringify(invoice));"
 										],
 										"type": "text/javascript"
 									}
@@ -6540,7 +6531,7 @@
 												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"var invoiceLine = utils.buildInvoiceLineWithMinContent(pm.environment.get(\"approvedInvoiceId\"));",
+													"var invoiceLine = utils.buildInvoiceLineWithMinContent(pm.environment.get(\"invoiceId\"));",
 													"",
 													"pm.variables.set(\"approvedInvoiceInvoiceLine\", JSON.stringify(invoiceLine));"
 												],
@@ -6553,7 +6544,7 @@
 										"header": [
 											{
 												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
+												"value": "{{xokapitoken-admin}}"
 											},
 											{
 												"key": "Content-Type",
@@ -6565,14 +6556,14 @@
 											"raw": "{{approvedInvoiceInvoiceLine}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
 											],
 											"port": "{{okapiport}}",
 											"path": [
-												"invoice",
+												"invoice-storage",
 												"invoice-lines"
 											]
 										}
@@ -6680,7 +6671,6 @@
 											"        let errors = jsonData.errors;",
 											"",
 											"        requiredObj(errors, \"description\");",
-											"        requiredArray(errors, \"fundDistributions\");",
 											"        requiredObj(errors, \"invoiceId\");",
 											"        requiredObj(errors, \"invoiceLineStatus\");",
 											"        requiredObj(errors, \"subTotal\");",
@@ -6695,12 +6685,7 @@
 											"    pm.expect(error.message).to.equal(\"may not be null\");",
 											"    pm.expect(error.parameters[0].value).to.equal(\"null\");",
 											"}",
-											"",
-											"function requiredArray(errors, propName) {",
-											"    let error = errors.find((errors) => errors.parameters[0].key === propName);",
-											"    pm.expect(error.message).to.equal(\"size must be between 1 and 2147483647\");",
-											"    pm.expect(error.parameters[0].value).to.equal(\"[]\");",
-											"}"
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -7302,26 +7287,26 @@
 											"let utils = eval(globals.loadUtils);",
 											"let adjustmentsArray = [];",
 											"",
-											"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/invoice_line.json\", function (err, res) {",
-											"    let invoiceLine = res.json();",
 											"",
-											"    delete invoiceLine.id;",
-											"    delete invoiceLine.invoiceLineNumber;",
-											"    delete invoiceLine.adjustments;",
-											"    invoiceLine.comment = \"Adding line for API testing adjustment\";",
-											"    invoiceLine.invoiceId = pm.environment.get(\"invoiceId\");",
+											"let invoiceLine = utils.getMockInvoiceLine();",
 											"",
-											"    let adjustment1 = utils.buildAdjustmentObject();",
-											"    adjustmentsArray.push(adjustment1);",
-											"    ",
-											"    let adjustment2 = utils.buildAdjustmentObject();",
-											"    adjustment2.relationToTotal = \"Not Included in\";",
-											"    adjustmentsArray.push(adjustment2);",
-											"    ",
-											"    invoiceLine.adjustments = adjustmentsArray;",
+											"delete invoiceLine.id;",
+											"delete invoiceLine.invoiceLineNumber;",
+											"delete invoiceLine.adjustments;",
+											"invoiceLine.comment = \"Adding line for API testing adjustment\";",
+											"invoiceLine.invoiceId = pm.environment.get(\"invoiceId\");",
 											"",
-											"    pm.variables.set(\"invoiceLineContent\", JSON.stringify(invoiceLine));",
-											"});"
+											"let adjustment1 = utils.buildAdjustmentObject();",
+											"adjustmentsArray.push(adjustment1);",
+											"",
+											"let adjustment2 = utils.buildAdjustmentObject();",
+											"adjustment2.relationToTotal = \"Not Included in\";",
+											"adjustmentsArray.push(adjustment2);",
+											"",
+											"invoiceLine.adjustments = adjustmentsArray;",
+											"",
+											"pm.variables.set(\"invoiceLineContent\", JSON.stringify(invoiceLine));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -7356,6 +7341,71 @@
 									]
 								},
 								"description": "Tests the adjustments calculations \n1.with amount and Percentage \n2.only \"In addition to\" relationToTotal adjustments are included in the calculation"
+							},
+							"response": []
+						},
+						{
+							"name": "Create invoice-line for approved invoice",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let error = {};",
+											"",
+											"pm.test(\"Can't add invoice line to the invoice that has been approved\", function () {",
+											"    pm.response.to.have.status(500);",
+											"    error = pm.response.json().errors[0];",
+											"    pm.expect(error.code).to.equal(\"prohibitedInvoiceLineCreation\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var invoiceLine = utils.buildInvoiceLineWithMinContent(pm.environment.get(\"negativeApprovedToPaidInvoice\"));",
+											"",
+											"pm.variables.set(\"approvedInvoiceInvoiceLine\", JSON.stringify(invoiceLine));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-admin}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{approvedInvoiceInvoiceLine}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines"
+									]
+								}
 							},
 							"response": []
 						}
@@ -9487,6 +9537,16 @@
 					"    utils.copyJsonObj = function(obj) {",
 					"        return JSON.parse(JSON.stringify(obj));",
 					"    };",
+					"    ",
+					"    utils.getMockInvoiceLine = function() {",
+					"        return JSON.parse(pm.globals.get(\"mock-invoiceLine\"));",
+					"    }",
+					"    ",
+					"    utils.getMockInvoice = function(i) {",
+					"        let invoices = JSON.parse(pm.globals.get(\"mock-invoices\"));",
+					"        return invoices.invoices[i];",
+					"    }",
+					"    ",
 					"",
 					"    /**",
 					"     * Creates OKAPI URL endpoint based on provided path",
@@ -9860,7 +9920,9 @@
 					"        pm.environment.unset(\"current-orders-configs\");",
 					"        pm.environment.unset(\"negativeAdjInLineId\");",
 					"        pm.environment.unset(\"negativeInvoiceLineContent\");",
-					"",
+					"        ",
+					"        pm.globals.unset(\"mock-invoices\");",
+					"        pm.globals.unset(\"mock-invoiceLine\");",
 					"        pm.globals.unset(\"testData\");",
 					"        pm.globals.unset(\"loadUtils\");",
 					"",
@@ -10074,37 +10136,37 @@
 	],
 	"variable": [
 		{
-			"id": "b766e669-3ce2-4602-8d18-f1c2efab5d85",
+			"id": "c8d4ec80-3dc7-49d1-a837-e6d09e8b3abb",
 			"key": "resourcesUrl",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-invoice/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "395e5d56-903b-4c6e-ac34-35ac824e996b",
+			"id": "dafc13d3-e034-40d2-bb6c-edd7837bb06f",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "865bddee-8d9e-4ed2-9c5d-e96e24ec87d0",
+			"id": "64dd8a40-8a94-4f98-be32-db1fdebff344",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "4f1d14e9-0fc8-47c2-bc9a-09b04ee18b4d",
+			"id": "1faec719-af75-44c5-bd0b-3e68cbbb971f",
 			"key": "finance-ledgerCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "ccad09da-f6a5-4d28-9326-3d7b06caed73",
+			"id": "6bba47ce-d894-4df8-a78a-fb112d0be7c0",
 			"key": "finance-fundCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "cd0c9d5f-030a-4c6a-a6cb-78b12de9971a",
+			"id": "e2f1a94c-7f9c-4fe0-b7e3-10f5feaa4b60",
 			"key": "voucherNumberPrefix",
 			"value": "testPrefix",
 			"type": "string"


### PR DESCRIPTION
- loading mock for invoices and invoiceLines once, keeping them in global variables and reusing if needed
- adding negative case to verify that it is not allowed to add invoice line for approved invoice

collection run locally:
![image](https://user-images.githubusercontent.com/41672277/61077276-b55d1680-a426-11e9-80b2-5cc85d6c8b71.png)
