### PR TITLE
MODINVOICE-86/87 Calculate and persist invoice and invoice line totals

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -3139,6 +3139,152 @@
 							"response": []
 						},
 						{
+							"name": "Verify invoice line totals persisted",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let lines = [];",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    lines = pm.response.json().invoiceLines || [];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    pm.expect(lines).to.have.lengthOf(1);",
+											"    let invoiceLine = lines[0];",
+											"",
+											"    // validate calculated totals are persisted",
+											"    pm.expect(invoiceLine.adjustmentsTotal, \"adjustmentsTotal\").to.equal(15.37);",
+											"    pm.expect(invoiceLine.subTotal, \"subTotal\").to.equal(54.32);",
+											"    pm.expect(invoiceLine.total, \"total\").to.equal(69.69);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines?query=invoiceId=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "invoiceId=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "Sending `GET` collection of invoice lines by invoice id to verify total amounts are persisted."
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice totals are updated",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    let invoices = pm.response.json().invoices;",
+											"    pm.expect(invoices).to.have.lengthOf(1);",
+											"    invoice = invoices[0];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    // validate against schema",
+											"    utils.validateInvoice(invoice);",
+											"",
+											"    // validate calculated totals",
+											"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(63.95);",
+											"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(54.32);",
+											"    pm.expect(invoice.total, \"total\").to.equal(12.34);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices?query=id=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "id=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "Sending `GET` collection of invoices by invoice id to verify total amounts are persisted."
+							},
+							"response": []
+						},
+						{
 							"name": "Get invoice with 1 line",
 							"event": [
 								{
@@ -3219,6 +3365,7 @@
 											"pm.test(\"Invoice Line is created\", function () {",
 											"    pm.response.to.have.status(201);",
 											"    invoiceLine = pm.response.json();",
+											"    pm.environment.set(\"invoiceWithLockedTotalSecondInvoiceLineId\", invoiceLine.id);",
 											"});",
 											"",
 											"pm.test(\"Calculated totals\",function(){",
@@ -3286,6 +3433,155 @@
 									]
 								},
 								"description": "Tests the adjustments calculations \n1.with amount and Percentage \n2.only \"In addition to\" relationToTotal adjustments are included in the calculation"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice lines totals persisted",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let lines = [];",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    lines = pm.response.json().invoiceLines || [];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    pm.expect(lines).to.have.lengthOf(2);",
+											"    lines.forEach(invoiceLine => {",
+											"        // validate calculated totals are persisted",
+											"        pm.expect(invoiceLine.adjustmentsTotal, \"adjustmentsTotal\").to.be.oneOf([15.37, 6.65]);",
+											"        pm.expect(invoiceLine.subTotal, \"subTotal\").to.be.oneOf([54.32, 15.87]);",
+											"        pm.expect(invoiceLine.total, \"total\").to.be.oneOf([69.69, 22.52]);",
+											"    });",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines?query=invoiceId=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "invoiceId=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "The invoice should have at this step 2 lines created. Sending `GET` collection of invoice lines by invoice id to verify total amounts are persisted."
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice totals are updated",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    let invoices = pm.response.json().invoices;",
+											"    pm.expect(invoices).to.have.lengthOf(1);",
+											"    invoice = invoices[0];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    // validate against schema",
+											"    utils.validateInvoice(invoice);",
+											"",
+											"    // validate calculated totals",
+											"    // 22.02 - invoice lines adjustments total; 35 - fixed amount of invoice adjustments; 17.55 - 25% of invoice's subTotal",
+											"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(22.02 + 35 + 17.55);",
+											"    // sum of sub totals of invoice lines",
+											"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(70.19);",
+											"    // the total is locked",
+											"    pm.expect(invoice.total, \"total\").to.equal(12.34);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices?query=id=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "id=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "The invoice should have at this step 2 lines created. Sending `GET` collection of invoices by invoice id to verify total amounts are persisted."
 							},
 							"response": []
 						},
@@ -3385,8 +3681,6 @@
 									"script": {
 										"id": "d30a0dbb-bd13-400b-9f39-687730665090",
 										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
 											"pm.test(\"Invoice updated\", () => pm.response.to.have.status(204));"
 										],
 										"type": "text/javascript"
