### PR TITLE
MODINVOICE-75/76 Empty Fund Distribution. Invoice approval details set by system

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -4254,6 +4254,8 @@
 															"        pm.test(\"Invoice status updated\", function () {",
 															"            let invoice = res.json();",
 															"            pm.expect(invoice.status).to.equal(\"Approved\");",
+															"            pm.expect(invoice.approvalDate).to.exist;",
+															"            pm.expect(invoice.approvedBy).to.exist;",
 															"",
 															"            // Remember updated invoice",
 															"            pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
@@ -4646,7 +4648,9 @@
 															"        pm.test(\"Invoice status updated\", function () {",
 															"            let invoice = res.json();",
 															"            pm.expect(invoice.status).to.equal(\"Approved\");",
-															"",
+															"            pm.expect(invoice.approvalDate).to.exist;",
+															"            pm.expect(invoice.approvedBy).to.exist;",
+															"            ",
 															"            // Remember updated invoice",
 															"            pm.environment.set(\"emptyConfigWorkflow-invoiceWith1LineContent\", JSON.stringify(invoice));",
 															"",
@@ -10357,8 +10361,6 @@
 					"        pm.expect(invoiceLine.id, \"Invoice line: id expected\").to.exist;",
 					"        pm.expect(invoiceLine.description, \"Invoice line: description expected\").to.exist;",
 					"        pm.expect(invoiceLine.description, \"Invoice line: description does not match to expected\").to.eql(expectedLine.description);",
-					"        pm.expect(invoiceLine.fundDistributions, \"Invoice line: fund distributions non empty array expected\").to.be.an('array').that.is.not.empty;",
-					"        pm.expect(invoiceLine.fundDistributions, \"Invoice line: fund distributions does not match to expected\").to.eql(expectedLine.fundDistributions);",
 					"        pm.expect(invoiceLine.invoiceId, \"Invoice line: invoiceId expected\").to.exist;",
 					"        pm.expect(invoiceLine.invoiceLineNumber, \"Invoice line: invoiceLineNumber expected\").to.exist;",
 					"        pm.expect(invoiceLine.invoiceLineStatus, \"Invoice line: invoiceLineStatus expected\").to.exist;",
@@ -10391,12 +10393,6 @@
 					"    utils.buildInvoiceLineWithMinContent = function(invoiceId) {",
 					"        return {",
 					"            \"description\": \"Some description\",",
-					"            \"fundDistributions\": [",
-					"                {",
-					"                    \"fundId\": pm.environment.get(\"fundId\"),",
-					"                    \"percentage\": 50",
-					"                }",
-					"            ],",
 					"            \"invoiceId\": invoiceId,",
 					"            \"invoiceLineStatus\": \"Open\",",
 					"            \"subTotal\": 2.20,",
@@ -10851,37 +10847,37 @@
 	],
 	"variable": [
 		{
-			"id": "c8d4ec80-3dc7-49d1-a837-e6d09e8b3abb",
+			"id": "dda6725d-d65c-4588-a433-880a42dce6bc",
 			"key": "resourcesUrl",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-invoice/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "dafc13d3-e034-40d2-bb6c-edd7837bb06f",
+			"id": "4d45e7ea-0cf8-4910-ba44-eadaa73775e7",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "64dd8a40-8a94-4f98-be32-db1fdebff344",
+			"id": "3abab933-f635-4753-87e0-2e5c158d5349",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "1faec719-af75-44c5-bd0b-3e68cbbb971f",
+			"id": "2c367500-ebce-446a-8bf7-d07413ad6bfc",
 			"key": "finance-ledgerCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "6bba47ce-d894-4df8-a78a-fb112d0be7c0",
+			"id": "7711e3c3-470a-4c4c-be5e-45e2b5014888",
 			"key": "finance-fundCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "e2f1a94c-7f9c-4fe0-b7e3-10f5feaa4b60",
+			"id": "84554cb7-f056-4572-b1ce-6fa8273eab31",
 			"key": "voucherNumberPrefix",
 			"value": "testPrefix",
 			"type": "string"

--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -5028,6 +5028,9 @@
 											"invoice.note += \" - locked total\";",
 											"invoice.status = \"Open\";",
 											"",
+											"delete invoice.approvalDate;",
+											"delete invoice.approvedBy;",
+											"",
 											"pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));"
 										],
 										"type": "text/javascript"
@@ -8093,6 +8096,610 @@
 								}
 							],
 							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Transition to Approved with Empty FundDistributions",
