### PR TITLE
MODORDERS-256 Restrict view of PO and POL records based upon acquisitions unit

### DIFF
--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -720,6 +720,68 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Create ISBN identifier",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"ISBN is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"name\":\"ISBN\",\r\n  \"source\": \"folio\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/identifier-types",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"identifier-types"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -1539,6 +1601,7 @@
 											"    let jsonData = pm.response.json();",
 											"    pm.expect(jsonData.id).to.exist;",
 											"    pm.environment.set(\"firstOrderId\", jsonData.id); ",
+											"    pm.environment.set(\"firstOrderFirstLineId\", jsonData.compositePoLines[0].id); ",
 											"});",
 											""
 										],
@@ -1581,6 +1644,112 @@
 							"response": []
 						},
 						{
+							"name": "Get order with 1 line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{firstOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{firstOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Get line of order with 1 line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{firstOrderFirstLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{firstOrderFirstLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
 							"name": "Create Draft order with 2 lines",
 							"event": [
 								{
@@ -1607,6 +1776,7 @@
 											"    let jsonData = pm.response.json();",
 											"    pm.expect(jsonData.id).to.exist;",
 											"    pm.environment.set(\"secondOrderId\", jsonData.id); ",
+											"    pm.environment.set(\"secondOrderFirstLineId\", jsonData.compositePoLines[0].id); ",
 											"});",
 											""
 										],
@@ -1645,6 +1815,112 @@
 									]
 								},
 								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
+							},
+							"response": []
+						},
+						{
+							"name": "Get order with 2 lines",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{secondOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{secondOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Get line of order with 2 lines",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{secondOrderFirstLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{secondOrderFirstLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
 							},
 							"response": []
 						},
@@ -1832,7 +2108,7 @@
 							"response": []
 						},
 						{
-							"name": "Assign fully protected unit to an order",
+							"name": "Assign fully protected unit to an order with 1 line",
 							"event": [
 								{
 									"listen": "test",
@@ -1901,6 +2177,303 @@
 										"{{firstOrderId}}"
 									]
 								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get order with 1 line - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can not be viewed\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{firstOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{firstOrderId}}"
+									]
+								},
+								"description": "Fully protected acq unit is assigned to this order so view is forbidden"
+							},
+							"response": []
+						},
+						{
+							"name": "Get line of order with 1 line - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can not be viewed\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{firstOrderFirstLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{firstOrderFirstLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Assign read-only unit to an order with 2 lines",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Order is updated successfully\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.sendGetRequest(\"/orders/composite-orders/\" + pm.environment.get(\"secondOrderId\"), (err, res) => {",
+											"    pm.test(\"Order is successfully retrieved and ready for updates\", () => {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(res).to.have.property('code', 200);",
+											"",
+											"        // Assign unit to an order",
+											"        let order = res.json();",
+											"        order.acqUnitIds.push(pm.environment.get(\"readOpenUnitId\"));",
+											"        pm.variables.set(\"orderBody\", JSON.stringify(order));",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{orderBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{secondOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{secondOrderId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get order with 2 lines - success",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{secondOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{secondOrderId}}"
+									]
+								},
+								"description": "There is one acq unit assigned to this order but it does not restrict \"view\""
+							},
+							"response": []
+						},
+						{
+							"name": "Get line of order with 2 lines - success",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{secondOrderFirstLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{secondOrderFirstLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
 							},
 							"response": []
 						},
@@ -2148,6 +2721,218 @@
 										"memberships"
 									]
 								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get order with 1 line - success",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{firstOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{firstOrderId}}"
+									]
+								},
+								"description": "Fully protected acq unit is assigned to this order but user belongs to it so view is allowed"
+							},
+							"response": []
+						},
+						{
+							"name": "Get line of order with 1 line - success",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{firstOrderFirstLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{firstOrderFirstLineId}}"
+									]
+								},
+								"description": "Fully protected acq unit is assigned to this order but user belongs to it so view is allowed"
+							},
+							"response": []
+						},
+						{
+							"name": "Get order with 2 lines - success",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{secondOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{secondOrderId}}"
+									]
+								},
+								"description": "There is one acq unit assigned to this order but it does not restrict \"view\""
+							},
+							"response": []
+						},
+						{
+							"name": "Get line of order with 2 lines - success",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => pm.response.to.be.ok);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{secondOrderFirstLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{secondOrderFirstLineId}}"
+									]
+								},
+								"description": "There is one acq unit assigned to this order but it does not restrict \"view\""
 							},
 							"response": []
 						},
@@ -4088,6 +4873,9 @@
 					"        if (poLine.hasOwnProperty(\"physical\")) {",
 					"            poLine.physical.createInventory = \"None\";",
 					"        }",
+					"        if (poLine.hasOwnProperty(\"details\")) {",
+					"            delete poLine.details.productIds;",
+					"        }",
 					"",
 					"        return poLine;",
 					"    };",
@@ -4188,10 +4976,13 @@
 					"        pm.environment.unset(\"activeVendorId\");",
 					"        pm.environment.unset(\"enabledModules\");",
 					"        pm.environment.unset(\"firstOrderId\");",
+					"        pm.environment.unset(\"firstOrderFirstLineId\");",
 					"        pm.environment.unset(\"fullyProtectedUnitId\");",
+					"        pm.environment.unset(\"readOpenUnitId\");",
 					"        pm.environment.unset(\"createOpenUnitId\");",
 					"        pm.environment.unset(\"xokapitoken-limitedUesr\");",
 					"        pm.environment.unset(\"secondOrderId\");",
+					"        pm.environment.unset(\"secondOrderFirstLineId\");",
 					"        pm.environment.unset(\"xokapitoken\");",
 					"        pm.environment.unset(\"xokapitoken-admin\");",
 					"        pm.environment.unset(\"xokapitoken-testAdmin\");",


### PR DESCRIPTION
## Purpose
[MODORDERS-256](https://issues.folio.org/browse/MODORDERS-256) Restrict view of PO and POLrecords based upon acquisitions unit

## Approach
Adding tests to verify restriction of getting order and order line by id operations.

![image](https://user-images.githubusercontent.com/43410167/62790115-0ec26f00-bad3-11e9-85c6-62974af9eb5e.png)

## Verification on folio-snapshot
![image](https://user-images.githubusercontent.com/43410167/62851871-4c501380-bcf0-11e9-8a06-f97dac4d2162.png)