@@ -3422,6 +3716,75 @@
 										"{{invoiceWithLockedTotalId}}"
 									]
 								}
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice total is recalculated and persisted",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    invoice = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    // validate against schema",
+											"    utils.validateInvoice(invoice);",
+											"",
+											"    // validate calculated totals",
+											"    // 22.02 - invoice lines adjustments total; 35 - fixed amount of invoice adjustments; 17.55 - 25% of invoice's subTotal",
+											"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(74.57);",
+											"    // sum of sub totals of invoice lines",
+											"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(70.19);",
+											"    // the total is locked",
+											"    pm.expect(invoice.total, \"total\").to.equal(144.76);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{invoiceWithLockedTotalId}}"
+									]
+								},
+								"description": "The invoice should have at this step 2 lines created by `Invoice lines -> adjustments` requests"
 							},
 							"response": []
 						},
@@ -3495,6 +3858,551 @@
 							"response": []
 						},
 						{
+							"name": "Update second line removing adjustments",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"utils.sendGetRequest(\"/invoice/invoice-lines/\" + pm.environment.get(\"invoiceWithLockedTotalSecondInvoiceLineId\"), (err, res) => {",
+											"    let invoiceLine = res.json();",
+											"",
+											"    delete invoiceLine.adjustments;",
+											"    invoiceLine.subTotal = 8.13;",
+											"",
+											"    pm.variables.set(\"invoiceLineUpdatedContent\", JSON.stringify(invoiceLine));",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d30a0dbb-bd13-400b-9f39-687730665090",
+										"exec": [
+											"pm.test(\"Invoice line is updated\", () => pm.response.to.have.status(204));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{invoiceLineUpdatedContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{invoiceWithLockedTotalSecondInvoiceLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines",
+										"{{invoiceWithLockedTotalSecondInvoiceLineId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Verify second invoice line totals updated",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let lines = [];",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    lines = pm.response.json().invoiceLines || [];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    pm.expect(lines).to.have.lengthOf(2);",
+											"    lines.forEach(invoiceLine => {",
+											"        // validate calculated totals are persisted",
+											"        pm.expect(invoiceLine.adjustmentsTotal, \"adjustmentsTotal\").to.be.oneOf([15.37, 0.0]);",
+											"        pm.expect(invoiceLine.subTotal, \"subTotal\").to.be.oneOf([54.32, 8.13]);",
+											"        pm.expect(invoiceLine.total, \"total\").to.be.oneOf([69.69, 8.13]);",
+											"    });",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines?query=invoiceId=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "invoiceId=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "The invoice should have at this step 2 lines created. Sending `GET` collection of invoice lines by invoice id to verify total amounts are persisted."
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice totals are updated - by query",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    let invoices = pm.response.json().invoices;",
+											"    pm.expect(invoices).to.have.lengthOf(1);",
+											"    invoice = invoices[0];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    // validate against schema",
+											"    utils.validateInvoice(invoice);",
+											"",
+											"    // validate calculated totals",
+											"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(65.98);",
+											"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(62.45);",
+											"    pm.expect(invoice.total, \"total\").to.equal(128.43);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices?query=id=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "id=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "The invoice should have at this step 2 lines created. Sending `GET` collection of invoices by invoice id to verify total amounts are persisted."
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice totals are updated - by id",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    invoice = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    // validate against schema",
+											"    utils.validateInvoice(invoice);",
+											"",
+											"    // validate calculated totals",
+											"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(65.98);",
+											"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(62.45);",
+											"    pm.expect(invoice.total, \"total\").to.equal(128.43);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{invoiceWithLockedTotalId}}"
+									]
+								},
+								"description": "The invoice should have at this step 2 lines created by `Invoice lines -> adjustments` requests"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete second invoice line",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Invoice line is deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.environment.unset(\"invoiceWithLockedTotalSecondInvoiceLineId\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{invoiceWithLockedTotalSecondInvoiceLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines",
+										"{{invoiceWithLockedTotalSecondInvoiceLineId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get invoice lines for invoice - only one left",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let lines = [];",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    lines = pm.response.json().invoiceLines || [];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    pm.expect(lines).to.have.lengthOf(1);",
+											"    let invoiceLine = lines[0];",
+											"",
+											"    // validate calculated totals are persisted",
+											"    pm.expect(invoiceLine.adjustmentsTotal, \"adjustmentsTotal\").to.equal(15.37);",
+											"    pm.expect(invoiceLine.subTotal, \"subTotal\").to.equal(54.32);",
+											"    pm.expect(invoiceLine.total, \"total\").to.equal(69.69);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines?query=invoiceId=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "invoiceId=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "Sending `GET` collection of invoice lines by invoice id to verify total amounts are persisted."
+							},
+							"response": []
+						},
+						{
+							"name": "Verify invoice totals are updated - by query",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    let invoices = pm.response.json().invoices;",
+											"    pm.expect(invoices).to.have.lengthOf(1);",
+											"    invoice = invoices[0];",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    // validate against schema",
+											"    utils.validateInvoice(invoice);",
+											"",
+											"    // validate calculated totals",
+											"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(63.95);",
+											"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(54.32);",
+											"    pm.expect(invoice.total, \"total\").to.equal(118.27);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices?query=id=={{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "id=={{invoiceWithLockedTotalId}}"
+										}
+									]
+								},
+								"description": "Sending `GET` collection of invoices by invoice id to verify total amounts are persisted."
+							},
+							"response": []
+						},
+						{
+							"name": "Get invoice to check totals - by id",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let invoice = {};",
+											"",
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.json;",
+											"    invoice = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Validate fields\", function() {",
+											"    // validate against schema",
+											"    utils.validateInvoice(invoice);",
+											"",
+											"    // validate calculated totals",
+											"    pm.expect(invoice.adjustmentsTotal, \"adjustmentsTotal\").to.equal(63.95);",
+											"    pm.expect(invoice.subTotal, \"subTotal\").to.equal(54.32);",
+											"    pm.expect(invoice.total, \"total\").to.equal(118.27);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceWithLockedTotalId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{invoiceWithLockedTotalId}}"
+									]
+								},
+								"description": "The invoice should have at this step 2 lines created by `Invoice lines -> adjustments` requests"
+							},
+							"response": []
+						},
+						{
 							"name": "Delete  invoice",
 							"event": [
 								{
@@ -3504,6 +4412,7 @@
 										"exec": [
 											"pm.test(\"Invoice is deleted\", function () {",
 											"    pm.response.to.have.status(204);",
+											"    pm.environment.unset(\"invoiceWithLockedTotalId\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -4826,386 +5735,70 @@
 					"name": "Create invoices for negative tests",
 					"item": [
 						{
-							"name": "Create reviewed invoice",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"let invoice = {};",
-											"",
-											"pm.test(\"Invoice is created\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    invoice = pm.response.json();",
-											"});",
-											"",
-											"pm.test(\"Invoice content is valid\", function() {",
-											"    pm.environment.set(\"negativeReviewedToApprovedInvoiceId\", invoice.id);",
-											"    pm.environment.set(\"negativeReviewedToApprovedInvoiceContent\", JSON.stringify(invoice));",
-											"",
-											"    createLine(invoice.id);",
-											"",
-											"    // Verify that voucher has not been created",
-											"    utils.getVouchersForInvoice(invoice.id, (err, res) => {",
-											"        pm.test(\"No voucher created\", () => pm.expect(res.json().vouchers).to.be.empty);",
-											"    });",
-											"});",
-											"",
-											"function createLine(invoiceId) {",
-											"",
-											"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoiceId);",
-											"",
-											"    // Now creating invoice line",
-											"    utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
-											"        pm.test(\"Invoice line is created in storage\", () => {",
-											"          pm.expect(err).to.equal(null);",
-											"          pm.expect(response).to.have.property('code', 201);",
-											"        });",
-											"    });",
-											"",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
-											"",
-											"invoice.note += \" - transition to Approved\";",
-											"invoice.status = \"Reviewed\";",
-											"delete invoice.adjustments;",
-											"delete invoice.voucherNumber;",
-											"delete invoice.approvalDate;",
-											"delete invoice.approvedBy;",
-											"",
-											"pm.environment.set(\"negativeReviewedToApprovedInvoiceContent\", JSON.stringify(invoice));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{negativeReviewedToApprovedInvoiceContent}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Create approved invoice",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"let invoice = {};",
-											"",
-											"pm.test(\"Invoice is created\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    invoice = pm.response.json();",
-											"});",
-											"",
-											"pm.test(\"Invoice content is valid\", function() {",
-											"    pm.environment.set(\"negativeApprovedToPaidInvoice\", invoice.id);",
-											"    pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
-											"    utils.validateInvoice(invoice);",
-											"    ",
-											"});",
-											"",
-											"",
-											"let invoiceLine = utils.getMockInvoiceLine();",
-											"invoiceLine.invoiceId = pm.environment.get(\"negativeApprovedToPaidInvoice\");",
-											"invoiceLine.fundDistributions.forEach(distro => distro.fundId = pm.environment.get(\"fundId\"));",
-											"delete invoiceLine.id;",
-											"delete invoiceLine.metadata;",
-											"var uuid = require('uuid');",
-											"invoiceLine.poLineId = uuid.v4();",
-											"",
-											"utils.sendPostRequest(\"/invoice-storage/invoice-lines\", invoiceLine, function(err,response){",
-											"    pm.test(\"Invoice line is created in storage\", function(){",
-											"      pm.expect(err).to.equal(null);",
-											"    });",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
-											"",
-											"invoice.note += \" - transition to Paid\";",
-											"invoice.status = \"Approved\";",
-											"",
-											"pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{negativeApprovedToPaidInvoiceContent}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Create approved invoice with locked total",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let invoice = utils.prepareInvoice(utils.getMockInvoice(0));",
-											"",
-											"invoice.lockTotal = true;",
-											"invoice.total = 12.34;",
-											"invoice.note += \" - locked total\";",
-											"invoice.status = \"Open\";",
-											"",
-											"delete invoice.approvalDate;",
-											"delete invoice.approvedBy;",
-											"",
-											"pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "d30a0dbb-bd13-400b-9f39-687730665090",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"let invoice = {};",
-											"",
-											"pm.test(\"Invoice is created\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    invoice = pm.response.json();",
-											"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalId\", invoice.id);",
-											"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalContent\", JSON.stringify(invoice));",
-											"    utils.validateInvoice(invoice);",
-											"    addLine(invoice);",
-											"});",
-											"",
-											"function addLine(invoice) {",
-											"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoice.id);",
-											"    invoiceLine.poLineId = pm.globals.get(\"poLine1Id\");",
-											"",
-											"    utils.sendPostRequest(\"/invoice-storage/invoice-lines\", invoiceLine, function(err,response){",
-											"        pm.test(\"Invoice line is created in storage\", function(){",
-											"          pm.expect(err).to.equal(null);",
-											"          pm.expect(response).to.have.property('code', 201);",
-											"          utils.updateInvoiceStatus(invoice, \"Approved\");",
-											"        });",
-											"    });",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{invoiceContentLockedTotal}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Verify invoice with locked total and delete voucher",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "d30a0dbb-bd13-400b-9f39-687730665090",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"let invoice = {};",
-											"",
-											"pm.test(\"Invoice is Approved\", function () {",
-											"    pm.response.to.have.status(200);",
-											"    invoice = pm.response.json();",
-											"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalContent\", JSON.stringify(invoice));",
-											"    pm.expect(invoice).to.have.property('status', \"Approved\");",
-											"    utils.deleteVouchersForInvoice(invoice.id);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativeApprovedInvoiceWithLockedTotalId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices",
-										"{{negativeApprovedInvoiceWithLockedTotalId}}"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Invoices",
-					"item": [
-						{
-							"name": "Protected Fields Modification",
+							"name": "Reviewed",
 							"item": [
 								{
-									"name": "Create invoice with protected fields",
+									"name": "Create reviewed invoice",
 									"event": [
 										{
-											"listen": "prerequest",
+											"listen": "test",
 											"script": {
-												"id": "3f4b21e8-9911-4c39-8757-1d69b0f99051",
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
 													"",
-													"let json = utils.buildInvoiceWithMinContent();",
-													"json.status = \"Approved\";",
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    invoice = pm.response.json();",
+													"});",
 													"",
-													"pm.variables.set(\"approvedInvoice\", JSON.stringify(json));",
-													""
+													"pm.test(\"Invoice content is valid\", function() {",
+													"    pm.environment.set(\"negativeReviewedToApprovedInvoiceId\", invoice.id);",
+													"    pm.environment.set(\"negativeReviewedToApprovedInvoiceContent\", JSON.stringify(invoice));",
+													"",
+													"    createLine(invoice.id);",
+													"",
+													"    // Verify that voucher has not been created",
+													"    utils.getVouchersForInvoice(invoice.id, (err, res) => {",
+													"        pm.test(\"No voucher created\", () => pm.expect(res.json().vouchers).to.be.empty);",
+													"    });",
+													"});",
+													"",
+													"function createLine(invoiceId) {",
+													"",
+													"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoiceId);",
+													"",
+													"    // Now creating invoice line",
+													"    utils.sendPostRequest(\"/invoice/invoice-lines\", invoiceLine, (err, response) => {",
+													"        pm.test(\"Invoice line is created in storage\", () => {",
+													"          pm.expect(err).to.equal(null);",
+													"          pm.expect(response).to.have.property('code', 201);",
+													"        });",
+													"    });",
+													"",
+													"}"
 												],
 												"type": "text/javascript"
 											}
 										},
 										{
-											"listen": "test",
+											"listen": "prerequest",
 											"script": {
-												"id": "7bfa1e35-0c0b-4def-8439-e400734ec857",
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
 													"",
-													"pm.test(\"Invoice is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    let invoice = pm.response.json();",
-													"    pm.environment.set(\"approvedInvoiceId\", invoice.id);",
-													"});"
+													"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
+													"",
+													"invoice.note += \" - transition to Approved\";",
+													"invoice.status = \"Reviewed\";",
+													"delete invoice.adjustments;",
+													"delete invoice.voucherNumber;",
+													"delete invoice.approvalDate;",
+													"delete invoice.approvedBy;",
+													"",
+													"pm.environment.set(\"negativeReviewedToApprovedInvoiceContent\", JSON.stringify(invoice));"
 												],
 												"type": "text/javascript"
 											}
@@ -5225,7 +5818,102 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{{approvedInvoice}}"
+											"raw": "{{negativeReviewedToApprovedInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Approved",
+							"item": [
+								{
+									"name": "Create approved invoice",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"",
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    invoice = pm.response.json();",
+													"});",
+													"",
+													"pm.test(\"Invoice content is valid\", function() {",
+													"    pm.environment.set(\"negativeApprovedToPaidInvoice\", invoice.id);",
+													"    pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
+													"    utils.validateInvoice(invoice);",
+													"    addInvoiceLine();",
+													"});",
+													"",
+													"function addInvoiceLine() {",
+													"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), pm.environment.get(\"negativeApprovedToPaidInvoice\"));",
+													"    invoiceLine.poLineId = require('uuid').v4();",
+													"    ",
+													"    utils.sendPostRequest(\"/invoice-storage/invoice-lines\", invoiceLine, function(err,response){",
+													"        pm.test(\"Invoice line is created in storage\", function(){",
+													"          pm.expect(response).to.have.status(201);",
+													"          pm.expect(err).to.equal(null);",
+													"          pm.environment.set(\"negativeApprovedToPaidInvoiceLineId\", response.json().id);",
+													"        });",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
+													"",
+													"invoice.note += \" - transition to Paid\";",
+													"invoice.status = \"Approved\";",
+													"",
+													"pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{negativeApprovedToPaidInvoiceContent}}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
@@ -5243,6 +5931,169 @@
 									"response": []
 								},
 								{
+									"name": "Create approved invoice with locked total",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let invoice = utils.prepareInvoice(utils.getMockInvoice(0));",
+													"",
+													"invoice.lockTotal = true;",
+													"invoice.total = 12.34;",
+													"invoice.note += \" - locked total\";",
+													"invoice.status = \"Open\";",
+													"",
+													"delete invoice.approvalDate;",
+													"delete invoice.approvedBy;",
+													"",
+													"pm.variables.set(\"invoiceContentLockedTotal\", JSON.stringify(invoice));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "d30a0dbb-bd13-400b-9f39-687730665090",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"",
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    invoice = pm.response.json();",
+													"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalId\", invoice.id);",
+													"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalContent\", JSON.stringify(invoice));",
+													"    utils.validateInvoice(invoice);",
+													"    addLine(invoice);",
+													"});",
+													"",
+													"function addLine(invoice) {",
+													"    let invoiceLine = utils.prepareInvoiceLine(utils.getMockInvoiceLine(), invoice.id);",
+													"    invoiceLine.poLineId = pm.globals.get(\"poLine1Id\");",
+													"",
+													"    utils.sendPostRequest(\"/invoice-storage/invoice-lines\", invoiceLine, function(err,response){",
+													"        pm.test(\"Invoice line is created in storage\", function(){",
+													"          pm.expect(err).to.equal(null);",
+													"          pm.expect(response).to.have.property('code', 201);",
+													"          utils.updateInvoiceStatus(invoice, \"Approved\");",
+													"        });",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{invoiceContentLockedTotal}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify invoice with locked total and delete voucher",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5ad7d58e-c223-4e15-a362-29e49c972f3d",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "d30a0dbb-bd13-400b-9f39-687730665090",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"",
+													"pm.test(\"Invoice is Approved\", function () {",
+													"    pm.response.to.have.status(200);",
+													"    invoice = pm.response.json();",
+													"    pm.environment.set(\"negativeApprovedInvoiceWithLockedTotalContent\", JSON.stringify(invoice));",
+													"    pm.expect(invoice).to.have.property('status', \"Approved\");",
+													"    utils.deleteVouchersForInvoice(invoice.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativeApprovedInvoiceWithLockedTotalId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativeApprovedInvoiceWithLockedTotalId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Invoices",
+					"item": [
+						{
+							"name": "Protected Fields Modification",
+							"item": [
+								{
 									"name": "Update Invoice with protected fields",
 									"event": [
 										{
@@ -5252,9 +6103,10 @@
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
 													"",
-													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"approvedInvoiceId\"), (err, res) => {",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativeApprovedToPaidInvoice\"), (err, res) => {",
 													"    let invoice  = res.json();",
 													"    invoice.currency = \"TUGRIK\";",
+													"    invoice.total = 100.500;",
 													"    pm.variables.set(\"updatedApprovedInvoiceBody\", JSON.stringify(invoice));",
 													"});"
 												],
@@ -5270,9 +6122,11 @@
 													"",
 													"pm.test(\"Status code is 400\", function () {",
 													"    pm.response.to.have.status(400);",
-													"    pm.expect(pm.response.text()).to.include(\"Field can't be modified\");",
-													"    pm.expect(pm.response.text()).to.include(\"protectedFieldChanging\");",
-													"    pm.expect(pm.response.text()).to.include(\"currency\");",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors).to.have.lengthOf(1);",
+													"    pm.expect(errors[0].message).to.include(\"Field can't be modified\");",
+													"    pm.expect(errors[0].code).to.include(\"protectedFieldChanging\");",
+													"    pm.expect(errors[0].protectedAndModifiedFields).to.include.members([\"currency\", \"total\"]);",
 													"    pm.response.to.have.jsonBody(\"total_records\", 1);",
 													"});"
 												],
@@ -5303,7 +6157,7 @@
 											"raw": "{{updatedApprovedInvoiceBody}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{approvedInvoiceId}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativeApprovedToPaidInvoice}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -5312,7 +6166,7 @@
 											"path": [
 												"invoice",
 												"invoices",
-												"{{approvedInvoiceId}}"
+												"{{negativeApprovedToPaidInvoice}}"
 											]
 										},
 										"description": "Verify [MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) - the order can be updated if created without workflow status"
@@ -6058,8 +6912,6 @@
 										"exec": [
 											"let invoice = JSON.parse(globals.negativeApprovedToPaidInvoiceContent);",
 											"invoice.status = \"Paid\";",
-											"delete invoice.subTotal;",
-											"delete invoice.total;",
 											"pm.globals.set(\"negativeApprovedToPaidInvoiceContent\", JSON.stringify(invoice));",
 											""
 										],
@@ -6513,71 +7365,6 @@
 							"name": "Protected Fields Modification",
 							"item": [
 								{
-									"name": "Create invoice-line",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"let invoiceLine = {};",
-													"",
-													"pm.test(\"Invoice Line is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    invoiceLine = pm.response.json();",
-													"    pm.environment.set(\"approvedInvoiceInvoiceLineId\", invoiceLine.id);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"var invoiceLine = utils.buildInvoiceLineWithMinContent(pm.environment.get(\"invoiceId\"));",
-													"",
-													"pm.variables.set(\"approvedInvoiceInvoiceLine\", JSON.stringify(invoiceLine));"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken-admin}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{approvedInvoiceInvoiceLine}}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"invoice-storage",
-												"invoice-lines"
-											]
-										}
-									},
-									"response": []
-								},
-								{
 									"name": "Update Invoice-Line with protected fields",
 									"event": [
 										{
@@ -6587,9 +7374,10 @@
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
 													"",
-													"utils.sendGetRequest(\"/invoice/invoice-lines/\" + pm.environment.get(\"approvedInvoiceInvoiceLineId\"), (err, res) => {",
+													"utils.sendGetRequest(\"/invoice/invoice-lines/\" + pm.environment.get(\"negativeApprovedToPaidInvoiceLineId\"), (err, res) => {",
 													"    let invoiceLine  = res.json();",
 													"    invoiceLine.quantity = 10;",
+													"    invoiceLine.subTotal = 100.500;",
 													"    pm.variables.set(\"updatedApprovedInvoiceInvoiceLine\", JSON.stringify(invoiceLine));",
 													"});"
 												],
@@ -6602,7 +7390,15 @@
 												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
+													"",
 													"pm.test(\"Status code is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors).to.have.lengthOf(1);",
+													"    pm.expect(errors[0].message).to.include(\"Field can't be modified\");",
+													"    pm.expect(errors[0].code).to.include(\"protectedFieldChanging\");",
+													"    pm.expect(errors[0].protectedAndModifiedFields).to.include.members([\"quantity\", \"subTotal\"]);",
+													"    pm.response.to.have.jsonBody(\"total_records\", 1);",
 													"});"
 												],
 												"type": "text/javascript"
@@ -6632,7 +7428,7 @@
 											"raw": "{{updatedApprovedInvoiceInvoiceLine}}"
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{approvedInvoiceInvoiceLineId}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{negativeApprovedToPaidInvoiceLineId}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -6641,7 +7437,7 @@
 											"path": [
 												"invoice",
 												"invoice-lines",
-												"{{approvedInvoiceInvoiceLineId}}"
+												"{{negativeApprovedToPaidInvoiceLineId}}"
 											]
 										},
 										"description": "Verify [MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) - the order can be updated if created without workflow status"
@@ -9333,60 +10129,6 @@
 							"response": []
 						},
 						{
-							"name": "Delete Invoice with protected fields",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-										"exec": [
-											"pm.test(\"Invoice is deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{approvedInvoiceId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices",
-										"{{approvedInvoiceId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "Delete Invoice with empty FundDistributions",
 							"event": [
 								{
@@ -9664,9 +10406,7 @@
 									"script": {
 										"id": "ac493f0c-3e8c-4c07-94d2-6105617f0384",
 										"exec": [
-											"pm.test(\"User deleted - Expected No Content (204)\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
+											"pm.test(\"User deleted - Expected No Content (204)\", () => pm.response.to.have.status(204));"
 										],
 										"type": "text/javascript"
 									}
@@ -10641,6 +11381,7 @@
 					"        pm.environment.unset(\"negativeInvoiceLineContent\");",
 					"        pm.environment.unset(\"InvoiceWithEmptyFundDistrosId\");",
 					"        pm.environment.unset(\"incompatibleFieldsInvoiceId\");",
+					"        pm.environment.unset(\"negativeApprovedToPaidInvoiceLineId\");",
 					"        ",
 					"        pm.globals.unset(\"mock-invoices\");",
 					"        pm.globals.unset(\"mock-invoiceLine\");",


### PR DESCRIPTION
## Purpose
[MODINVOICE-87](https://issues.folio.org/browse/MODINVOICE-87) Calculate and persist invoice totals
[MODINVOICE-86](https://issues.folio.org/browse/MODINVOICE-86) Calculate and persist invoice line totals on creation

## Approach
Main updates: `Positive Tests` -> `Invoice calculated totals`. Additional tests are added to verify:
- invoice totals are updated when invoice line is added/deleted or invoice line totals are updated.
- invoice and invoice line totals are persisted (requests to get collection of invoices/invoice lines)

![image](https://user-images.githubusercontent.com/43410167/62955551-ebacfd80-bdf9-11e9-8923-f6b7d9cc24eb.png)

## Test run
![image](https://user-images.githubusercontent.com/43410167/62955579-f8315600-bdf9-11e9-816b-c3e89a02f973.png)
