### PR TITLE
fixing mod-users tests

### DIFF
--- a/mod-users/mod-users.postman_collection.json
+++ b/mod-users/mod-users.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d0e6021e-a4b4-4961-a959-4b46656a69d4",
+		"_postman_id": "9a57f0c5-930a-4a78-9c93-7ef4a582e8b6",
 		"name": "mod-users",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -33,10 +33,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_error}}",
 							"host": [
@@ -75,10 +71,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_errors}}",
 							"host": [
@@ -117,10 +109,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_metadata}}",
 							"host": [
@@ -159,10 +147,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_resultInfo}}",
 							"host": [
@@ -201,10 +185,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_tags}}",
 							"host": [
@@ -243,10 +223,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{schema_parameters}}",
 							"host": [
@@ -285,10 +261,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_addresstype}}",
 							"host": [
@@ -328,10 +300,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_addresstypeCollection}}",
 							"host": [
@@ -371,10 +339,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_proxyfor}}",
 							"host": [
@@ -414,10 +378,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_proxyforCollection}}",
 							"host": [
@@ -457,10 +417,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_userdata}}",
 							"host": [
@@ -500,10 +456,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_userdataCollection}}",
 							"host": [
@@ -543,10 +495,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_usergroups}}",
 							"host": [
@@ -586,10 +534,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{schema_loc}}/{{schema_path}}/{{mod_name}}/{{schema_usergroup}}",
 							"host": [
@@ -775,10 +719,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups",
 							"protocol": "{{protocol}}",
@@ -904,10 +844,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?limit=30",
 							"protocol": "{{protocol}}",
@@ -962,10 +898,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?limit=-1",
 							"protocol": "{{protocol}}",
@@ -1020,10 +952,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?limit=2147483648",
 							"protocol": "{{protocol}}",
@@ -1174,10 +1102,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?offset={{groupoffset}}",
 							"protocol": "{{protocol}}",
@@ -1328,10 +1252,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?offset=0",
 							"protocol": "{{protocol}}",
@@ -1403,10 +1323,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?offset=-1",
 							"protocol": "{{protocol}}",
@@ -1478,10 +1394,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?offset=2147483648",
 							"protocol": "{{protocol}}",
@@ -2125,10 +2037,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups/{{newgroupid}}",
 							"protocol": "{{protocol}}",
@@ -2268,10 +2176,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?query=(group=fse*)",
 							"protocol": "{{protocol}}",
@@ -2407,10 +2311,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?query=(group=fse testing librarian)",
 							"protocol": "{{protocol}}",
@@ -2438,7 +2338,6 @@
 							"listen": "test",
 							"script": {
 								"id": "65f15cd6-09b9-436c-a8d6-ebf90e3c440a",
-								"type": "text/javascript",
 								"exec": [
 									"let response = JSON.parse(responseBody);",
 									"let groupId = pm.environment.get(\"newgroupid\");",
@@ -2528,17 +2427,18 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "86e6fcdc-8458-4d14-8559-d9c8bce64fcb",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2554,12 +2454,8 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?query=(group=*test* and desc=main*)",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?query=(group=fse* and desc=main*)",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -2571,7 +2467,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "(group=*test* and desc=main*)"
+									"value": "(group=fse* and desc=main*)"
 								}
 							]
 						}
@@ -2585,7 +2481,6 @@
 							"listen": "test",
 							"script": {
 								"id": "65f15cd6-09b9-436c-a8d6-ebf90e3c440a",
-								"type": "text/javascript",
 								"exec": [
 									"let response = JSON.parse(responseBody);",
 									"let groupId = pm.environment.get(\"newgroupid\");",
@@ -2675,17 +2570,18 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "86e6fcdc-8458-4d14-8559-d9c8bce64fcb",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2701,12 +2597,8 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?query=(group=*test* and desc=main*)",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups?query=(group=fse* and desc=main*)",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -2718,7 +2610,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "(group=*test* and desc=main*)"
+									"value": "(group=fse* and desc=main*)"
 								}
 							]
 						}
@@ -2946,10 +2838,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/groups/{{newgroupid}}",
 							"protocol": "{{protocol}}",
@@ -3100,10 +2988,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/addresstypes",
 							"protocol": "{{protocol}}",
@@ -3589,10 +3473,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/addresstypes/{{newaddresstypeid}}",
 							"protocol": "{{protocol}}",
@@ -3807,10 +3687,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/addresstypes/{{newaddresstypeid}}",
 							"protocol": "{{protocol}}",
@@ -4067,10 +3943,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/proxiesfor",
 							"protocol": "{{protocol}}",
@@ -4189,10 +4061,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/proxiesfor/{{proxyforid}}",
 							"protocol": "{{protocol}}",
@@ -4630,10 +4498,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/proxiesfor/{{proxyforid}}",
 							"protocol": "{{protocol}}",
@@ -4766,10 +4630,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users",
 							"protocol": "{{protocol}}",
@@ -5177,10 +5037,6 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/{{newuserid}}",
 							"protocol": "{{protocol}}",
@@ -5430,13 +5286,12 @@
 					"response": []
 				},
 				{
-					"name": "/users/foo",
+					"name": "/users/3ae9bc25-e65b-4bb7-875a-3d440a24309a (non-existent user)",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "d4300850-b836-4003-ba91-e345eca7c9a4",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"Status is 404\", function () {",
 									"    pm.response.to.have.status(404);",
@@ -5447,7 +5302,7 @@
 									"});",
 									"",
 									"pm.test(\"Body matches string\", function () {",
-									"    pm.expect(pm.response.text()).to.include(\"UserObject does not exist\");",
+									"    pm.expect(pm.response.text()).to.include(\"Not found\");",
 									"});",
 									"",
 									"",
@@ -5513,7 +5368,8 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5533,12 +5389,8 @@
 								"value": "{{xokapitoken}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/foo",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/3ae9bc25-e65b-4bb7-875a-3d440a24309a",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -5546,24 +5398,22 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"users",
-								"foo"
+								"3ae9bc25-e65b-4bb7-875a-3d440a24309a"
 							]
 						}
 					},
 					"response": []
 				},
 				{
-					"name": "/users/foo",
+					"name": "/users/3ae9bc25-e65b-4bb7-875a-3d440a24309a (non-existent user)",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "b159c9a5-710a-4d66-89d3-9fdf88af9a20",
-								"type": "text/javascript",
 								"exec": [
-									"//this actually should be 404 status",
-									"pm.test(\"Status is 204\", function () {",
-									"    pm.response.to.have.status(204);",
+									"pm.test(\"Status is 404\", function () {",
+									"    pm.response.to.have.status(404);",
 									"});",
 									"",
 									"",
@@ -5620,7 +5470,8 @@
 									"",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5645,7 +5496,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/foo",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/3ae9bc25-e65b-4bb7-875a-3d440a24309a",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -5653,7 +5504,7 @@
 							"port": "{{okapiport}}",
 							"path": [
 								"users",
-								"foo"
+								"3ae9bc25-e65b-4bb7-875a-3d440a24309a"
 							]
 						}
 					},


### PR DESCRIPTION
Several minor adjustments to account for changes to mod-users behavior:

* Can no longer use preceding wildcard in CQL queries... 
  * Changed `*test*` -> `fse*` in a few places
* DELETE of a non-existent record results in a 404, not 204
* GET of a non-existent user results in 404 - Not Found
* UUID format enforced - results in a separate error 
  * Changed `GET /user/foo` to `GET /user/<UUID>`
  * Changed `DELETE /user/foo` to `DELETE /user/<UUID>`