### PR TITLE
Newer mod-rtac API tests

### DIFF
--- a/mod-rtac/mod-rtac.postman_collection.json
+++ b/mod-rtac/mod-rtac.postman_collection.json
@@ -1,11 +1,819 @@
 {
 	"info": {
-		"_postman_id": "020727e7-d9c3-4614-a8cb-0a32eb916b99",
+		"_postman_id": "a452a58b-e4b5-4665-b2aa-3746a6226e88",
 		"name": "mod-rtac",
 		"description": "Tests for mod-rtac",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
+		{
+			"name": "Test Setup",
+			"item": [
+				{
+					"name": "/authn/login (OKAPI)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "bd1890b6-57e9-4b7b-bb50-dc5bb7de6e94",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});\r",
+									"\r",
+									"let tenant = pm.environment.get(\"xokapitenant\");\r",
+									"let token = postman.getResponseHeader(\"x-okapi-token\");\r",
+									"pm.globals.set(\"xokapitoken\", token);\r",
+									"\r",
+									"let baseURI = pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\")+ \":\" + pm.environment.get(\"okapiport\");\r",
+									"let endpointBooks = baseURI + \"/instance-types?query=(name=Books)\";\r",
+									"let endpointLocations = baseURI + \"/locations\";\r",
+									"let endpointBook = baseURI + \"/material-types?query=(name=book)\";\r",
+									"let endpointGroups = baseURI + \"/groups\";\r",
+									"let endpointCanCirculate = baseURI + \"/loan-types?query=(name=can circulate)\";\r",
+									"\r",
+									"let testData = {\r",
+									"    user: {\r",
+									"    \tusername: \"rwegener\",\r",
+									"    \tid: \"bde27422-efe1-4327-b5af-acbad05cd24f\",\r",
+									"    \tpersonal: {\r",
+									"    \t\tfirstName: \"Rudolph\",\r",
+									"    \t\tlastName: \"Wegener\"\r",
+									"    \t}\r",
+									"    },\r",
+									"\tcase1: {\r",
+									"\t\tdescription: \"single holding, single item\",\r",
+									"\t\tinstance: {\r",
+									"\t\t\ttitle: \"The Man in the High Castle\",\r",
+									"\t\t\tsource: \"Local\"\r",
+									"\t\t},\r",
+									"\t\tholdings: {\r",
+									"\t\t\tA: {\r",
+									"\t\t\t\tid: \"8163b604-2086-4922-bb2c-94b7779d6808\",\r",
+									"\t\t\t\tcallNumber: \"DK4315.Z9 D44 2012\"\r",
+									"\t\t\t}\r",
+									"\t\t},\r",
+									"\t\titems: {\r",
+									"\t\t\tA1: {\r",
+									"\t\t\t\t\"barcode\": \"978-7657572482\",\r",
+									"\t\t\t\t\"status\": {\r",
+									"\t\t\t\t\t\"name\": \"Checked out\"\r",
+									"\t\t\t\t}\r",
+									"\t\t\t}\r",
+									"\t\t}\r",
+									"\t},\r",
+									"\tcase2: {\r",
+									"\t\tdescription: \"multiple holdings, single item each\",\r",
+									"\t\tinstance: {\r",
+									"\t\t\ttitle: \"Highrise\",\r",
+									"\t\t\tsource: \"Local\"\r",
+									"\t\t},\r",
+									"\t\tholdings: {\r",
+									"\t\t\tA: {\r",
+									"\t\t\t\tid: \"382c5793-672d-4371-a112-3f4a9213e61f\",\r",
+									"\t\t\t\tcallNumber: \"JH8675.Z1 D12 2001\"\r",
+									"\t\t\t},\r",
+									"\t\t\tB: {\r",
+									"\t\t\t\tid: \"787275e6-e6e7-43e6-8a2f-f4d291383bc6\",\r",
+									"\t\t\t\tcallNumber: \"JH8675.Z2 D12 2001\"\r",
+									"\t\t\t}\r",
+									"\t\t},\r",
+									"\t\titems: {\r",
+									"\t\t\tA1: {\r",
+									"\t\t\t\t\"barcode\": \"978-1237572482\",\r",
+									"\t\t\t\t\"status\": {\r",
+									"\t\t\t\t\t\"name\": \"Checked out\"\r",
+									"\t\t\t\t}\t\t\t\t\r",
+									"\t\t\t},\r",
+									"\t\t\tB1: {\r",
+									"\t\t\t\t\"barcode\": \"978-8736724821\",\r",
+									"\t\t\t\t\"status\": {\r",
+									"\t\t\t\t\t\"name\": \"Available\"\r",
+									"\t\t\t\t}\r",
+									"\t\t\t}\t\t\t\r",
+									"\t\t}\r",
+									"\t}\r",
+									"};\r",
+									"\r",
+									"//get instance type\r",
+									"pm.sendRequest({\r",
+									"    url: endpointBooks,\r",
+									"    method: \"GET\",\r",
+									"    header: {\r",
+									"         \"x-okapi-tenant\": tenant,\r",
+									"         \"x-okapi-token\": token\r",
+									"    }},\r",
+									"    function (err, res) {\r",
+									"        if (res.json().instanceTypes.length > 0) {\r",
+									"            testData.case1.instance.instanceTypeId = res.json().instanceTypes[0].id;\r",
+									"            testData.case2.instance.instanceTypeId = res.json().instanceTypes[0].id;\r",
+									"            \r",
+									"            pm.globals.set(\"case1_instance\", JSON.stringify(testData.case1.instance, null, 2));\r",
+									"            pm.globals.set(\"case2_instance\", JSON.stringify(testData.case2.instance, null, 2));\r",
+									"        }\r",
+									"\t\tpm.globals.set(\"testData\", testData);\r",
+									"\r",
+									"\t\t//get locationId\r",
+									"\t\tpm.sendRequest({\r",
+									"\t\t\turl: endpointLocations,\r",
+									"\t\t\tmethod: \"GET\",\r",
+									"\t\t\theader: {\r",
+									"\t\t\t\t\"x-okapi-tenant\": tenant,\r",
+									"\t\t\t\t\"x-okapi-token\": token\r",
+									"\t\t\t}},\r",
+									"\t\t\tfunction (err, res) {\r",
+									"\t\t\t\tif (res.json().locations.length > 0) {\r",
+									"\t\t\t\t\ttestData.case1.holdings.A.permanentLocationId = res.json().locations[0].id;\r",
+									"\t\t\t\t\ttestData.case2.holdings.A.permanentLocationId = res.json().locations[0].id;\r",
+									"\t\t\t\t\ttestData.case2.holdings.B.permanentLocationId = res.json().locations[0].id;\r",
+									"\t\t\t\t\t\r",
+									"\t\t\t\t\tpm.globals.set(\"location\", res.json().locations[0].name);\r",
+									"\t\t\t\t\tpm.globals.set(\"case1_holdingA\", JSON.stringify(testData.case1.holdings.A, null, 2));\r",
+									"\t\t\t\t\tpm.globals.set(\"case2_holdingA\", JSON.stringify(testData.case2.holdings.A, null, 2));\r",
+									"\t\t\t\t\tpm.globals.set(\"case2_holdingB\", JSON.stringify(testData.case2.holdings.B, null, 2));\r",
+									"\t\t\t\t}\r",
+									"\t\t\t\tpm.globals.set(\"testData\", testData);\r",
+									"\t\r",
+									"\t\t\t\t//get material type\r",
+									"\t\t\t\tpm.sendRequest({\r",
+									"\t\t\t\t\turl: endpointBook,\r",
+									"\t\t\t\t\tmethod: \"GET\",\r",
+									"\t\t\t\t\theader: {\r",
+									"\t\t\t\t\t\t \"x-okapi-tenant\": tenant,\r",
+									"\t\t\t\t\t\t \"x-okapi-token\": token\r",
+									"\t\t\t\t\t}},\r",
+									"\t\t\t\t\tfunction (err, res) {\r",
+									"\t\t\t\t\t\tif (res.json().mtypes.length > 0) {\r",
+									"\t\t\t\t\t\t\ttestData.case1.items.A1.materialTypeId = res.json().mtypes[0].id;\r",
+									"\t\t\t\t\t\t\ttestData.case2.items.A1.materialTypeId = res.json().mtypes[0].id;\r",
+									"\t\t\t\t\t\t\ttestData.case2.items.B1.materialTypeId = res.json().mtypes[0].id;\r",
+									"\t\t\t\t\t\t}\r",
+									"\t\t\t\t\t\tpm.globals.set(\"testData\", testData);\r",
+									"\t\t\t\t\t\t\r",
+									"\t\t\t\t\t\t//get patron group\r",
+									"        \t\t\t\tpm.sendRequest({\r",
+									"        \t\t\t\t\turl: endpointGroups,\r",
+									"        \t\t\t\t\tmethod: \"GET\",\r",
+									"        \t\t\t\t\theader: {\r",
+									"        \t\t\t\t\t\t \"x-okapi-tenant\": tenant,\r",
+									"        \t\t\t\t\t\t \"x-okapi-token\": token\r",
+									"        \t\t\t\t\t}},\r",
+									"        \t\t\t\t\tfunction (err, res) {\r",
+									"        \t\t\t\t\t\tif (res.json().usergroups.length > 0) {\r",
+									"        \t\t\t\t\t\t\ttestData.user.patronGroup = res.json().usergroups[0].id;\r",
+									"        \t\t\t\t\t\t}\r",
+									"        \t\t\t\t\t\tpm.globals.set(\"testData\", testData);\r",
+									"        \t\t\t\t\t\t\r",
+									"        \t\t\t\t\t\t//get loan type\r",
+									"        \t\t\t\t\t\tpm.sendRequest({\r",
+									"        \t\t\t\t\t\t\turl: endpointCanCirculate,\r",
+									"        \t\t\t\t\t\t\tmethod: \"GET\",\r",
+									"        \t\t\t\t\t\t\theader: {\r",
+									"        \t\t\t\t\t\t\t\t\"x-okapi-tenant\": tenant,\r",
+									"        \t\t\t\t\t\t\t\t\"x-okapi-token\": token\r",
+									"        \t\t\t\t\t\t\t}},\r",
+									"        \t\t\t\t\t\t\tfunction (err, res) {\r",
+									"        \t\t\t\t\t\t\t\tif (res.json().loantypes.length > 0) {\r",
+									"        \t\t\t\t\t\t\t\t\ttestData.case1.items.A1.permanentLoanTypeId = res.json().loantypes[0].id;\r",
+									"        \t\t\t\t\t\t\t\t\ttestData.case2.items.A1.permanentLoanTypeId = res.json().loantypes[0].id;\r",
+									"        \t\t\t\t\t\t\t\t\ttestData.case2.items.B1.permanentLoanTypeId = res.json().loantypes[0].id;\r",
+									"        \t\t\t\t\t\t\t\t}\r",
+									"        \t\t\t\t\t\t\t\tpm.globals.set(\"testData\", testData);\r",
+									"        \r",
+									"                                        pm.globals.set(\"user\", JSON.stringify(testData.user, null, 2));\r",
+									"        \t\t\t\t\t\t\t\tpm.globals.set(\"case1_itemA1\", JSON.stringify(testData.case1.items.A1, null, 2));\r",
+									"        \t\t\t\t\t\t\t\tpm.globals.set(\"case2_itemA1\", JSON.stringify(testData.case2.items.A1, null, 2));\r",
+									"        \t\t\t\t\t\t\t\tpm.globals.set(\"case2_itemB1\", JSON.stringify(testData.case2.items.B1, null, 2));\r",
+									"        \t\t\t\t\t\t\t}\r",
+									"        \t\t\t\t\t\t);\r",
+									"        \t\t\t\t\t}\r",
+									"    \t\t\t\t\t);\r",
+									"\t\t\t\t\t}\r",
+									"\t\t\t\t);\r",
+									"\t\t\t}\r",
+									"\t\t);\r",
+									"    }\r",
+									");"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d75a59b9-367d-4055-86c6-0b6c1cf9b86c",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\":\"{{username}}\",\"password\":\"{{password}}\"}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"authn",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/instance-storage/instances (The Man in the High Castle)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "1bbdfa7d-58ce-4503-b098-ba3a9cdafc29",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"New inventory instance was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case1.instance = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "0b57483b-5d2b-4bbf-8c8c-2744c65b86c1",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case1_instance}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-storage/instances",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"instance-storage",
+								"instances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/instance-storage/instances (Highrise)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "cc4c2f4a-d380-4d2f-b97e-ff981bd0aad9",
+								"exec": [
+									"pm.test(\"New inventory instance was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case2.instance = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "8611172a-a90c-4b11-a41f-dc93509020ed",
+								"exec": [
+									"console.log(pm.globals.get(\"testData\"));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case2_instance}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-storage/instances",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"instance-storage",
+								"instances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/holdings-storage/holdings (The man in the High Castle - A)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9369c038-23dc-45e0-8491-c3ff8863119d",
+								"exec": [
+									"pm.test(\"New holdings record was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case1.holdings.A = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "680be087-3fa4-4acf-88a4-8bd8a4145b90",
+								"exec": [
+									"let testData = pm.globals.get(\"testData\");",
+									"",
+									"testData.case1.holdings.A.instanceId = testData.case1.instance.id;",
+									"",
+									"pm.globals.set(\"testData\", testData);",
+									"pm.globals.set(\"case1_holdingA\", JSON.stringify(testData.case1.holdings.A, 2, null));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case1_holdingA}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/holdings-storage/holdings",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"holdings-storage",
+								"holdings"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/holdings-storage/holdings (Highrise - A)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "1d89cbfa-5c9a-4371-a7ad-1cd2f7419542",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"New holdings record was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case2.holdings.A = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "955b4294-48fe-4f77-a596-7d136531ae5f",
+								"type": "text/javascript",
+								"exec": [
+									"let testData = pm.globals.get(\"testData\");",
+									"",
+									"testData.case2.holdings.A.instanceId = testData.case2.instance.id;",
+									"",
+									"pm.globals.set(\"testData\", testData);",
+									"pm.globals.set(\"case2_holdingA\", JSON.stringify(testData.case2.holdings.A, 2, null));"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case2_holdingA}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/holdings-storage/holdings",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"holdings-storage",
+								"holdings"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/holdings-storage/holdings (Highrise - B)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9369c038-23dc-45e0-8491-c3ff8863119d",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"New holdings record was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case2.holdings.B = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "680be087-3fa4-4acf-88a4-8bd8a4145b90",
+								"type": "text/javascript",
+								"exec": [
+									"let testData = pm.globals.get(\"testData\");",
+									"",
+									"testData.case2.holdings.B.instanceId = testData.case2.instance.id;",
+									"",
+									"pm.globals.set(\"testData\", testData);",
+									"pm.globals.set(\"case2_holdingB\", JSON.stringify(testData.case2.holdings.B, 2, null));"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case2_holdingB}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/holdings-storage/holdings",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"holdings-storage",
+								"holdings"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/inventory/items (The Man in the High Castle - A1)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb1d887b-3bad-4274-a4df-37aa2b9d1ce1",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"New inventory item was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case1.items.A1 = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5144daf9-b98f-456a-91bd-6add711c0661",
+								"type": "text/javascript",
+								"exec": [
+									"let testData = pm.globals.get(\"testData\");",
+									"",
+									"testData.case1.items.A1.holdingsRecordId = testData.case1.holdings.A.id;",
+									"",
+									"pm.globals.set(\"testData\", testData);",
+									"pm.globals.set(\"case1_itemA1\", JSON.stringify(testData.case1.items.A1, 2, null));"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case1_itemA1}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/item-storage/items",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"item-storage",
+								"items"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/inventory/items (Highrise - A1)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a6845947-a482-423a-a33d-bce67617ef0d",
+								"exec": [
+									"pm.test(\"New inventory item was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case2.items.A1 = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "884f0d44-9301-4e9c-b533-ac76c8b55342",
+								"exec": [
+									"let testData = pm.globals.get(\"testData\");",
+									"",
+									"testData.case2.items.A1.holdingsRecordId = testData.case2.holdings.A.id;",
+									"",
+									"pm.globals.set(\"testData\", testData);",
+									"pm.globals.set(\"case2_itemA1\", JSON.stringify(testData.case2.items.A1, 2, null));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case2_itemA1}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/item-storage/items",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"item-storage",
+								"items"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/inventory/items (Highrise - B1)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f682972c-4934-473e-8040-9f3ca8a4c16f",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"New inventory item was created. Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"let testData = pm.globals.get(\"testData\");",
+									"testData.case2.items.B1 = pm.response.json();",
+									"pm.globals.set(\"testData\", testData);"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "ebe58057-1a85-4658-bd08-91ddb9664bda",
+								"type": "text/javascript",
+								"exec": [
+									"let testData = pm.globals.get(\"testData\");",
+									"",
+									"testData.case2.items.B1.holdingsRecordId = testData.case2.holdings.B.id;",
+									"",
+									"pm.globals.set(\"testData\", testData);",
+									"pm.globals.set(\"case2_itemB1\", JSON.stringify(testData.case2.items.B1, 2, null));"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{case2_itemB1}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/item-storage/items",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"item-storage",
+								"items"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "971a30b9-eb1b-457f-82bb-547e30d3bcc1",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "5f7fd960-6f38-498f-bcb2-0ca6edc5e7bf",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
 		{
 			"name": "Schemas",
 			"item": [
@@ -16,16 +824,17 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"type": "text/javascript",
 								"exec": [
 									""
-								],
-								"type": "text/javascript"
+								]
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "ffa902b8-5ba8-4035-8270-a735f424ff82",
+								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_parameters OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -36,8 +845,7 @@
 									"});",
 									"",
 									"pm.environment.set(\"schema_holding_content\", responseBody);"
-								],
-								"type": "text/javascript"
+								]
 							}
 						}
 					],
@@ -57,18 +865,14 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{schema_loc}}/mod-rtac/{{mod_version}}/ramls/{{schema_holding}}",
+							"raw": "{{schema_loc}}/mod-rtac/master/ramls/{{schema_holding}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"mod-rtac",
-								"{{mod_version}}",
+								"master",
 								"ramls",
 								"{{schema_holding}}"
 							]
@@ -84,16 +888,17 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
+								"type": "text/javascript",
 								"exec": [
 									""
-								],
-								"type": "text/javascript"
+								]
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "85917db7-7320-4a02-9489-64a8351404c7",
+								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"GET schema_parameters OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -105,8 +910,7 @@
 									"",
 									"pm.environment.set(\"schema_holdings_content\", responseBody);",
 									""
-								],
-								"type": "text/javascript"
+								]
 							}
 						}
 					],
