### PR TITLE
MODORDERS-256 Restrict search for PO, POL, Piece records based upon acquisitions unit

### DIFF
--- a/mod-orders/README.md
+++ b/mod-orders/README.md
@@ -1,8 +1,10 @@
-## Introduction
+# Introduction
 
 This is the API Tests (Postman Collection) for [mod-orders](https://github.com/folio-org/mod-orders/blob/master/README.md) module.
 
-## Additional information
+# Collections
+## [mod-orders](mod-orders.postman_collection.json)
+The collection contents set of tests to verify `orders` APIs and different workflows
 
 ### Collection structure
 
@@ -53,11 +55,43 @@ Variable | Initial Value | Description
 
 The functions and request body templates are defined in the `Pre-request Scripts` section of the collection. The main idea is to create reusable functions to not duplicate the same logic in the tests.
 
-### Issue tracker
+## [mod-orders-acq-units](mod-orders-acq-units.postman_collection.json)
+The collection contents set of tests to verify `orders` APIs behavior depending on acquisition unit(s) assignment
+
+### Collection structure
+Folder | Description  
+--- | --- 
+`Setup` | Contains various preparation requests/operations required for test runs
+`- Create tenant and enable modules` | Creates new tenant for API tests, enables required modules and creates admin user for this tenant
+`- Update configs` | Update PO Lines limit (based on variable with default value 10);
+`- Prepare required external data` | Prepares data in the external modules e.g. active vendor
+`- Create units` | Creates test acq units
+`- Create regular users` | Creates user with orders permissions
+`- Setup new tenant` | Create new tenant to verify tenant-specific logic
+`Positive Tests` | Contains various requests and tests to verify success cases
+`Cleanup` | Deletes test tenant
+
+### Collection variables
+
+Variable | Initial Value | Description  
+ --- | --- | --- 
+`mod-ordersResourcesURL` | https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources | Path to mod-orders test resources
+`poLines-limit` | 10 | Purchase Order Lines Limit to be used for configuration update
+`testTenant` | orders_acq_units_test | Tenant identifier which is going to be used (created) for API tests
+
+### Collection utility functions
+
+The functions and request body templates are defined in the `Pre-request Scripts` section of the collection.
+
+### Known limitations 
+Once the collection run is completed, the second one might fail. The reason is that when DB schemas are deleted for test tenant, some modules still keep open DB connection in pool for a minute (please refer to [AsyncConnectionPool.java](https://github.com/folio-org/vertx-mysql-postgresql-client/blob/release-connection-pool-3-5-1-folio-1/src/main/java/io/vertx/ext/asyncsql/impl/pool/AsyncConnectionPool.java#L52)). When test tenant is created again in less then 1 min after previous run, the module's connection from pool cannot access DB schema because it is recreated but the connection still tries to access "old" DB schema.  
+To avoid this issue, either wait for at least 1 minute after previous run completed or change `testTenant` collection level variable to some new value.
+
+# Issue tracker
 
 See project [MODORDERS](https://issues.folio.org/browse/MODORDERS) at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
-### Other documentation
+# Other documentation
 
  * [Conduct API testing](https://dev.folio.org/guides/api-testing/)
  * Other [modules](https://dev.folio.org/source-code/#server-side) are described, with further FOLIO Developer documentation at [dev.folio.org](https://dev.folio.org/)

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "faa905f9-2cbc-4349-8b1e-ce3f3643c3a1",
+		"_postman_id": "d92105d2-221a-45b8-aabb-5d0b3044e25e",
 		"name": "mod-orders-acq-units",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -220,23 +220,7 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"let user = globals.testData.users.admin.user;",
-											"utils.sendGetRequest(\"/users/\" + user.id, (err, res) => {",
-											"    pm.test(\"Check if user for API Tests already exists\", () => {",
-											"        pm.expect(err).to.equal(null);",
-											"        pm.expect(res.code).to.be.oneOf([200, 404]);",
-											"        // If user already exists, check if this is for API Tests and delete it",
-											"        if (res.code === 200 && res.json().username) {",
-											"            utils.sendDeleteRequest(\"/users/\" + user.id, (err, res) => {",
-											"                pm.test(\"User '\" + user.username + \"' deleted\", () => {",
-											"                    pm.expect(res.code).to.eql(204);",
-											"                });",
-											"            });",
-											"        }",
-											"    });",
-											"});",
-											"",
-											"pm.variables.set(\"userData\", JSON.stringify(user));"
+											"pm.variables.set(\"userData\", JSON.stringify(globals.testData.users.admin.user));"
 										],
 										"type": "text/javascript"
 									}
@@ -670,6 +654,77 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "Prepare required external data",
+					"item": [
+						{
+							"name": "Create vendor",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Vendor is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.environment.set(\"activeVendorId\", pm.response.json().id);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"name\": \"Test active vendor\",\n\t\"code\": \"TAV\",\n\t\"isVendor\": true,\n\t\"status\" : \"Active\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"organizations-storage",
+										"organizations"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "Create units",
 					"item": [
 						{
@@ -817,23 +872,7 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"let user = globals.testData.users.regular.user;",
-											"utils.sendGetRequest(\"/users/\" + user.id, (err, res) => {",
-											"    pm.test(\"Check if user for API Tests already exists\", () => {",
-											"        pm.expect(err).to.equal(null);",
-											"        pm.expect(res.code).to.be.oneOf([200, 404]);",
-											"        // If user already exists, check if this is for API Tests and delete it",
-											"        if (res.code === 200 && res.json().username) {",
-											"            utils.sendDeleteRequest(\"/users/\" + user.id, (err, res) => {",
-											"                pm.test(\"User '\" + user.username + \"' deleted\", () => {",
-											"                    pm.expect(res.code).to.eql(204);",
-											"                });",
-											"            });",
-											"        }",
-											"    });",
-											"});",
-											"",
-											"pm.variables.set(\"userData\", JSON.stringify(user));"
+											"pm.variables.set(\"userData\", JSON.stringify(globals.testData.users.regular.user));"
 										],
 										"type": "text/javascript"
 									}
@@ -909,18 +948,6 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"let user = globals.testData.users.regular.user;",
-											"utils.sendGetRequest(\"/authn/credentials?query=userId=\" + user.id, (err, res) => {",
-											"    // If user already has credentials and delete them to create fresh each time",
-											"    if (res.code === 200 && res.json().totalRecords > 0) {",
-											"        utils.sendDeleteRequest(\"/authn/credentials/\" + res.json().credentials[0].id, (err, res) => {",
-											"            pm.test(user.username + \" user's credentials deleted\", () => {",
-											"                pm.expect(res.code).to.eql(204);",
-											"            });",
-											"        });",
-											"    }",
-											"});",
-											"",
 											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
 										],
 										"type": "text/javascript"
@@ -980,19 +1007,7 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"utils.sendGetRequest(\"/perms/users?query=userId==\" + globals.testData.users.regular.user.id, (err, res) => {",
-											"    // If user already has permissions and delete them to create fresh each time",
-											"    if (res.code === 200 && res.json().totalRecords > 0) {",
-											"        utils.sendDeleteRequest(\"/perms/users/\" + res.json().permissionUsers[0].id, (err, res) => {",
-											"            pm.test(globals.testData.users.admin.user.username + \" user's permissions deleted\", () => {",
-											"                pm.expect(res.code).to.eql(204);",
-											"            });",
-											"        });",
-											"    }",
-											"});",
-											"",
-											"pm.variables.set(\"userPermissions\", JSON.stringify(globals.testData.users.regular.permissions));",
-											""
+											"pm.variables.set(\"userPermissions\", JSON.stringify(globals.testData.users.regular.permissions));"
 										],
 										"type": "text/javascript"
 									}
@@ -1104,7 +1119,7 @@
 			"name": "Positive Tests",
 			"item": [
 				{
-					"name": "Create Draft order with 2 lines",
+					"name": "Create Open order with 1 line",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -1114,7 +1129,11 @@
 									"let utils = eval(globals.loadUtils);",
 									"",
 									"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
-									"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(utils.prepareOrder(res.json())));",
+									"    let order = utils.prepareOrder(res.json());",
+									"    // Set Open status and leave only one line",
+									"    order.compositePoLines.pop();",
+									"    order.workflowStatus = \"Open\";",
+									"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(order));",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1130,6 +1149,74 @@
 									"    let jsonData = pm.response.json();",
 									"    pm.expect(jsonData.id).to.exist;",
 									"    pm.environment.set(\"firstOrderId\", jsonData.id); ",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{po_listed_print_monograph}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"composite-orders"
+							]
+						},
+						"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders"
+					},
+					"response": []
+				},
+				{
+					"name": "Create Draft order with 2 lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
+									"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(utils.prepareOrder(res.json())));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"Order is created\", function () {",
+									"    pm.response.to.have.status(201);",
+									"    let jsonData = pm.response.json();",
+									"    pm.expect(jsonData.id).to.exist;",
+									"    pm.environment.set(\"secondOrderId\", jsonData.id); ",
 									"});",
 									""
 								],
@@ -1189,62 +1276,7 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
-									"pm.test(\"1 order found\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.totalRecords).to.eql(1);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							}
-						],
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"orders",
-								"composite-orders"
-							]
-						},
-						"description": "GET /orders/composite-orders/id requests that return 200"
-					},
-					"response": []
-				},
-				{
-					"name": "Get list of lines",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-								"exec": [
-									"pm.test(\"2 lines found\", function () {",
+									"pm.test(\"2 orders should be found\", function () {",
 									"    var jsonData = pm.response.json();",
 									"    pm.expect(jsonData.totalRecords).to.eql(2);",
 									"});"
@@ -1266,7 +1298,68 @@
 							}
 						],
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?query=cql.allRecords=1 sortBy poNumber/sort.ascending",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"composite-orders"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "cql.allRecords=1 sortBy poNumber/sort.ascending"
+								}
+							]
+						},
+						"description": "There is no any order with assigned acq unit"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"3 lines should be found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(3);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?query=cql.allRecords=1 sortBy poLineNumber/sort.ascending",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -1275,6 +1368,12 @@
 							"path": [
 								"orders",
 								"order-lines"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "cql.allRecords=1 sortBy poLineNumber/sort.ascending"
+								}
 							]
 						},
 						"description": "GET /orders/orders/order-lines requests that return 200"