+							"item": [
+								{
+									"name": "Create invoice with minimal content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"",
+													"pm.test(\"Invoice is created\", function() {",
+													"    pm.response.to.have.status(201);",
+													"    invoice = pm.response.json();",
+													"});",
+													"",
+													"pm.test(\"Invoice content is valid\", function() {",
+													"    pm.environment.set(\"InvoiceWithEmptyFundDistrosId\", invoice.id);",
+													"    // pm.environment.set(\"folioInvoiceNo\", invoice.folioInvoiceNo);",
+													"    pm.environment.set(\"InvoiceWithEmptyFundDistrosContent\", JSON.stringify(invoice));",
+													"",
+													"    utils.validateInvoiceWithMinimalContent(invoice);",
+													"",
+													"    utils.validateInvoice(invoice);",
+													"",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.variables.set(\"invoiceContent\", JSON.stringify(utils.buildInvoiceWithMinContent()));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{invoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add line with FundDistributions percentage !=100",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "94753103-bb6d-46d3-bebd-3ce94cc05fcd",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/e0d08448-343b-118a-8c2f-4fb50248d672.json\", function(err, res) {",
+													"    let invoiceLine = utils.prepareInvoiceLine(res.json(), pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"));",
+													"    ",
+													"    invoiceLine.fundDistributions[0].percentage=50;;",
+													"    pm.environment.set(\"lineWithoutFundDistros\", JSON.stringify(invoiceLine));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "dbfd94db-59c5-4fd9-8467-a284b21fb175",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoiceLine = {};",
+													"",
+													"pm.test(\"Invoice is created\", function() {",
+													"    pm.response.to.have.status(201);",
+													"    invoiceLine = pm.response.json();",
+													"    pm.environment.set(\"InvoiceLineWithePercentageNot100Id\", invoiceLine.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-admin}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{lineWithoutFundDistros}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice-storage",
+												"invoice-lines"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Transit to approved. FundDistros percantage !=100",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "f17bb1f5-ff53-49f0-8706-0e4c40ac8dfd",
+												"exec": [
+													"let invoice = JSON.parse(pm.environment.get(\"InvoiceWithEmptyFundDistrosContent\"));",
+													"invoice.status = \"Approved\";",
+													"",
+													"pm.environment.set(\"InvoiceWithEmptyFundDistrosContent\", JSON.stringify(invoice));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "238f0667-02ea-4763-972c-b0a6d1e7d3c2",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"pm.test(\"Status code is 400\", function() {",
+													"    pm.response.to.have.status(\"Bad Request\");",
+													"    // The test can be run only if update succeded",
+													"    utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"), (err, res) => {",
+													"        invoice = res.json();",
+													"        pm.test(\"Invoice status changed\", function() {",
+													"            pm.expect(invoice.status).to.equal(\"Open\");",
+													"        });",
+													"    });",
+													"",
+													"    //delete invalid line",
+													"    let lineToDelete = pm.environment.get(\"InvoiceLineWithePercentageNot100Id\");",
+													"    utils.sendDeleteRequest(\"/invoice-storage/invoice-lines/\" + lineToDelete, (err, res) => {",
+													"        pm.expect(res).to.have.property('code', 204);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{InvoiceWithEmptyFundDistrosContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{InvoiceWithEmptyFundDistrosId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{InvoiceWithEmptyFundDistrosId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add line without FundDistributions",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "94753103-bb6d-46d3-bebd-3ce94cc05fcd",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/e0d08448-343b-118a-8c2f-4fb50248d672.json\", function(err, res) {",
+													"    let invoiceLine = utils.prepareInvoiceLine(res.json(), pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"));",
+													"    delete invoiceLine.fundDistributions;",
+													"    pm.environment.set(\"lineWithoutFundDistros\", JSON.stringify(invoiceLine));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "cb8eab54-0245-46b7-b52f-1769914da16e",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-admin}}",
+												"type": "text"
+											},
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{lineWithoutFundDistros}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice-storage",
+												"invoice-lines"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Transit ot approved invoice without FundDistros",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "f17bb1f5-ff53-49f0-8706-0e4c40ac8dfd",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "238f0667-02ea-4763-972c-b0a6d1e7d3c2",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"pm.test(\"Status code is 400\", function() {",
+													"    pm.response.to.have.status(\"Bad Request\");",
+													"    // The test can be run only if update succeded",
+													"    utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"), (err, res) => {",
+													"        invoice = res.json();",
+													"        pm.test(\"Invoice status changed\", function() {",
+													"            pm.expect(invoice.status).to.equal(\"Open\");",
+													"        });",
+													"    });",
+													"});",
+													"",
+													"pm.globals.unset(\"InvoiceWithEmptyFundDistrosContent\");"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{InvoiceWithEmptyFundDistrosContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{InvoiceWithEmptyFundDistrosId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{InvoiceWithEmptyFundDistrosId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "7e3760d3-5781-4771-ab48-f3fbe71589c0",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "ce5e7416-6d02-4d2d-a699-1e6f9ea1a28d",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Invoice with incompatible fields",
+							"item": [
+								{
+									"name": "Create Open invoice",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Invoice is not created\", function() {",
+													"    pm.response.to.have.status(201);",
+													"    pm.variables.set(\"incompatibleFieldsInvoiceContent\", JSON.stringify(pm.response.json()));",
+													"    pm.variables.set(\"incompatibleFieldsInvoiceId\", pm.response.json().id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let incompatibleFieldsInvoice = utils.buildInvoiceWithMinContent();",
+													"",
+													"pm.variables.set(\"incompatibleFieldsInvoiceContent\", JSON.stringify(incompatibleFieldsInvoice));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{incompatibleFieldsInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update Open invoice with incompatible fields",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Invoice is not updated\", function() {",
+													"    pm.response.to.have.status(422);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let incompatibleFieldsInvoice = JSON.parse(pm.variables.get(\"incompatibleFieldsInvoiceContent\"));",
+													"incompatibleFieldsInvoice.approvedBy = \"1d17b91c-5eaf-4f24-b50b-cb10b4cfbc63\";",
+													"",
+													"pm.variables.set(\"incompatibleFieldsInvoiceContent\", JSON.stringify(incompatibleFieldsInvoice));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{incompatibleFieldsInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{incompatibleFieldsInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{incompatibleFieldsInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Open invoice with incompatible fields",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Invoice is not created\", function() {",
+													"    pm.response.to.have.status(422);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let incompatibleFieldsInvoice = utils.buildInvoiceWithMinContent();",
+													"incompatibleFieldsInvoice.approvedBy = \"1d17b91c-5eaf-4f24-b50b-cb10b4cfbc63\";",
+													"",
+													"pm.variables.set(\"incompatibleFieldsInvoiceContent\", JSON.stringify(incompatibleFieldsInvoice));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{incompatibleFieldsInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
 						}
 					],
 					"_postman_isSubFolder": true
@@ -8764,6 +9371,114 @@
 										"invoice",
 										"invoices",
 										"{{approvedInvoiceId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Invoice with empty FundDistributions",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Invoice is deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{InvoiceWithEmptyFundDistrosId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{InvoiceWithEmptyFundDistrosId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Invoice with incompatible fields",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Invoice is deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{incompatibleFieldsInvoiceId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{incompatibleFieldsInvoiceId}}"
 									]
 								}
 							},

--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a48cab24-cc7b-4095-8df1-2d95d966c75e",
+		"_postman_id": "68479f52-3912-4295-a97d-3dfa4777d554",
 		"name": "mod-invoice",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -8189,12 +8189,12 @@
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
 													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/e0d08448-343b-118a-8c2f-4fb50248d672.json\", function(err, res) {",
-													"    let invoiceLine = utils.prepareInvoiceLine(res.json(), pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"));",
-													"    ",
-													"    invoiceLine.fundDistributions[0].percentage=50;;",
-													"    pm.environment.set(\"lineWithoutFundDistros\", JSON.stringify(invoiceLine));",
-													"});"
+													"",
+													"let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"));",
+													"",
+													"invoiceLine.fundDistributions[0].percentage=50;",
+													"pm.environment.set(\"lineWithoutFundDistros\", JSON.stringify(invoiceLine));",
+													""
 												],
 												"type": "text/javascript"
 											}