@@ -126,18 +930,14 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{schema_loc}}/mod-rtac/{{mod_version}}/ramls/{{schema_holdings}}",
+							"raw": "{{schema_loc}}/mod-rtac/master/ramls/{{schema_holdings}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"mod-rtac",
-								"{{mod_version}}",
+								"master",
 								"ramls",
 								"{{schema_holdings}}"
 							]
@@ -171,18 +971,14 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_error}}",
+							"raw": "{{schema_loc}}/raml/raml1.0/schemas/{{schema_error}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"raml",
-								"{{raml_version}}",
+								"raml1.0",
 								"schemas",
 								"{{schema_error}}"
 							]
@@ -215,74 +1011,16 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{schema_loc}}/raml/{{raml_version}}/schemas/{{schema_errors}}",
+							"raw": "{{schema_loc}}/raml/raml1.0/schemas/{{schema_errors}}",
 							"host": [
 								"{{schema_loc}}"
 							],
 							"path": [
 								"raml",
-								"{{raml_version}}",
+								"raml1.0",
 								"schemas",
 								"{{schema_errors}}"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Auth",
-			"item": [
-				{
-					"name": "/authn/login",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-								"type": "text/javascript",
-								"exec": [
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"xokapitoken\", postman.getResponseHeader(\"x-okapi-token\"));"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "x-okapi-tenant",
-								"value": "{{xokapitenant}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{  \r\n   \"username\":\"{{username}}\",\r\n   \"password\":\"{{password}}\"\r\n}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"authn",
-								"login"
 							]
 						}
 					},
@@ -300,20 +1038,21 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
-								"type": "text/javascript",
 								"exec": [
-									"pm.environment.set(\"instanceIdSingleHolding\", \"163d51fd-633f-40d3-aa5d-d5e39951409b\");",
+									"pm.environment.set(\"instanceIdSingleHolding\", pm.globals.get(\"testData\").case1.holdings.A.instanceId);",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
-								"type": "text/javascript",
 								"exec": [
 									"var jsonData = pm.response.json();",
+									"let testData = pm.globals.get(\"testData\");",
+									"",
 									"",
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -324,10 +1063,10 @@
 									"});",
 									"",
 									"pm.test(\"Required holdings data returned\", function () {",
-									"    pm.expect(jsonData.holdings[0].callNumber).to.equal(\"163d51fd-633f-40d3-aa5d-d5e39951409b\");",
-									"    pm.expect(jsonData.holdings[0].status).to.equal(\"Checked out\");",
-									"    pm.expect(jsonData.holdings[0].id).to.equal(\"6cd4aa93-72d3-41b8-a0b2-97de03b9798d\");",
-									"    pm.expect(jsonData.holdings[0].location).to.equal(\"Annex\");",
+									"    pm.expect(jsonData.holdings[0].callNumber).to.equal(testData.case1.holdings.A.callNumber);",
+									"    pm.expect(jsonData.holdings[0].status).to.equal(testData.case1.items.A1.status.name);",
+									"    pm.expect(jsonData.holdings[0].id).to.equal(testData.case1.items.A1.id);",
+									"    pm.expect(jsonData.holdings[0].location).to.equal(pm.globals.get(\"location\"));",
 									"});",
 									"",
 									"pm.test(\"Validate schema\", function () {",
@@ -335,7 +1074,8 @@
 									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_holdings_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"});"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -355,12 +1095,8 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/163d51fd-633f-40d3-aa5d-d5e39951409b",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -368,7 +1104,7 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"rtac",
-								"163d51fd-633f-40d3-aa5d-d5e39951409b"
+								"{{instanceIdSingleHolding}}"
 							]
 						},
 						"description": "GET /rtac/ requests that return 200"
@@ -382,19 +1118,19 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-								"type": "text/javascript",
 								"exec": [
-									"pm.environment.set(\"instanceIdMultipleHoldings\", \"7cac8bf1-8f72-4593-bfdb-075f59d12e60\");"
-								]
+									"pm.environment.set(\"instanceIdMultipleHoldings\", pm.globals.get(\"testData\").case2.holdings.A.instanceId);"
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-								"type": "text/javascript",
 								"exec": [
 									"var jsonData = pm.response.json();",
+									"let testData = pm.globals.get(\"testData\");",
 									" ",
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -416,18 +1152,17 @@
 									"",
 									"pm.test(\"Statuses are \\\"Available\\\" and \\\"Checked out\\\"\", function(){",
 									"    ",
-									"    console.log(jsonData.holdings);",
-									"    ",
 									"    jsonData.holdings.forEach(function(element){",
 									"        ",
 									"        console.log(element);",
 									"        ",
-									"        if (element.id == \"7cac8bf1-8f72-4593-bfdb-075f59d12e60\"){",
+									"        if (element.id == testData.case2.items.A1.id){",
 									"            pm.expect(element.status).equal(\"Checked out\");",
-									"            pm.expect(element.dueDate).to.exist;",
-									"            pm.expect(element.dueDate).equal(\"2018-05-31T17:58:49.198+0000\");",
+									"            pm.expect(element.callNumber).exist;",
+									"            pm.expect(element.id).to.exist;",
+									"            pm.expect(element.location).to.exist;",
 									"        }",
-									"        else if (element.id == \"9e029caf-79c2-4d9c-9f38-89e4e12b75d0\"){",
+									"        else if (element.id == testData.case2.items.B1.id){",
 									"            pm.expect(element.status).equal(\"Available\");",
 									"        }",
 									"    });",
@@ -439,7 +1174,8 @@
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -459,10 +1195,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdMultipleHoldings}}",
 							"protocol": "{{protocol}}",