@@ -1282,15 +1381,76 @@
 					"response": []
 				},
 				{
-					"name": "Assign fully protected unit to order",
+					"name": "Get list of pieces",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"4 pieces should be found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(4);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=cql.allRecords=1 sortBy title/sort.ascending",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"receiving-history"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "cql.allRecords=1 sortBy title/sort.ascending"
+								}
+							]
+						},
+						"description": "GET /orders/orders/order-lines requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Assign fully protected unit to an order",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
 								"exec": [
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
+									"pm.test(\"Order is updated successfully\", function () {",
+									"    pm.response.to.have.status(204);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1303,14 +1463,24 @@
 								"exec": [
 									"let utils = eval(globals.loadUtils);",
 									"",
-									"pm.variables.set(\"assignmentBody\", JSON.stringify(utils.buildAssignmentContent(pm.environment.get(\"firstOrderId\"), pm.environment.get(\"fullyProtectedUnitId\"))));"
+									"utils.sendGetRequest(\"/orders/composite-orders/\" + pm.environment.get(\"firstOrderId\"), (err, res) => {",
+									"    pm.test(\"Order is successfully retrieved and ready for updates\", () => {",
+									"        pm.expect(err).to.equal(null);",
+									"        pm.expect(res).to.have.property('code', 200);",
+									"",
+									"        // Assign unit to an order",
+									"        let order = res.json();",
+									"        order.acqUnitIds.push(pm.environment.get(\"fullyProtectedUnitId\"));",
+									"        pm.variables.set(\"orderBody\", JSON.stringify(order));",
+									"    });",
+									"});"
 								],
 								"type": "text/javascript"
 							}
 						}
 					],
 					"request": {
-						"method": "POST",
+						"method": "PUT",
 						"header": [
 							{
 								"key": "x-okapi-token",
@@ -1326,10 +1496,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{{assignmentBody}}\r\n"
+							"raw": "{{orderBody}}"
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{firstOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -1337,7 +1507,8 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"orders",
-								"acquisitions-unit-assignments"
+								"composite-orders",
+								"{{firstOrderId}}"
 							]
 						}
 					},
@@ -1361,9 +1532,9 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
-									"pm.test(\"No orders found\", function () {",
+									"pm.test(\"Only one order should be found\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.totalRecords).to.eql(0);",
+									"    pm.expect(jsonData.totalRecords).to.eql(1);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1383,7 +1554,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?query=approved==false or approved==true sortBy poNumber/sort.ascending",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -1392,9 +1563,15 @@
 							"path": [
 								"orders",
 								"composite-orders"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "approved==false or approved==true sortBy poNumber/sort.ascending"
+								}
 							]
 						},
