### PR TITLE
MODORDERS-286 - Restrict receive/checkin based on acquisitions units

### DIFF
--- a/mod-orders/acquisitions-units.postman_collection.json
+++ b/mod-orders/acquisitions-units.postman_collection.json
@@ -1768,7 +1768,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units?query=cql.allRecords=1 sortBy isDeleted/sort.descending",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units?query=isDeleted==(true or false) sortBy isDeleted/sort.descending",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -1781,7 +1781,7 @@
 									"query": [
 										{
 											"key": "query",
-											"value": "cql.allRecords=1 sortBy isDeleted/sort.descending"
+											"value": "isDeleted==(true or false) sortBy isDeleted/sort.descending"
 										}
 									]
 								}

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -7573,6 +7573,926 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Test protectReceivingChekin",
+					"item": [
+						{
+							"name": "Create order #1 [protected unit]",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "e0e31459-5477-4f72-a9d3-9cc347090686",
+										"exec": [
+											"pm.test(\"Order is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"orderId_1\", jsonData.id); ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "2e7a1cdc-439f-42da-bbea-3f23e6e474e9",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var order = {};",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
+											"    var order = utils.prepareOrder(res.json());",
+											"    order.workflowStatus = \"Pending\";",
+											"    order.acqUnitIds = [pm.environment.get(\"updateProtectUnitId\")];",
+											"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(order));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{po_listed_print_monograph}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create order #2 [non-protected unit]",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "e0e31459-5477-4f72-a9d3-9cc347090686",
+										"exec": [
+											"pm.test(\"Order is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"orderId_2\", jsonData.id); ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "2e7a1cdc-439f-42da-bbea-3f23e6e474e9",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var order = {};",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
+											"    var order = utils.prepareOrder(res.json());",
+											"    order.workflowStatus = \"Pending\";",
+											"    order.acqUnitIds = [pm.environment.get(\"updateOpenUnitId\"), pm.environment.get(\"createOpenUnitId\")];",
+											"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(order));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{po_listed_print_monograph}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create order line #1 [order with protected unit]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var line = {};",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/compositeLines/minimalContent.json\", function (err, res) {",
+											"    var line = utils.preparePoLine(res.json());",
+											"    line.purchaseOrderId = pm.environment.get(\"orderId_1\");",
+											"    pm.variables.set(\"minimal_content_line\", JSON.stringify(line));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Line is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"lineId_1\", jsonData.id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{minimal_content_line}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create order line #2 [order with non-protected unit]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var line = {};",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/compositeLines/minimalContent.json\", function (err, res) {",
+											"    var line = utils.preparePoLine(res.json());",
+											"    line.purchaseOrderId = pm.environment.get(\"orderId_2\"); ",
+											"    pm.variables.set(\"minimal_content_line\", JSON.stringify(line));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Line is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"lineId_2\", jsonData.id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{minimal_content_line}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create piece #1 [protected]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var piece = {};",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
+											"    var piece = utils.preparePoLine(res.json());",
+											"    piece.poLineId = pm.environment.get(\"lineId_1\");",
+											"    piece.receivingStatus = \"Expected\";",
+											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Piece is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"pieceId_1\", jsonData.id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{piece_content}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create piece #2 [non-protected]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var piece = {};",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
+											"    var piece = utils.preparePoLine(res.json());",
+											"    piece.poLineId = pm.environment.get(\"lineId_2\");",
+											"    piece.receivingStatus = \"Expected\";",
+											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Piece is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"pieceId_2\", jsonData.id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{piece_content}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check-In piece [non-protected unit, any user]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "6a20ec7b-44ce-4294-a23c-cdacdebf88bc",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let toBeCheckedInRq = utils.prepareCheckinRequestBody(pm.environment.get(\"lineId_2\"), pm.environment.get(\"pieceId_2\"), \"Expected\");",
+											"pm.variables.set(\"toBeCheckedIn_2\", JSON.stringify(toBeCheckedInRq));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a49d3ae5-3761-424e-85a7-b156b56347c5",
+										"exec": [
+											"pm.test(\"Check-in flow is OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedSuccessfully).to.eql(0);",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedWithError).to.eql(1);",
+											"    pm.expect(pm.response.json().receivingResults.pop().receivingItemResults.pop().processingStatus.error.code).not.to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{toBeCheckedIn_2}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Receive piece [non-protected unit, any user]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "6a20ec7b-44ce-4294-a23c-cdacdebf88bc",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let toBeReceivedRq = utils.prepareReceivingRequestBody(pm.environment.get(\"lineId_2\"), pm.environment.get(\"pieceId_2\"), \"Expected\");",
+											"pm.variables.set(\"toBeReceived_2\", JSON.stringify(toBeReceivedRq));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a49d3ae5-3761-424e-85a7-b156b56347c5",
+										"exec": [
+											"pm.test(\"Receiving flow is OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedSuccessfully).to.eql(0);",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedWithError).to.eql(1);",
+											"    pm.expect(pm.response.json().receivingResults.pop().receivingItemResults.pop().processingStatus.error.code).not.to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{toBeReceived_2}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check-In piece [protected unit, user isn't member of unit]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "6a20ec7b-44ce-4294-a23c-cdacdebf88bc",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let toBeCheckedInRq = utils.prepareCheckinRequestBody(pm.environment.get(\"lineId_1\"), pm.environment.get(\"pieceId_1\"), \"Expected\");",
+											"pm.variables.set(\"toBeCheckedIn_1\", JSON.stringify(toBeCheckedInRq));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a49d3ae5-3761-424e-85a7-b156b56347c5",
+										"exec": [
+											"pm.test(\"Check-in flow is OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedSuccessfully).to.eql(0);",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedWithError).to.eql(1);",
+											"    pm.expect(pm.response.json().receivingResults.pop().receivingItemResults.pop().processingStatus.error.code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{toBeCheckedIn_1}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Receive piece [protected unit, user isn't member of unit]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "6a20ec7b-44ce-4294-a23c-cdacdebf88bc",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let toBeReceivedRq = utils.prepareReceivingRequestBody(pm.environment.get(\"lineId_1\"), pm.environment.get(\"pieceId_1\"), \"Expected\");",
+											"pm.variables.set(\"toBeReceived_1\", JSON.stringify(toBeReceivedRq));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a49d3ae5-3761-424e-85a7-b156b56347c5",
+										"exec": [
+											"pm.test(\"Receiving flow is OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedSuccessfully).to.eql(0);",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedWithError).to.eql(1);",
+											"    pm.expect(pm.response.json().receivingResults.pop().receivingItemResults.pop().processingStatus.error.code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{toBeReceived_1}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Assign current user to create receiving/check-in",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "92915c1b-6bde-4a36-9433-bc8f257b567d",
+										"exec": [
+											"var jsonData = {};",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    jsonData = pm.response.json();",
+											"    pm.environment.set(\"createProtectUnitMembershipId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "0f1a616f-fd38-4215-96ab-50a48a033dec",
+										"exec": [
+											"let body = {};",
+											"",
+											"body.userId = globals.testData.users.limited.user.id;",
+											"body.acquisitionsUnitId = pm.environment.get(\"updateProtectUnitId\");",
+											"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{membershipBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check-In piece [protected unit, user is member of unit]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "6a20ec7b-44ce-4294-a23c-cdacdebf88bc",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let toBeCheckedInRq = utils.prepareCheckinRequestBody(pm.environment.get(\"lineId_1\"), pm.environment.get(\"pieceId_1\"), \"Expected\");",
+											"pm.variables.set(\"toBeCheckedIn_1\", JSON.stringify(toBeCheckedInRq));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a49d3ae5-3761-424e-85a7-b156b56347c5",
+										"exec": [
+											"pm.test(\"Check-in flow is OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedSuccessfully).to.eql(0);",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedWithError).to.eql(1);",
+											"    pm.expect(pm.response.json().receivingResults.pop().receivingItemResults.pop().processingStatus.error.code).not.to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{toBeCheckedIn_1}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/check-in",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"check-in"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Receive piece [protected unit, user is member of unit]",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "6a20ec7b-44ce-4294-a23c-cdacdebf88bc",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"let toBeReceivedRq = utils.prepareReceivingRequestBody(pm.environment.get(\"lineId_1\"), pm.environment.get(\"pieceId_1\"), \"Expected\");",
+											"pm.variables.set(\"toBeReceived_1\", JSON.stringify(toBeReceivedRq));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a49d3ae5-3761-424e-85a7-b156b56347c5",
+										"exec": [
+											"pm.test(\"Receiving flow is OK\", function () {",
+											"    pm.response.to.be.ok;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedSuccessfully).to.eql(0);",
+											"    pm.expect(pm.response.json().receivingResults.pop().processedWithError).to.eql(1);",
+											"    pm.expect(pm.response.json().receivingResults.pop().receivingItemResults.pop().processingStatus.error.code).not.to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{toBeReceived_1}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receive",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receive"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b20e65bd-71d2-4d2b-9f31-1771686ad0ad",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "0e90c309-2832-4572-b80e-3bee22105dfe",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -8142,8 +9062,48 @@
 					"        \"id\": pm.variables.get(\"testTenant\"),",
 					"        \"name\": \"Test orders tenant\",",
 					"        \"description\": \"Tenant for test purpose\"",
+					"    },",
+					"    receiving: {",
+					"        bodyTemplate: {",
+					"            \"toBeReceived\": [{",
+					"                \"poLineId\": \"\",",
+					"                \"received\": 1,",
+					"                \"receivedItems\": [{",
+					"                    \"barcode\": \"11111111111\",",
+					"                    \"comment\": \"Very important note\",",
+					"                    \"caption\": \"Vol. 1\",",
+					"                    \"itemStatus\": \"Received\",",
+					"                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",",
+					"                    \"pieceId\": \"\"",
+					"                }]",
+					"            }],",
+					"            \"totalRecords\": 1",
+					"        }",
+					"    },",
+					"    checkin: {",
+					"        bodyTemplate: {",
+					"            \"toBeCheckedIn\": [",
+					"              {",
+					"                \"poLineId\": \"\",",
+					"                \"checkedIn\": \"\",",
+					"                \"checkInPieces\": [",
+					"                    {",
+					"                        \"id\": \"\",",
+					"                        \"barcode\": Math.floor(Math.random() * 1000),",
+					"                        \"comment\": \"checkedin from API test\",",
+					"                        \"caption\": \"Vol. 1\",",
+					"                        \"createItem\": true,",
+					"                        \"supplement\": false,",
+					"                        \"locationId\": \"\",",
+					"                        \"accessionNumber\": \"1956.1\",",
+					"                        \"itemDescription\": \"This is the piece item checkin\",",
+					"                        \"electronicBookplate\": \"This item is from API tests\",",
+					"                        \"itemStatus\": \"\"",
+					"                    }]",
+					"              }],",
+					"              \"totalRecords\":1",
+					"        }",
 					"    }",
-					"",
 					"};",
 					"",
 					"// Global testing object - used in further tests",
@@ -8221,6 +9181,50 @@
 					"        }",
 					"",
 					"        return order;",
+					"    };",
+					"    ",
+					"    /**",
+					"     * This method is used for generation check-in request body",
+					"     * ",
+					"     */",
+					"    utils.prepareCheckinRequestBody = function(compPoLineId, pieceId, checkinStatus) {",
+					"        let checkinRq = globals.testData.checkin.bodyTemplate;",
+					"        let toBeCheckedInTemplate = checkinRq.toBeCheckedIn.pop();",
+					"        let checkinPiecesTemplate = toBeCheckedInTemplate.checkInPieces.pop();",
+					"        toBeCheckedInTemplate.poLineId = compPoLineId;",
+					"        toBeCheckedInTemplate.checkedIn = 1;",
+					"        checkinPiecesTemplate.id = pieceId;",
+					"        checkinPiecesTemplate.locationId = pm.environment.get(\"newLocationId\");",
+					"         if (typeof checkinStatus === \"undefined\") {",
+					"            checkinPiecesTemplate.itemStatus = \"In Process\";",
+					"        } else {",
+					"            checkinPiecesTemplate.itemStatus = checkinStatus;",
+					"        }",
+					"        toBeCheckedInTemplate.checkInPieces.push(checkinPiecesTemplate);",
+					"        checkinRq.toBeCheckedIn.push(toBeCheckedInTemplate);",
+					"        return checkinRq;",
+					"    };",
+					"    ",
+					"    /**",
+					"     * This method is used for generation receiving request body",
+					"     * ",
+					"     */",
+					"    utils.prepareReceivingRequestBody = function(compPoLineId, pieceId, receivingStatus) {",
+					"        let receivingRq = globals.testData.receiving.bodyTemplate;",
+					"        let toBeReceivedTemplate = receivingRq.toBeReceived.pop();",
+					"        let receivingItemsTemplate = toBeReceivedTemplate.receivedItems.pop();",
+					"        toBeReceivedTemplate.poLineId = compPoLineId;",
+					"        toBeReceivedTemplate.received = 1;",
+					"        receivingItemsTemplate.locationId = pm.environment.get(\"newLocationId\");",
+					"         if (typeof receivingStatus === \"undefined\") {",
+					"            receivingItemsTemplate.itemStatus = \"In Process\";",
+					"        } else {",
+					"            receivingItemsTemplate.itemStatus = receivingStatus;",
+					"        }",
+					"        receivingItemsTemplate.pieceId = pieceId;",
+					"        toBeReceivedTemplate.receivedItems.push(receivingItemsTemplate);",
+					"        receivingRq.toBeReceived.push(toBeReceivedTemplate);",
+					"        return receivingRq;",
 					"    };",
 					"    ",
 					"     /**",
@@ -8424,19 +9428,19 @@
 	],
 	"variable": [
 		{
-			"id": "1e1d6aad-b081-4b5c-ae84-a3d6bc0d5234",
+			"id": "c64c7919-ce69-4de7-892c-086ddc335b07",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "b34020e7-13f9-4bf8-9644-7c45902c1229",
+			"id": "ac5d54ad-6122-427f-9674-65c5302d6491",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "878494bc-9934-4235-8c52-6455e0baf1eb",
+			"id": "9ca30dc2-3f32-408c-a786-3eeba0dca475",
 			"key": "testTenant",
 			"value": "orders_acq_units_test",
 			"type": "string"

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -8522,7 +8522,7 @@
 			"name": "Negative Tests",
 			"item": [
 				{
-					"name": "Delete create protect unit",
+					"name": "Delete create protect unit - from storage until MODORDERS-294",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -8556,14 +8556,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{createProtectUnitId}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units-storage/units/{{createProtectUnitId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
 							],
 							"port": "{{okapiport}}",
 							"path": [
-								"acquisitions-units",
+								"acquisitions-units-storage",
 								"units",
 								"{{createProtectUnitId}}"
 							]


### PR DESCRIPTION
API Tests for [MODORDERS-286](https://issues.folio.org/browse/MODORDERS-286) - Restrict receive/checkin based on acquisitions units.
Receiving/check-in flows implemented for the following cases:

- order (protected for update) <-> order-line <-> piece with user isn't a member of units - operation is restricted
- order (protected for update) <-> order-line <-> piece with user is a member of units - operation is allowed
- order (not protected for update) <-> order-line <-> piece + any user units - operation is allowed

Regular user (with xokapitoken) creates needed orders, order-lines and pieces.

1) Another user - limited user (with xokapitoken-limitedUser) tries to check-in/receive pieces that related to non-protected for updating orders -> operation allowed.
2) This limited user tries to check-in/receive pieces that related to protected for updating orders. But limited user isn't member of order units -> so operation is restricted. 
3) Limited user is assigned to one of the protected order units and tries to check-in/receive pieces that related to protected for updating orders again. Limited user is a member of protected order units now -> so operation is allowed.
 
![MODORDERS-286-testing](https://user-images.githubusercontent.com/42964285/64163065-3219d900-ce49-11e9-9271-44c3a3a4fd29.png)