@@ -8294,6 +8294,7 @@
 													"    utils.sendDeleteRequest(\"/invoice-storage/invoice-lines/\" + lineToDelete, (err, res) => {",
 													"        pm.expect(res).to.have.property('code', 204);",
 													"    });",
+													"    pm.environment.unset(\"InvoiceLineWithePercentageNot100Id\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -8348,11 +8349,10 @@
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
 													"",
-													"pm.sendRequest(pm.variables.get(\"resourcesUrl\") + \"/mockdata/invoiceLines/e0d08448-343b-118a-8c2f-4fb50248d672.json\", function(err, res) {",
-													"    let invoiceLine = utils.prepareInvoiceLine(res.json(), pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"));",
-													"    delete invoiceLine.fundDistributions;",
-													"    pm.environment.set(\"lineWithoutFundDistros\", JSON.stringify(invoiceLine));",
-													"});"
+													"let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), pm.environment.get(\"InvoiceWithEmptyFundDistrosId\"));",
+													"delete invoiceLine.fundDistributions;",
+													"pm.environment.set(\"lineWithoutFundDistros\", JSON.stringify(invoiceLine));",
+													""
 												],
 												"type": "text/javascript"
 											}
@@ -8362,7 +8362,12 @@
 											"script": {
 												"id": "cb8eab54-0245-46b7-b52f-1769914da16e",
 												"exec": [
-													""
+													"let utils = eval(globals.loadUtils);",
+													"let invoiceLine = {};",
+													"",
+													"pm.test(\"Invoice is created\", function() {",
+													"    pm.response.to.have.status(201);",
+													"});"
 												],
 												"type": "text/javascript"
 											}
