### PR TITLE
MODINVOICE-74 Transpose invoice acquisitions-units to voucher upon voucher creation

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -4704,8 +4704,7 @@
 														"exec": [
 															"let invoice = JSON.parse(pm.environment.get(\"workflow-invoiceWith4LinesContent\"));",
 															"invoice.status = \"Approved\";",
-															"pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));",
-															""
+															"pm.environment.set(\"workflow-invoiceWith4LinesContent\", JSON.stringify(invoice));"
 														],
 														"type": "text/javascript"
 													}
@@ -4737,6 +4736,8 @@
 															"                    let voucher = res.json().vouchers[0];",
 															"                    pm.expect(voucher.status).to.eql(\"Awaiting payment\");",
 															"                    pm.expect(voucher.voucherNumber).to.include(pm.variables.get(\"voucherNumberPrefix\"));",
+															"                    //check acqUnitIds list of invoice and created voucher are equal",
+															"                    pm.expect(utils.arraysOfStringsAreEqual(invoice.acqUnitIds, voucher.acqUnitIds)).to.be.true;",
 															"                });",
 															"            });",
 															"        });",
@@ -5131,6 +5132,8 @@
 															"                    let voucher = res.json().vouchers[0];",
 															"                    pm.expect(voucher.status).to.eql(\"Awaiting payment\");",
 															"                    pm.expect(voucher.voucherNumber).to.not.include(pm.variables.get(\"voucherNumberPrefix\"));",
+															"                    //check acqUnitIds list of invoice and created voucher are equal",
+															"                    pm.expect(utils.arraysOfStringsAreEqual(invoice.acqUnitIds, voucher.acqUnitIds)).to.be.true;",
 															"                });",
 															"            });",
 															"        });",
@@ -11375,6 +11378,15 @@
 					"",
 					"        pm.sendRequest(pmRq, handler);",
 					"    };",
+					"    ",
+					"    ",
+					"    /**",
+					"    * Check if two arrays are equal",
+					"    */",
+					"    utils.arraysOfStringsAreEqual = function(array1, array2) {",
+					"        return JSON.stringify(array1)==JSON.stringify(array2);",
+					"    };",
+					"",
 					"",
 					"    return utils;",
 					"",
@@ -11395,37 +11407,37 @@
 	],
 	"variable": [
 		{
-			"id": "f0f36292-279d-4b40-a479-b5ea0bd06377",
+			"id": "0b8dcd18-4d7a-41b7-ace9-176a0fb7ee69",
 			"key": "resourcesUrl",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-invoice/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "cc6e0628-8680-4d80-a9fe-f32d85a12a38",
+			"id": "4b1436a2-a3f0-4aac-a0a5-95b7cc9413d8",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "906bcb9c-4e0e-430f-9f47-efeb3b57eceb",
+			"id": "b67c2460-6f2d-4402-ad2c-e111430960af",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "de88215b-906f-48a2-b735-d18f5c76552d",
+			"id": "872b279f-e6f3-40f2-bf0c-eb8e4bc6c47c",
 			"key": "finance-ledgerCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "cd57cd7d-2916-4a5b-af32-7f63df52ca98",
+			"id": "a1b681e4-95a7-4953-b6e8-6da0128d03f0",
 			"key": "finance-fundCode",
 			"value": "invoicingApiTests",
 			"type": "string"
 		},
 		{
-			"id": "6651c0ef-96f8-4fa4-87a5-60528a1de9d1",
+			"id": "81e498a7-5735-46a1-a7ad-71d55f449cd4",
 			"key": "voucherNumberPrefix",
 			"value": "testPrefix",
 			"type": "string"


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODINVOICE-74

## Approach
* Checked invoice and voucher acqUnitIds lists for equality after invoice approval.
![image](https://user-images.githubusercontent.com/45555481/63155298-f692a880-c01a-11e9-9941-ccbddf4af366.png)


Verified on folio testing:
![image](https://user-images.githubusercontent.com/45555481/63155137-b2070d00-c01a-11e9-950f-d4c62b824376.png)