-						"description": "GET /orders/composite-orders/id requests that return 200"
+						"description": "One order is now protected so user should not get it in the response"
 					},
 					"response": []
 				},
@@ -1416,9 +1593,9 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
-									"pm.test(\"No lines found\", function () {",
+									"pm.test(\"2 lines should be found\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.totalRecords).to.eql(0);",
+									"    pm.expect(jsonData.totalRecords).to.eql(2);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1438,7 +1615,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?query=approved==false or approved==true sortBy poLineNumber/sort.ascending",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -1447,9 +1624,76 @@
 							"path": [
 								"orders",
 								"order-lines"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "approved==false or approved==true sortBy poLineNumber/sort.ascending"
+								}
 							]
 						},
 						"description": "GET /orders/orders/order-lines requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of pieces",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"4 pieces should be found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.receivingHistory).to.be.empty;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=cql.allRecords=1 sortBy title/sort.ascending",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"receiving-history"
+							],
+							"query": [
+								{
+									"key": "query",
+									"value": "cql.allRecords=1 sortBy title/sort.ascending"
+								}
+							]
+						},
+						"description": "Open order is now protected"
 					},
 					"response": []
 				},
@@ -1532,9 +1776,9 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
-									"pm.test(\"1 order found\", function () {",
+									"pm.test(\"2 orders should be found\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.totalRecords).to.eql(1);",
+									"    pm.expect(jsonData.totalRecords).to.eql(2);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1587,9 +1831,9 @@
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 								"exec": [
-									"pm.test(\"2 lines found\", function () {",
+									"pm.test(\"3 lines should be found\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.totalRecords).to.eql(2);",
+									"    pm.expect(jsonData.totalRecords).to.eql(3);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1618,6 +1862,61 @@
 							"path": [
 								"orders",
 								"order-lines"
+							]
+						},
+						"description": "GET /orders/orders/order-lines requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of pieces",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"4 pieces should be found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(4);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"receiving-history"
 							]
 						},
 						"description": "GET /orders/orders/order-lines requests that return 200"
@@ -1758,7 +2057,10 @@
 										"exec": [
 											"pm.test(\"Tenant deleted - Expected Created (204)\", () => {",
 											"    pm.response.to.have.status(204);",
-											"});"
+											"});",
+											"",
+											"// Remove all created variables",
+											"eval(globals.loadUtils).unsetTestVariables();"
 										],
 										"type": "text/javascript"
 									}
@@ -1948,6 +2250,7 @@
 					"        delete order.totalItems;",
 					"        delete order.poNumber;",
 					"        order.workflowStatus = \"Pending\";",
+					"        order.vendor = pm.environment.get(\"activeVendorId\");",
 					"",
 					"        for (var i = 0; i < order.compositePoLines.length; i++) {",
 					"            utils.preparePoLine(order.compositePoLines[i]);",
@@ -1963,8 +2266,18 @@
 					"        delete poLine.id;",
 					"        delete poLine.purchaseOrderId;",
 					"        delete poLine.receiptDate;",
+					"        delete poLine.fundDistribution;",
 					"        utils._deleteSubObjectsIds(poLine.alerts);",
 					"        utils._deleteSubObjectsIds(poLine.reportingCodes);",
+					"",
+					"        if (poLine.hasOwnProperty(\"eresource\")) {",
+					"            poLine.eresource.accessProvider = pm.environment.get(\"activeVendorId\");",
+					"            poLine.eresource.createInventory = \"None\";",
+					"        }",
+					"        if (poLine.hasOwnProperty(\"physical\")) {",
+					"            poLine.physical.createInventory = \"None\";",
+					"        }",
+					"",
 					"        return poLine;",
 					"    };",
 					"",
