### PR TITLE
Changed the instance-types query to use "Books"

### DIFF
--- a/edge-rtac/edge-rtac.postman_collection.json
+++ b/edge-rtac/edge-rtac.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "93717ba2-b56d-4cec-ae0e-79e1c069c902",
+		"_postman_id": "477a601c-dee6-4ca8-9703-e5cfb0717e76",
 		"name": "edge-rtac",
 		"description": "Tests for edge-rtac",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -26,7 +26,7 @@
 									"pm.globals.set(\"xokapitoken\", token);",
 									"",
 									"let baseURI = pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\")+ \":\" + pm.environment.get(\"okapiport\");",
-									"let endpointBooks = baseURI + \"/instance-types?query=(name=text)\";",
+									"let endpointBooks = baseURI + \"/instance-types?query=(name=Books)\";",
 									"let endpointLocations = baseURI + \"/locations\";",
 									"let endpointBook = baseURI + \"/material-types?query=(name=book)\";",
 									"let endpointGroups = baseURI + \"/groups\";",
@@ -1506,10 +1506,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{edge.host}}:{{edge.port}}/prod/rtac/folioRTAC?apiKey={{edge.apikey}}&mms_id={{instanceId}}",
 							"protocol": "{{protocol}}",
@@ -1591,10 +1587,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{edge.host}}:{{edge.port}}/prod/rtac/folioRTAC?apiKey={{edge.apikey}}&mms_id={{instanceId}}",
 							"protocol": "{{protocol}}",
@@ -1660,10 +1652,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{edge.host}}:{{edge.port}}/prod/rtac/folioRTAC?apiKey={{edge.apikey}}&mms_id={{instanceId}}",
 							"protocol": "{{protocol}}",
@@ -1745,10 +1733,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{edge.host}}:{{edge.port}}/prod/rtac/folioRTAC?apiKey={{edge.apikey}}&mms_id={{instanceId}}",
 							"protocol": "{{protocol}}",
@@ -1839,10 +1823,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{edge.host}}:{{edge.port}}/prod/rtac/folioRTAC?apiKey=eyJzIjoiWHMwMWVrbWR5MCIsInQiOiJmb28iLCJ1IjoiYmFyYmF6In0=&mms_id={{instanceId}}",
 							"protocol": "{{protocol}}",
@@ -1906,10 +1886,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{edge.host}}:{{edge.port}}/prod/rtac/folioRTAC?apiKey={{malformedApiKey}}&mms_id={{instanceId}}",
 							"protocol": "{{protocol}}",
@@ -1973,10 +1949,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{edge.host}}:{{edge.port}}/prod/rtac/folioRTAC?apiKey={{edge.apikey}}&mms_id={{$guid}}",
 							"protocol": "{{protocol}}",


### PR DESCRIPTION
It appears there is no longer a "text" instance type, so the query to `instance-types` needed to change from "text" to "Books". With this change, the tests now pass.