@@ -561,10 +1293,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/123456",
 							"protocol": "{{protocol}}",
@@ -636,10 +1364,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
 							"protocol": "{{protocol}}",
@@ -663,19 +1387,19 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "63145320-5160-4511-b040-bd72005f8468",
-								"type": "text/javascript",
 								"exec": [
 									"var jsonData = pm.response.json();",
+									"let testData = pm.globals.get(\"testData\");",
 									"",
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -683,10 +1407,10 @@
 									"",
 									"pm.test(\"holdings data returned despite missing tentant, because the token contains the tenant ID\", function () {",
 									"        pm.expect(jsonData.holdings).to.have.lengthOf(1);",
-									"        pm.expect(jsonData.holdings[0].callNumber).to.equal(\"163d51fd-633f-40d3-aa5d-d5e39951409b\");",
-									"        pm.expect(jsonData.holdings[0].status).to.equal(\"Checked out\");",
-									"        pm.expect(jsonData.holdings[0].id).to.equal(\"6cd4aa93-72d3-41b8-a0b2-97de03b9798d\");",
-									"        pm.expect(jsonData.holdings[0].location).to.equal(\"Annex\");",
+									"        pm.expect(jsonData.holdings[0].callNumber).to.equal(testData.case1.holdings.A.callNumber);",
+									"        pm.expect(jsonData.holdings[0].status).to.equal(testData.case1.items.A1.status.name);",
+									"        pm.expect(jsonData.holdings[0].id).to.equal(testData.case1.items.A1.id);",
+									"        pm.expect(jsonData.holdings[0].location).to.equal(pm.globals.get(\"location\"));",
 									"});",
 									"",
 									"pm.test(\"Validate schema\", function () {",
@@ -694,7 +1418,8 @@
 									"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_holdings_content\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
 									"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 									"});"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -710,10 +1435,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
 							"protocol": "{{protocol}}",
