### PR TITLE
MODINVOICE-77 Invoice and invoiceLine schema updates

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -11620,7 +11620,7 @@
 					"            \"invoiceDate\": \"2018-07-20T00:00:00.000+0000\",",
 					"            \"paymentMethod\": \"EFT\",",
 					"            \"status\": \"Open\",",
-					"            \"source\": \"024b6f41-c5c6-4280-858e-33fba452a334\",",
+					"            \"source\": \"API\",",
 					"            \"vendorInvoiceNo\": \"YK75851\",",
 					"            \"vendorId\": \"168f8a63-d612-406e-813f-c7527f241ac3\",",
 					"            \"note\": utils.INVOICE_NOTE",
@@ -11675,37 +11675,37 @@
 	],
 	"variable": [
 		{
-			"id": "b88b1ffc-f9f1-4617-82f3-a40c9812c6aa",
+			"id": "ea762096-7f22-4d7e-bb57-6bbf88042cfa",
 			"key": "resourcesUrl",
-			"value": "https://raw.githubusercontent.com/folio-org/mod-invoice/4b9f7cca26991a396dd321879b5f305d204d4b82/src/test/resources",
+			"value": "https://raw.githubusercontent.com/folio-org/mod-invoice/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "c9c4d2a0-ed99-4e6b-90e6-2c0bf2279146",
+			"id": "0e5fcb3b-9e72-4aec-be84-5b8e84b9baa3",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "7f297a97-fce5-4d3f-8c7d-00c6ccf582c4",
+			"id": "6a638638-a9d1-4fc3-b455-f605b9c1793f",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "2fafddfc-cb12-4c37-8daa-3433a4fb692d",
+			"id": "e469f695-e634-41da-a899-9bcd9a7b15bf",
 			"key": "finance-ledgerCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "5be3ed90-8ef5-467d-812f-a86dc126e40b",
+			"id": "868820a9-3a30-460d-91b2-594349bca881",
 			"key": "finance-fundCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "a067ead1-b68b-418e-9b4c-d9c4868712e2",
+			"id": "8d55c746-5415-45b9-943c-a8a4998d6c81",
 			"key": "voucherNumberPrefix",
 			"value": "testPrefix",
 			"type": "string"


### PR DESCRIPTION
- setting API to invoice.source instead of UUID

Verified loacally:
![image](https://user-images.githubusercontent.com/41672277/61854881-b29efe80-aec7-11e9-93e1-5c04244478c7.png)