@@ -2061,8 +2374,15 @@
 					"        pm.globals.unset(\"testData\");",
 					"        pm.globals.unset(\"loadUtils\");",
 					"",
+					"        pm.environment.unset(\"activeVendorId\");",
+					"        pm.environment.unset(\"enabledModules\");",
+					"        pm.environment.unset(\"firstOrderId\");",
+					"        pm.environment.unset(\"fullyProtectedUnitId\");",
+					"        pm.environment.unset(\"readOpenUnitId\");",
+					"        pm.environment.unset(\"secondOrderId\");",
 					"        pm.environment.unset(\"xokapitoken\");",
 					"        pm.environment.unset(\"xokapitoken-admin\");",
+					"        pm.environment.unset(\"xokapitoken-testAdmin\");",
 					"    };",
 					"",
 					"    /**",
@@ -2093,19 +2413,19 @@
 	],
 	"variable": [
 		{
-			"id": "edc107df-31da-495e-9e15-cc8270429888",
+			"id": "21d2b5ad-736c-469d-bbfe-c75392a5ce46",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "e34f550c-13ed-4435-8160-331d85ce4b9d",
+			"id": "ae6aa0de-a6e0-42fc-b82e-1fb97486df82",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "11a904b7-ed5b-45ff-9401-a75adf0a6f71",
+			"id": "a1d767b6-a235-42c5-89ca-6c7c051e5332",
 			"key": "testTenant",
 			"value": "orders_acq_units_test",
 			"type": "string"

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -1,0 +1,2114 @@
+{
+	"info": {
+		"_postman_id": "faa905f9-2cbc-4349-8b1e-ce3f3643c3a1",
+		"name": "mod-orders-acq-units",
+		"description": "Tests for mod-orders",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Setup",
+			"item": [
+				{
+					"name": "Create tenant and enable modules",
+					"item": [
+						{
+							"name": "Login by existing admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.environment.set(\"xokapitoken-admin\", postman.getResponseHeader(\"x-okapi-token\"));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{  \r\n   \"username\":\"{{username}}\",\r\n   \"password\":\"{{password}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"login"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create new tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"tenantData\", JSON.stringify(globals.testData.tenant));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
+										"exec": [
+											"// In case the tenant was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"Tenant created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-admin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{tenantData}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Enable modules for new tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.getModuleId(\"mod-orders\", bodyHandler);",
+											"utils.getModuleId(\"mod-login\", bodyHandler);",
+											"utils.getModuleId(\"mod-permissions\", bodyHandler);",
+											"",
+											"var modulesToEnable = [];",
+											"",
+											"function bodyHandler(moduleId) {",
+											"\tmodulesToEnable.push({",
+											"\t\t\"id\" : moduleId,",
+											"\t\t\"action\": \"enable\"",
+											"\t});",
+											"    pm.variables.set(\"modulesToEnable\", JSON.stringify(modulesToEnable));",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"postman.setNextRequest(null);",
+											"pm.test(\"Enabled required modules\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"enabledModules\", pm.response.json());",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToEnable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create admin user",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "76c0a072-8ef6-4371-b926-f56d6a3218a0",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let user = globals.testData.users.admin.user;",
+											"utils.sendGetRequest(\"/users/\" + user.id, (err, res) => {",
+											"    pm.test(\"Check if user for API Tests already exists\", () => {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(res.code).to.be.oneOf([200, 404]);",
+											"        // If user already exists, check if this is for API Tests and delete it",
+											"        if (res.code === 200 && res.json().username) {",
+											"            utils.sendDeleteRequest(\"/users/\" + user.id, (err, res) => {",
+											"                pm.test(\"User '\" + user.username + \"' deleted\", () => {",
+											"                    pm.expect(res.code).to.eql(204);",
+											"                });",
+											"            });",
+											"        }",
+											"    });",
+											"});",
+											"",
+											"pm.variables.set(\"userData\", JSON.stringify(user));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d98143bb-5fc0-4394-ac89-bff8d0df33fe",
+										"exec": [
+											"// In case the user was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"User created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userData}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create credentials for admin user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "5542417e-4b64-431c-8b07-7f5b5e9179ff",
+										"exec": [
+											"pm.test(globals.testData.users.admin.user.username + \" user's credentials created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "de3203a8-0abe-4599-aee0-b34306d051de",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let user = globals.testData.users.admin.user;",
+											"utils.sendGetRequest(\"/authn/credentials?query=userId=\" + user.id, (err, res) => {",
+											"    // If user already has credentials and delete them to create fresh each time",
+											"    if (res.code === 200 && res.json().totalRecords > 0) {",
+											"        utils.sendDeleteRequest(\"/authn/credentials/\" + res.json().credentials[0].id, (err, res) => {",
+											"            pm.test(user.username + \" user's credentials deleted\", () => {",
+											"                pm.expect(res.code).to.eql(204);",
+											"            });",
+											"        });",
+											"    }",
+											"});",
+											"",
+											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.admin.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"credentials"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add all permissions to admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1f1202b1-b74a-46cc-8fcd-e5d9b76d53b7",
+										"exec": [
+											"pm.test(globals.testData.users.admin.user.username + \" user's permissions created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "dded3598-c238-487d-b06c-721c60509cf4",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.sendGetRequest(\"/perms/users?query=userId==\" + globals.testData.users.admin.user.id, (err, res) => {",
+											"    // If user already has permissions and delete them to create fresh each time",
+											"    if (res.code === 200 && res.json().totalRecords > 0) {",
+											"        utils.sendDeleteRequest(\"/perms/users/\" + res.json().permissionUsers[0].id, (err, res) => {",
+											"            pm.test(globals.testData.users.admin.user.username + \" user's permissions deleted\", () => {",
+											"                pm.expect(res.code).to.eql(204);",
+											"            });",
+											"        });",
+											"    }",
+											"});",
+											"",
+											"utils.sendGetRequest('/perms/permissions?length=1000&query=(subPermissions=\"\" NOT subPermissions ==/respectAccents []) and (cql.allRecords=1 NOT childOf <>/respectAccents [])', (err, res) => {",
+											"        let userPermissions = globals.testData.users.admin.permissions;",
+											"        userPermissions.permissions = res.json().permissions.map(perm => perm.permissionName);",
+											"        pm.variables.set(\"userPermissions\", JSON.stringify(userPermissions));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userPermissions}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"perms",
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Enable mod-authtoken for new tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.getModuleId(\"mod-authtoken\", bodyHandler);",
+											"",
+											"var modulesToEnable = [];",
+											"",
+											"function bodyHandler(moduleId) {",
+											"\tmodulesToEnable.push({",
+											"\t\t\"id\" : moduleId,",
+											"\t\t\"action\": \"enable\"",
+											"\t});",
+											"    pm.variables.set(\"modulesToEnable\", JSON.stringify(modulesToEnable));",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"postman.setNextRequest(null);",
+											"pm.test(\"Enabled mod-orders with all dependencies\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"enabledModules\", pm.response.json());",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToEnable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Login by new admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"// In case the new user cannot be logged in no sense to run further tests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});",
+											"",
+											"pm.environment.set(\"xokapitoken-testAdmin\", postman.getResponseHeader(\"x-okapi-token\"));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a59f5097-d5cb-4e46-8bf6-3bddff268e65",
+										"exec": [
+											"pm.variables.set(\"newUserCreds\", JSON.stringify(globals.testData.users.admin.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{newUserCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"login"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Update configs",
+					"item": [
+						{
+							"name": "Check configs and update",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let testConfigs = globals.testData.configs;",
+											"",
+											"testConfigs.configNames.forEach(configName => utils.createOrdersConfig(configName));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=module==ORDERS",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"configurations",
+										"entries"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "module==ORDERS"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "0f0c2518-826f-44fb-ab7e-11157f1e7187",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "b82ea9c5-8f62-4a16-bf56-907e3dcb4662",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Create units",
+					"item": [
+						{
+							"name": "Fully protected",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.unit;",
+											"body.name += \" - Fully protected\";",
+											"",
+											"pm.variables.set(\"unitBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"fullyProtectedUnitId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{unitBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Read open",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.unit;",
+											"body.name += \" - Read open\";",
+											"body.protectRead = false;",
+											"",
+											"pm.variables.set(\"unitBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"readOpenUnitId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{unitBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Create regular users",
+					"item": [
+						{
+							"name": "Create user",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "76c0a072-8ef6-4371-b926-f56d6a3218a0",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let user = globals.testData.users.regular.user;",
+											"utils.sendGetRequest(\"/users/\" + user.id, (err, res) => {",
+											"    pm.test(\"Check if user for API Tests already exists\", () => {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(res.code).to.be.oneOf([200, 404]);",
+											"        // If user already exists, check if this is for API Tests and delete it",
+											"        if (res.code === 200 && res.json().username) {",
+											"            utils.sendDeleteRequest(\"/users/\" + user.id, (err, res) => {",
+											"                pm.test(\"User '\" + user.username + \"' deleted\", () => {",
+											"                    pm.expect(res.code).to.eql(204);",
+											"                });",
+											"            });",
+											"        }",
+											"    });",
+											"});",
+											"",
+											"pm.variables.set(\"userData\", JSON.stringify(user));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d98143bb-5fc0-4394-ac89-bff8d0df33fe",
+										"exec": [
+											"// In case the user was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"User created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userData}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create credentials for user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "5542417e-4b64-431c-8b07-7f5b5e9179ff",
+										"exec": [
+											"pm.test(globals.testData.users.regular.user.username + \" user's credentials created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "de3203a8-0abe-4599-aee0-b34306d051de",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let user = globals.testData.users.regular.user;",
+											"utils.sendGetRequest(\"/authn/credentials?query=userId=\" + user.id, (err, res) => {",
+											"    // If user already has credentials and delete them to create fresh each time",
+											"    if (res.code === 200 && res.json().totalRecords > 0) {",
+											"        utils.sendDeleteRequest(\"/authn/credentials/\" + res.json().credentials[0].id, (err, res) => {",
+											"            pm.test(user.username + \" user's credentials deleted\", () => {",
+											"                pm.expect(res.code).to.eql(204);",
+											"            });",
+											"        });",
+											"    }",
+											"});",
+											"",
+											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"credentials"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add orders permissions to user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1f1202b1-b74a-46cc-8fcd-e5d9b76d53b7",
+										"exec": [
+											"pm.test(globals.testData.users.regular.user.username + \" user's permissions created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "dded3598-c238-487d-b06c-721c60509cf4",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.sendGetRequest(\"/perms/users?query=userId==\" + globals.testData.users.regular.user.id, (err, res) => {",
+											"    // If user already has permissions and delete them to create fresh each time",
+											"    if (res.code === 200 && res.json().totalRecords > 0) {",
+											"        utils.sendDeleteRequest(\"/perms/users/\" + res.json().permissionUsers[0].id, (err, res) => {",
+											"            pm.test(globals.testData.users.admin.user.username + \" user's permissions deleted\", () => {",
+											"                pm.expect(res.code).to.eql(204);",
+											"            });",
+											"        });",
+											"    }",
+											"});",
+											"",
+											"pm.variables.set(\"userPermissions\", JSON.stringify(globals.testData.users.regular.permissions));",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userPermissions}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"perms",
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Login by new user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"// In case the new user cannot be logged in no sense to run further tests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});",
+											"",
+											"pm.environment.set(\"xokapitoken\", postman.getResponseHeader(\"x-okapi-token\"));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a59f5097-d5cb-4e46-8bf6-3bddff268e65",
+										"exec": [
+											"pm.variables.set(\"newUserCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{newUserCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"login"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
+		},
+		{
+			"name": "Positive Tests",
+			"item": [
+				{
+					"name": "Create Draft order with 2 lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
+									"    pm.globals.set(\"po_listed_print_monograph\", JSON.stringify(utils.prepareOrder(res.json())));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"Order is created\", function () {",
+									"    pm.response.to.have.status(201);",
+									"    let jsonData = pm.response.json();",
+									"    pm.expect(jsonData.id).to.exist;",
+									"    pm.environment.set(\"firstOrderId\", jsonData.id); ",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{po_listed_print_monograph}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"composite-orders"
+							]
+						},
+						"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of orders",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"1 order found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(1);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"composite-orders"
+							]
+						},
+						"description": "GET /orders/composite-orders/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"2 lines found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"order-lines"
+							]
+						},
+						"description": "GET /orders/orders/order-lines requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Assign fully protected unit to order",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"pm.variables.set(\"assignmentBody\", JSON.stringify(utils.buildAssignmentContent(pm.environment.get(\"firstOrderId\"), pm.environment.get(\"fullyProtectedUnitId\"))));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"type": "text",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{assignmentBody}}\r\n"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/acquisitions-unit-assignments",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"acquisitions-unit-assignments"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of orders",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"No orders found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(0);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"composite-orders"
+							]
+						},
+						"description": "GET /orders/composite-orders/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"No lines found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(0);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"order-lines"
+							]
+						},
+						"description": "GET /orders/orders/order-lines requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Assign user to protected unit",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let body = {};",
+									"",
+									"body.userId = globals.testData.users.regular.user.id;",
+									"body.acquisitionsUnitId = pm.environment.get(\"fullyProtectedUnitId\");",
+									"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken-testAdmin}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{membershipBody}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"acquisitions-units",
+								"memberships"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of orders",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"1 order found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(1);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"composite-orders"
+							]
+						},
+						"description": "GET /orders/composite-orders/id requests that return 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of lines",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"pm.test(\"2 lines found\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.totalRecords).to.eql(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"order-lines"
+							]
+						},
+						"description": "GET /orders/orders/order-lines requests that return 200"
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "eabc0e99-5321-4b94-8073-c1009945649c",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "42e30b13-2d65-40cc-871d-b736930858cb",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Cleanup",
+			"item": [
+				{
+					"name": "Cleanup test tenant",
+					"item": [
+						{
+							"name": "Purge and disable all module for created tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.sendRequest(utils.buildOkapiUrl(\"/_/proxy/tenants/\" + pm.variables.get(\"testTenant\") + \"/modules\"), (err, res) => {",
+											"    pm.test(\"Preparing request to disable modules\", () => {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(res.code).to.equal(200);",
+											"        let modulesToDisable = res.json();",
+											"        modulesToDisable.forEach(entry => entry.action = \"disable\");",
+											"",
+											"        console.log(modulesToDisable);",
+											"        pm.variables.set(\"modulesToDisable\", JSON.stringify(modulesToDisable));",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Disable all modules for test tenant\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Okapi-Token",
+										"value": "{{xokapitoken-admin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToDisable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install?purge=true",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									],
+									"query": [
+										{
+											"key": "purge",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete test tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
+										"exec": [
+											"pm.test(\"Tenant deleted - Expected Created (204)\", () => {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-admin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "29271af0-d608-4fd0-a6d0-7f47697b19ba",
+				"type": "text/javascript",
+				"exec": [
+					"const testData = {",
+					"    // mod-configuration",
+					"    configs: {",
+					"        configNames: [\"poLines-limit\"],",
+					"        bodyTemplate: {",
+					"            \"module\": \"ORDERS\",",
+					"            \"configName\": \"Test Config\",",
+					"            \"description\": \"Config for API Tests\",",
+					"            \"default\": true,",
+					"            \"enabled\": true,",
+					"            \"value\": \"\"",
+					"        }",
+					"    },",
+					"    unit: {",
+					"        name: \"ACQ units API tests\",",
+					"        protectCreate: true,",
+					"        protectRead: true,",
+					"        protectUpdate: true,",
+					"        protectDelete: true",
+					"    },",
+					"    // User template with hardcoded id",
+					"    users: {",
+					"        admin: {",
+					"            user: {",
+					"                \"id\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"username\": \"admin-user\",",
+					"                \"active\": true,",
+					"                \"personal\": {",
+					"                    \"firstName\": \"Orders API - Admin\",",
+					"                    \"lastName\": \"Orders Tests - Admin\"",
+					"                }",
+					"            },",
+					"            credentials: {",
+					"                \"username\": \"admin-user\",",
+					"                \"password\": \"admin-user-password\"",
+					"            },",
+					"            permissions: {",
+					"                \"userId\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"permissions\": [",
+					"                    \"orders.all\"",
+					"                ]",
+					"            }",
+					"        },",
+					"        regular: {",
+					"            user: {",
+					"                \"id\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"username\": \"mod-orders-user\",",
+					"                \"active\": true,",
+					"                \"personal\": {",
+					"                    \"firstName\": \"Orders API\",",
+					"                    \"lastName\": \"Orders Tests\"",
+					"                }",
+					"            },",
+					"            credentials: {",
+					"                \"username\": \"mod-orders-user\",",
+					"                \"password\": \"mod-orders-user-password\"",
+					"            },",
+					"            permissions: {",
+					"                \"userId\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"permissions\": [",
+					"                    \"orders.all\"",
+					"                ]",
+					"            }",
+					"        }",
+					"    },",
+					"    tenant: {",
+					"        \"id\": pm.variables.get(\"testTenant\"),",
+					"        \"name\": \"Test orders tenant\",",
+					"        \"description\": \"Tenant for test purpose\"",
+					"    }",
+					"",
+					"};",
+					"",
+					"// Global testing object - used in further tests",
+					"pm.globals.set(\"testData\", testData);",
+					"",
+					"postman.setGlobalVariable(\"loadUtils\", function loadUtils() {",
+					"    let utils = {};",
+					"",
+					"    /**",
+					"     * Builds Postman Request base data",
+					"     */",
+					"    utils.buildPmRequest = function(path, method, xokapitoken) {",
+					"        return {",
+					"            url: utils.buildOkapiUrl(path),",
+					"            method: method,",
+					"            header: {",
+					"                \"X-Okapi-Tenant\": pm.variables.get(\"testTenant\"),",
+					"                \"X-Okapi-Token\": xokapitoken || pm.environment.get(\"xokapitoken-testAdmin\")",
+					"            }",
+					"        };",
+					"    };",
+					"",
+					"    /**",
+					"     * Creates OKAPI URL endpoint based on provided path",
+					"     */",
+					"    utils.buildOkapiUrl = function(path) {",
+					"        return pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + path;",
+					"    };",
+					"",
+					"    /**",
+					"     * Sends GET request and uses passed handler to handle result",
+					"     */",
+					"    utils.sendGetRequest = function(path, handler) {",
+					"        pm.sendRequest(utils.buildPmRequest(path, \"GET\"), handler);",
+					"    };",
+					"",
+					"    utils.sendPostRequest = function (path, postBody, handler) {",
+					"        let pmRq = utils.buildPmRequest(path, \"POST\");",
+					"        pmRq.body = JSON.stringify(postBody);",
+					"        pmRq.header[\"Content-type\"] = \"application/json\";",
+					"        pm.sendRequest(pmRq, handler);",
+					"    };",
+					"",
+					"    /**",
+					"     * Sends PUT request and uses passed handler to handle result",
+					"     */",
+					"    utils.sendPutRequest = function(path, body, handler) {",
+					"        // Build request and add required header and body",
+					"        let pmRq = utils.buildPmRequest(path, \"PUT\");",
+					"        pmRq.header[\"Content-type\"] = \"application/json\";",
+					"        pmRq.body = JSON.stringify(body);",
+					"",
+					"        pm.sendRequest(pmRq, handler);",
+					"    };",
+					"",
+					"    /**",
+					"     * Sends DELETE request and uses passed handler to handle result",
+					"     */",
+					"    utils.sendDeleteRequest = function(path, handler) {",
+					"        pm.sendRequest(utils.buildPmRequest(path, \"DELETE\"), handler);",
+					"    };",
+					"",
+					"    /**",
+					"     * Updates PO json removing ids and updating PO lines.",
+					"     */",
+					"    utils.prepareOrder = function(order) {",
+					"        delete order.id;",
+					"        delete order.totalItems;",
+					"        delete order.poNumber;",
+					"        order.workflowStatus = \"Pending\";",
+					"",
+					"        for (var i = 0; i < order.compositePoLines.length; i++) {",
+					"            utils.preparePoLine(order.compositePoLines[i]);",
+					"        }",
+					"",
+					"        return order;",
+					"    };",
+					"",
+					"    /**",
+					"     * Updates sub-objects of the PO Line removing ids and adding missing data.",
+					"     */",
+					"    utils.preparePoLine = function(poLine) {",
+					"        delete poLine.id;",
+					"        delete poLine.purchaseOrderId;",
+					"        delete poLine.receiptDate;",
+					"        utils._deleteSubObjectsIds(poLine.alerts);",
+					"        utils._deleteSubObjectsIds(poLine.reportingCodes);",
+					"        return poLine;",
+					"    };",
+					"",
+					"    /**",
+					"     * Build unit assignment",
+					"     */",
+					"    utils.buildAssignmentContent = function(orderId, acqUnitId) {",
+					"        return {",
+					"            \"recordId\": orderId,",
+					"            \"acquisitionsUnitId\": acqUnitId",
+					"        };",
+					"    };",
+					"",
+					"    utils.copyJsonObj = function(obj) {",
+					"        return JSON.parse(JSON.stringify(obj));",
+					"    };",
+					"",
+					"    utils.getModuleId = function(moduleName, bodyHandler) {",
+					"        pm.sendRequest({",
+					"            url: utils.buildOkapiUrl(\"/_/proxy/modules?latest=1&filter=\" + moduleName),",
+					"            method: \"GET\",",
+					"            header: {",
+					"                \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
+					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken-admin\")",
+					"            }",
+					"        }, (err, res) => {",
+					"            pm.test(moduleName + \" module is available\", () => {",
+					"                pm.expect(err).to.equal(null);",
+					"                pm.expect(res.code).to.equal(200);",
+					"                bodyHandler(res.json()[0].id);",
+					"            });",
+					"        });",
+					"    };",
+					"",
+					"    /* BEGIN - Functions to work with mod-configuration */",
+					"    utils.getConfigsByName = function(configs, configName) {",
+					"        return configs.filter(config => config.configName === configName);",
+					"    };",
+					"",
+					"    utils.getConfigByName = function(configs, configName) {",
+					"        return utils.getConfigByNameAndCode(configs, configName);",
+					"    };",
+					"",
+					"    utils.getConfigByNameAndCode = function(configs, configName, configCode) {",
+					"        let filteredConfigs = utils.getConfigsByName(configs, configName);",
+					"        if (configCode) {",
+					"            filteredConfigs = filteredConfigs.filter(config => config.code === configCode);",
+					"        }",
+					"        return filteredConfigs.length > 0 ? filteredConfigs[0] : null;",
+					"    };",
+					"",
+					"    utils.createOrdersConfig = function(configName) {",
+					"        let body = utils.copyJsonObj(globals.testData.configs.bodyTemplate);",
+					"        body.configName = configName;",
+					"        body.value = pm.variables.get(configName);",
+					"        utils.createConfig(body);",
+					"    };",
+					"",
+					"    utils.createConfig = function(body) {",
+					"        utils.sendPostRequest(\"/configurations/entries\", body, function(err, response) {",
+					"            pm.test(\"Config created. Config name = \" + body.configName, function() {",
+					"                pm.expect(response.code).to.eql(201);",
+					"            });",
+					"        });",
+					"    };",
+					"",
+					"    /**",
+					"     * @param body with updated data",
+					"     */",
+					"    utils.updateConfig = function(body) {",
+					"        utils.sendPutRequest(\"/configurations/entries/\" + body.id, body, (err, response) => {",
+					"            pm.test(\"Config updated. Config name = \" + body.configName, function() {",
+					"                pm.expect(response.code).to.eql(204);",
+					"            });",
+					"        });",
+					"    };",
+					"",
+					"    utils.deleteConfig = function(id) {",
+					"        const timerId = setTimeout(() => {}, 60000);",
+					"        utils.processDeleteRequest(\"/configurations/entries/\" + id)",
+					"            .then(code => utils.validateResultOfDeleteRequest(code))",
+					"            .then(result => clearTimeout(timerId))",
+					"            .catch(err => {",
+					"                console.log(\"Error happened on Inventory Records deletion:\", err);",
+					"                clearTimeout(timerId);",
+					"            });",
+					"    };",
+					"    /* END - Functions to work with mod-configuration */",
+					"",
+					"    /**",
+					"     * Clean up variables",
+					"     */",
+					"    utils.unsetTestVariables = function() {",
+					"        pm.globals.unset(\"testData\");",
+					"        pm.globals.unset(\"loadUtils\");",
+					"",
+					"        pm.environment.unset(\"xokapitoken\");",
+					"        pm.environment.unset(\"xokapitoken-admin\");",
+					"    };",
+					"",
+					"    /**",
+					"     * Internal function to iterate sub-objects in array and delete ids",
+					"     */",
+					"    utils._deleteSubObjectsIds = function(data) {",
+					"        if (data) {",
+					"            data.forEach(obj => delete obj.id);",
+					"        }",
+					"    };",
+					"",
+					"    return utils;",
+					"",
+					"} + '; loadUtils();');"
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "65f7e387-a850-4a74-a499-63606dd653fa",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "edc107df-31da-495e-9e15-cc8270429888",
+			"key": "mod-ordersResourcesURL",
+			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
+			"type": "string"
+		},
+		{
+			"id": "e34f550c-13ed-4435-8160-331d85ce4b9d",
+			"key": "poLines-limit",
+			"value": "10",
+			"type": "string"
+		},
+		{
+			"id": "11a904b7-ed5b-45ff-9401-a75adf0a6f71",
+			"key": "testTenant",
+			"value": "orders_acq_units_test",
+			"type": "string"
+		}
+	]
+}


### PR DESCRIPTION
## Purpose
MODORDERS-256 Restrict search for PO, POL, Piece records based upon acquisitions unit
## Approach
Adding new collection which works with test tenant:
1. Log-in by existing admin user
2. Create test tenant
3. Install required modules
4. Create admin user for test tenant
5. Enable authtoken mechanism
6. Create acq units
7. Create regular user
8. Run positive tests
9. Delete test tenant

![image](https://user-images.githubusercontent.com/43410167/62297129-544ebe80-b479-11e9-854b-0ac49b97851f.png)


**Note**: once the collection is completed, the second run might fail because when the DB schema is deleted for test tenant, some modules still keep open DB connection in pool. When test tenant is created again in less then 1 min after previous run, the connection from pool cannot access DB schema because it is recreated but the connection still tries to access old DB schema. Please refer to [AsyncConnectionPool.java](https://github.com/folio-org/vertx-mysql-postgresql-client/blob/release-connection-pool-3-5-1-folio-1/src/main/java/io/vertx/ext/asyncsql/impl/pool/AsyncConnectionPool.java#L52)
To avoid this issue, either wait for at least 1 minute after previous run completed or change `testTenant` collection level variable to some new value.