@@ -737,17 +1458,16 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "e41e5c9e-c396-4f1e-81ff-10b79f737233",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 401\", function () {",
 									"    pm.response.to.have.status(401);",
@@ -765,7 +1485,8 @@
 									"    }",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -785,10 +1506,6 @@
 								"value": "eyJhbGciOiJIUzUxMiJ999999.eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiJlZjY3NmRiOS1kMjMxLTQ3OWEtYWE5MS1mNjVlYjRiMTc4NzIiLCJ0ZW5hbnQiOiJmczAwMDAwMDAwIn2.KC0RbgafcMmR5Mc3-I7a6SQPKeDSr0SkJlLMcqQz3nwI0lwPTlxw0wJgidxDq-qjCR0wurFRn5ugd9_SVadSxg"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
 							"protocol": "{{protocol}}",
@@ -812,26 +1529,23 @@
 							"listen": "prerequest",
 							"script": {
 								"id": "d8c9ac0f-96ad-4626-b6cd-5bd280e0e1a6",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "test",
 							"script": {
 								"id": "4c51240b-34ce-4a8b-9db1-a1150320f0fe",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status code is 404\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});",
 									"",
 									"pm.test(\"Error object contains status code and expected error message\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.statusCode).to.equal(404);",
-									"    pm.expect(jsonData.errorMessage).to.equal(\"Not Found\");",
+									"    pm.expect(pm.response.text()).to.equal(\"Not Found\");",
 									"});",
 									"",
 									"pm.test(\"Validate schema\", function () {",