@@ -8522,8 +8527,8 @@
 													"",
 													"pm.test(\"Invoice is not created\", function() {",
 													"    pm.response.to.have.status(201);",
-													"    pm.variables.set(\"incompatibleFieldsInvoiceContent\", JSON.stringify(pm.response.json()));",
-													"    pm.variables.set(\"incompatibleFieldsInvoiceId\", pm.response.json().id);",
+													"    pm.environment.set(\"incompatibleFieldsInvoiceContent\", JSON.stringify(pm.response.json()));",
+													"    pm.environment.set(\"incompatibleFieldsInvoiceId\", pm.response.json().id);",
 													"});"
 												],
 												"type": "text/javascript"
@@ -8586,7 +8591,8 @@
 													"",
 													"pm.test(\"Invoice is not updated\", function() {",
 													"    pm.response.to.have.status(422);",
-													"});"
+													"});",
+													"pm.environment.unset(\"incompatibleFieldsInvoiceContent\");"
 												],
 												"type": "text/javascript"
 											}
@@ -8598,7 +8604,7 @@
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
 													"",
-													"let incompatibleFieldsInvoice = JSON.parse(pm.variables.get(\"incompatibleFieldsInvoiceContent\"));",
+													"let incompatibleFieldsInvoice = JSON.parse(pm.environment.get(\"incompatibleFieldsInvoiceContent\"));",
 													"incompatibleFieldsInvoice.approvedBy = \"1d17b91c-5eaf-4f24-b50b-cb10b4cfbc63\";",
 													"",
 													"pm.variables.set(\"incompatibleFieldsInvoiceContent\", JSON.stringify(incompatibleFieldsInvoice));"
@@ -10631,6 +10637,8 @@
 					"        pm.environment.unset(\"current-orders-configs\");",
 					"        pm.environment.unset(\"negativeAdjInLineId\");",
 					"        pm.environment.unset(\"negativeInvoiceLineContent\");",
+					"        pm.environment.unset(\"InvoiceWithEmptyFundDistrosId\");",
+					"        pm.environment.unset(\"incompatibleFieldsInvoiceId\");",
 					"        ",
 					"        pm.globals.unset(\"mock-invoices\");",
 					"        pm.globals.unset(\"mock-invoiceLine\");",
@@ -10847,37 +10855,37 @@
 	],
 	"variable": [
 		{
-			"id": "dda6725d-d65c-4588-a433-880a42dce6bc",
+			"id": "fc77c058-fa27-425c-ab2b-f11bb41a53c0",
 			"key": "resourcesUrl",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-invoice/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "4d45e7ea-0cf8-4910-ba44-eadaa73775e7",
+			"id": "6475c7a9-118e-4020-bd8e-b3524bc3e69f",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "3abab933-f635-4753-87e0-2e5c158d5349",
+			"id": "8ab24b80-64d0-4616-90b8-fe8d55077f09",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "2c367500-ebce-446a-8bf7-d07413ad6bfc",
+			"id": "b3a2b498-8720-46fc-834a-87f94f824886",
 			"key": "finance-ledgerCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "7711e3c3-470a-4c4c-be5e-45e2b5014888",
+			"id": "77d1cf83-72b0-4dc2-a3fd-7b1f77bf8744",
 			"key": "finance-fundCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "84554cb7-f056-4572-b1ce-6fa8273eab31",
+			"id": "76a3f293-4e3f-4da2-965c-6723d2d52db8",
 			"key": "voucherNumberPrefix",
 			"value": "testPrefix",
 			"type": "string"


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODINVOICE-75
https://issues.folio.org/browse/MODINVOICE-76

## Approach
* added tests for the case of transition invoces to `Approved` with FundDistributions empty or percentage summary !=100
![image](https://user-images.githubusercontent.com/45555481/61208266-a95fa600-a6ff-11e9-8741-2e613e5a8991.png)

* added tests to exercise cases when Open invoice contains fields `approvedBy` and `approvalDate`
![image](https://user-images.githubusercontent.com/45555481/61208279-b7adc200-a6ff-11e9-88a8-90612ee6aaea.png)
* removed FundDistribution from invoice line with minimal content