@@ -842,7 +1556,8 @@
 									"    }",
 									"});",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -862,10 +1577,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{$guid}}",
 							"protocol": "{{protocol}}",
@@ -937,10 +1648,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/",
 							"protocol": "{{protocol}}",
@@ -963,43 +1670,497 @@
 			"name": "Cleanup",
 			"item": [
 				{
-					"name": "/rtac- 200 - cleanup",
+					"name": "/item-storage/items (Highrise - B1)",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "6d0c25d5-a2a2-411e-9e04-6e89dc1bf6da",
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
 								"type": "text/javascript",
 								"exec": [
-									"pm.test(\"GET /rtac returns 200 status\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.environment.unset(\"xokapitoken\");",
-									"pm.environment.unset(\"instanceIdSingleHolding\");",
-									"pm.environment.unset(\"instanceIdMultipleHoldings\");",
-									"",
-									"//schema variables",
-									"pm.environment.unset(\"schema_error_content\");",
-									"pm.environment.unset(\"schema_errors_content\");",
-									"pm.environment.unset(\"schema_holding_content\");",
-									"pm.environment.unset(\"schema_holdings_content\");"
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
 								]
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "f393df87-edee-4799-9eca-8cd8722fc7cd",
+								"id": "8ed00f05-29b1-428e-95a1-4c0a7df195d0",
 								"type": "text/javascript",
 								"exec": [
-									""
+									"pm.globals.set(\"itemId\", pm.globals.get(\"testData\").case2.items.B1.id);"
 								]
 							}
 						}
 					],
 					"request": {
-						"method": "GET",
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/item-storage/items/{{itemId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"item-storage",
+								"items",
+								"{{itemId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/item-storage/items (Highrise - A1)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "17d970f7-2a79-44ec-989e-5931fc6cb6fe",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"itemId\", pm.globals.get(\"testData\").case2.items.A1.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/item-storage/items/{{itemId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"item-storage",
+								"items",
+								"{{itemId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/item-storage/items (The Man in the High Castle - A1)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "50b3b7ec-78e9-4736-9b06-6aa82678119b",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"itemId\", pm.globals.get(\"testData\").case1.items.A1.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/item-storage/items/{{itemId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"item-storage",
+								"items",
+								"{{itemId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/holdings-storage/holdings (Highrise - B)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "9d6837b7-bf0a-49f9-9aab-c5ddfefc4c3f",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"holdingId\", pm.globals.get(\"testData\").case2.holdings.B.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/holdings-storage/holdings/{{holdingId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"holdings-storage",
+								"holdings",
+								"{{holdingId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/holdings-storage/holdings (Highrise - A)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b5a0fee0-9b16-4f1e-b7fd-266919acad2b",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"holdingId\", pm.globals.get(\"testData\").case2.holdings.A.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/holdings-storage/holdings/{{holdingId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"holdings-storage",
+								"holdings",
+								"{{holdingId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/holdings-storage/holdings (The Man in the High Castle - A)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "a76214c5-80fc-4633-bef2-808006cd2b0e",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"holdingId\", pm.globals.get(\"testData\").case1.holdings.A.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/holdings-storage/holdings/{{holdingId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"holdings-storage",
+								"holdings",
+								"{{holdingId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/instance-storage/instances (Highrise)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "c1b827dc-e1f5-4bc0-b23c-a5b1d4a7afa9",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"instanceId\", pm.globals.get(\"testData\").case2.instance.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-storage/instances/{{instanceId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"instance-storage",
+								"instances",
+								"{{instanceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/instance-storage/instances (The Man in the High Castle)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "231f4d10-b48d-4fca-8022-a898424a3646",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "44ad415b-274b-491d-b052-c739f955ebb3",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"instanceId\", pm.globals.get(\"testData\").case1.instance.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-storage/instances/{{instanceId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"instance-storage",
+								"instances",
+								"{{instanceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a817d5db-abfb-454c-972f-cbdb12256d7d",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"DELETE /user/<userId> returns 204 status\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								]
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "35e18d59-c76d-46cc-a876-70c6c7db45e4",
+								"type": "text/javascript",
+								"exec": [
+									"pm.globals.set(\"userId\", pm.globals.get(\"testData\").user.id);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
 						"header": [
 							{
 								"key": "Content-Type",
@@ -1019,7 +2180,83 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/{{instanceIdSingleHolding}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/{{userId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"users",
+								"{{userId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/rtac- 200 - cleanup",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6d0c25d5-a2a2-411e-9e04-6e89dc1bf6da",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "f393df87-edee-4799-9eca-8cd8722fc7cd",
+								"exec": [
+									"pm.environment.unset(\"xokapitoken\");",
+									"pm.environment.unset(\"instanceIdSingleHolding\");",
+									"pm.environment.unset(\"instanceIdMultipleHoldings\");",
+									"",
+									"//schema variables",
+									"pm.environment.unset(\"schema_error_content\");",
+									"pm.environment.unset(\"schema_errors_content\");",
+									"pm.environment.unset(\"schema_holding_content\");",
+									"pm.environment.unset(\"schema_holdings_content\");",
+									"",
+									"pm.globals.unset(\"case1_instance\");",
+									"pm.globals.unset(\"case2_instance\");",
+									"pm.globals.unset(\"location\");",
+									"pm.globals.unset(\"case1_holdingA\");",
+									"pm.globals.unset(\"case2_holdingA\");",
+									"pm.globals.unset(\"case2_holdingB\");",
+									"pm.globals.unset(\"case1_itemA1\");",
+									"pm.globals.unset(\"case2_itemA1\");",
+									"pm.globals.unset(\"case2_itemB1\");",
+									"pm.globals.unset(\"testData\");",
+									"pm.globals.unset(\"user\");",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-tenant",
+								"value": "{{xokapitenant}}"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/rtac/requestToExcuteCleanupScripts-notMeantToRetrieveValidResults",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -1027,7 +2264,7 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"rtac",
-								"{{instanceIdSingleHolding}}"
+								"requestToExcuteCleanupScripts-notMeantToRetrieveValidResults"
 							]
 						}
 					},
@@ -1060,51 +2297,39 @@
 	],
 	"variable": [
 		{
-			"id": "053d2cc9-6f93-4f6e-b10d-2e1582da2546",
+			"id": "854e0a4c-634b-49c9-8e59-42c9692058d1",
 			"key": "mod_name",
 			"value": "mod-rtac",
 			"type": "string"
 		},
 		{
-			"id": "22fa8416-a674-4ade-9973-bafac56053d9",
+			"id": "f3d871ce-d0b7-4ce9-b681-9ac493283a30",
 			"key": "schema_holding",
 			"value": "holding.json",
 			"type": "string"
 		},
 		{
-			"id": "f39cc60c-58dd-4c31-a41a-ba834886df18",
+			"id": "cf94808e-32ca-41c6-a4ec-34cd0cb9ebd9",
 			"key": "schema_holdings",
 			"value": "holdings.json",
 			"type": "string"
 		},
 		{
-			"id": "06aa2a80-6f75-4902-96ef-f390b361b2e8",
+			"id": "973fecdd-c42e-4bf5-894d-26a25d2708fa",
 			"key": "schema_loc",
 			"value": "https://raw.githubusercontent.com/folio-org",
 			"type": "string"
 		},
 		{
-			"id": "7158abc7-e832-4ee6-8a4e-39b4327e7523",
+			"id": "6a5df41f-4dc3-4d5d-8cfa-e917f797d042",
 			"key": "schema_error",
 			"value": "error.schema",
 			"type": "string"
 		},
 		{
-			"id": "bb102c50-7166-4341-95d9-f52ccde8f471",
+			"id": "4188c641-ef9a-429c-80e7-259092d3104b",
 			"key": "schema_errors",
 			"value": "errors.schema",
-			"type": "string"
-		},
-		{
-			"id": "9a277168-e367-4465-a121-db8aa1129646",
-			"key": "mod_version",
-			"value": "v1.2.0",
-			"type": "string"
-		},
-		{
-			"id": "bdeebdc4-0cc6-42cc-82c3-48bec6fd5f50",
-			"key": "raml_version",
-			"value": "20d6bc5c61c8509e203ea4fe0ce94ddb067200ba",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
Uploaded a newer version of mod-rtac API tests that have the setup/tear down steps to create test data on the fly.

Note that this version was created in the old gse.hosting.operations repo, and the build was running it, but for some reasons it failed to be migrated over to this repo when this repo was created.