### PR TITLE
MODORDERS-294 Disallow "isDeleted" acq units to be assigned to orders

### DIFF
--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -9157,7 +9157,7 @@
 											"    pm.response.to.have.status(422);",
 											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
 											"    let error = pm.response.json().errors[0];",
-											"    pm.expect(error.code).to.eql(\"orderUnitsNotFound\");",
+											"    pm.expect(error.code).to.eql(\"orderAcqUnitsNotFound\");",
 											"    pm.expect(error.acqUnitIds).to.have.lengthOf(1);",
 											"    pm.expect(error.acqUnitIds[0]).to.eql(pm.environment.get(\"deletedUnitId\"));",
 											"});"
@@ -9328,10 +9328,10 @@
 									"    pm.response.to.have.status(422);",
 									"});",
 									"",
-									"pm.test(\"Response contains error with orderUnitsNotFound code\", function () {",
+									"pm.test(\"Response contains error with orderAcqUnitsNotFound code\", function () {",
 									"    pm.expect(pm.response.json().errors.length).to.eql(1);",
 									"    error = pm.response.json().errors[0];",
-									"    pm.expect(error.code).to.eql(\"orderUnitsNotFound\");",
+									"    pm.expect(error.code).to.eql(\"orderAcqUnitsNotFound\");",
 									"    pm.expect(error.acqUnitIds).to.have.lengthOf(1);",
 									"    pm.expect(error.acqUnitIds[0]).to.eql(pm.environment.get(\"deletedUnitId\"));",
 									"});"
@@ -9454,10 +9454,10 @@
 									"    pm.response.to.have.status(422);",
 									"});",
 									"",
-									"pm.test(\"Response contains error with orderUnitsNotFound code\", function () {",
+									"pm.test(\"Response contains error with orderAcqUnitsNotFound code\", function () {",
 									"    pm.expect(pm.response.json().errors.length).to.eql(1);",
 									"    error = pm.response.json().errors[0];",
-									"    pm.expect(error.code).to.eql(\"orderUnitsNotFound\");",
+									"    pm.expect(error.code).to.eql(\"orderAcqUnitsNotFound\");",
 									"});"
 								],
 								"type": "text/javascript"
@@ -9528,10 +9528,10 @@
 									"    pm.response.to.have.status(422);",
 									"});",
 									"",
-									"pm.test(\"Response contains error with orderUnitsNotFound code\", function () {",
+									"pm.test(\"Response contains error with orderAcqUnitsNotFound code\", function () {",
 									"    pm.expect(pm.response.json().errors.length).to.eql(1);",
 									"    error = pm.response.json().errors[0];",
-									"    pm.expect(error.code).to.eql(\"orderUnitsNotFound\");",
+									"    pm.expect(error.code).to.eql(\"orderAcqUnitsNotFound\");",
 									"});"
 								],
 								"type": "text/javascript"
@@ -9602,10 +9602,10 @@
 									"    pm.response.to.have.status(422);",
 									"});",
 									"",
-									"pm.test(\"Response contains error with orderUnitsNotFound code\", function () {",
+									"pm.test(\"Response contains error with orderAcqUnitsNotFound code\", function () {",
 									"    pm.expect(pm.response.json().errors.length).to.eql(1);",
 									"    error = pm.response.json().errors[0];",
-									"    pm.expect(error.code).to.eql(\"orderUnitsNotFound\");",
+									"    pm.expect(error.code).to.eql(\"orderAcqUnitsNotFound\");",
 									"});"
 								],
 								"type": "text/javascript"

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -1316,6 +1316,139 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Fully unprotected",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.unit;",
+											"body.name += \" - unprotected\";",
+											"body.protectCreate = false;",
+											"body.protectRead = false;",
+											"body.protectUpdate = false;",
+											"body.protectDelete = false;",
+											"",
+											"pm.variables.set(\"unitBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"unprotectedUnitId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{unitBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "\"Deleted\" unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.unit;",
+											"body.name += \" - deleted\";",
+											"body.isDeleted = true;",
+											"",
+											"pm.variables.set(\"unitBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"deletedUnitId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{unitBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -6397,6 +6530,60 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Unassign user from fully protected unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{protectedUnitMembershipId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships",
+										"{{protectedUnitMembershipId}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -6966,6 +7153,70 @@
 										"orders",
 										"composite-orders",
 										"{{orderForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Assign regular user to fully protected unit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "92915c1b-6bde-4a36-9433-bc8f257b567d",
+										"exec": [
+											"var jsonData = {};",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    jsonData = pm.response.json();",
+											"    pm.environment.set(\"protectedUnitMembershipId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "0f1a616f-fd38-4215-96ab-50a48a033dec",
+										"exec": [
+											"let body = {};",
+											"",
+											"body.userId = globals.testData.users.regular.user.id;",
+											"body.acquisitionsUnitId = pm.environment.get(\"fullyProtectedUnitId\");",
+											"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{membershipBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships"
 									]
 								}
 							},
@@ -7570,6 +7821,1451 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Unassign user from fully protected unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{protectedUnitMembershipId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships",
+										"{{protectedUnitMembershipId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Soft delete",
+					"item": [
+						{
+							"name": "Create Open order with 1 line and 2 units",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
+											"    let order = utils.prepareOrder(res.json());",
+											"    // Set Open status and leave only one line",
+											"    order.compositePoLines.pop();",
+											"    order.poNumber = \"softdelete\";",
+											"    order.acqUnitIds = [pm.environment.get(\"fullyProtectedUnitId\"), pm.environment.get(\"unprotectedUnitId\")];",
+											"    order.workflowStatus = \"Open\";",
+											"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(order));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"softDeleteOrderId\", jsonData.id);",
+											"    pm.environment.set(\"softDeleteLineId\", jsonData.compositePoLines[0].id); ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{po_listed_print_monograph}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders"
+									]
+								},
+								"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders. 2 units are assigned: 1 - fully protected, 2 - fully unprotected"
+							},
+							"response": []
+						},
+						{
+							"name": "Get order",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\",  () => {",
+											"    pm.response.to.be.ok;",
+											"    pm.environment.set(\"softDeleteOrderContent\", pm.response.text());",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Get line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can be viewed\",  () => {",
+											"    pm.response.to.be.ok;",
+											"    pm.environment.set(\"softDeleteLineContent\", pm.response.text());",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{softDeleteLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{softDeleteLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Get orders by query",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"1 order should be found\", () => pm.expect(pm.response.json().totalRecords).to.eql(1));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?query=poNumber=softdelete",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "poNumber=softdelete"
+										}
+									]
+								},
+								"description": "There is no any order with assigned acq unit"
+							},
+							"response": []
+						},
+						{
+							"name": "Get lines by query",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"1 line should be found\", () => pm.expect(pm.response.json().totalRecords).to.eql(1));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?query=poNumber=softdelete",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "poNumber=softdelete"
+										}
+									]
+								},
+								"description": "GET /orders/orders/order-lines requests that return 200"
+							},
+							"response": []
+						},
+						{
+							"name": "Get list of pieces by query",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"4 pieces should be found\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.totalRecords).to.eql(4);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=poLineNumber=softdelete sortBy title/sort.ascending",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receiving-history"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "poLineNumber=softdelete sortBy title/sort.ascending"
+										}
+									]
+								},
+								"description": "GET /orders/orders/order-lines requests that return 200"
+							},
+							"response": []
+						},
+						{
+							"name": "\"Delete\" fully unprotected unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Unit \\\"deleted\\\"\", () => pm.response.to.have.status(204));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{unprotectedUnitId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units",
+										"{{unprotectedUnitId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get orders by query - nothing found",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"No orders should be found\", () => pm.expect(pm.response.json().totalRecords).to.eql(0));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?query=poNumber=softdelete",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "poNumber=softdelete"
+										}
+									]
+								},
+								"description": "There is no any order with assigned acq unit"
+							},
+							"response": []
+						},
+						{
+							"name": "Get lines by query - nothing found",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"No lines should be found\", () => pm.expect(pm.response.json().totalRecords).to.eql(0));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?query=poNumber=softdelete",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "poNumber=softdelete"
+										}
+									]
+								},
+								"description": "GET /orders/orders/order-lines requests that return 200"
+							},
+							"response": []
+						},
+						{
+							"name": "Get list of pieces by query - nothing found",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"No pieces should be found\", () => pm.expect(pm.response.json().totalRecords).to.eql(0));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=poLineNumber=softdelete",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"receiving-history"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "poLineNumber=softdelete"
+										}
+									]
+								},
+								"description": "GET /orders/orders/order-lines requests that return 200"
+							},
+							"response": []
+						},
+						{
+							"name": "Get order - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can not be viewed\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Update order - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let content = JSON.parse(pm.environment.get(\"softDeleteOrderContent\"));",
+											"delete content.acqUnitIds;",
+											"pm.environment.set(\"softDeleteOrderContent\", JSON.stringify(content));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can not be updated\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{softDeleteOrderContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete order - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can not be deleted\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Get line - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can not be viewed\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{softDeleteLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{softDeleteLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Update line - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can not be updated\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{softDeleteLineContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{softDeleteLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{softDeleteLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete line - forbidden",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can not be deleted\",  () => {",
+											"    pm.response.to.be.forbidden;",
+											"",
+											"    let errors = pm.response.json().errors;",
+											"    pm.expect(errors.length).to.eql(1);",
+											"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{softDeleteLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{softDeleteLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Assign regular user to fully protected unit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "92915c1b-6bde-4a36-9433-bc8f257b567d",
+										"exec": [
+											"var jsonData = {};",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    jsonData = pm.response.json();",
+											"    pm.environment.set(\"protectedUnitMembershipId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "0f1a616f-fd38-4215-96ab-50a48a033dec",
+										"exec": [
+											"let body = {};",
+											"",
+											"body.userId = globals.testData.users.regular.user.id;",
+											"body.acquisitionsUnitId = pm.environment.get(\"fullyProtectedUnitId\");",
+											"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{membershipBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"memberships"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get order",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\", () => {",
+											"    pm.response.to.be.ok;",
+											"    pm.environment.set(\"softDeleteOrderContent\", pm.response.text());",
+											"    pm.expect(pm.response.json().acqUnitIds).to.have.lengthOf(2).and.to.have.members([pm.environment.get(\"fullyProtectedUnitId\"), pm.environment.get(\"unprotectedUnitId\")]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Get line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order line can be viewed\",  () => {",
+											"    pm.response.to.be.ok;",
+											"    pm.environment.set(\"softDeleteLineContent\", pm.response.text());",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines/{{softDeleteLineId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-lines",
+										"{{softDeleteLineId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Update order adding one more unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let content = JSON.parse(pm.environment.get(\"softDeleteOrderContent\"));",
+											"content.acqUnitIds.push(pm.environment.get(\"readOpenUnitId\"));",
+											"pm.environment.set(\"softDeleteOrderContent\", JSON.stringify(content));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be updated\",  () => pm.response.to.have.status(204));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{softDeleteOrderContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Get order with 3 units",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Order can be viewed\", () => {",
+											"    pm.response.to.be.ok;",
+											"    pm.environment.set(\"softDeleteOrderContent\", pm.response.text());",
+											"    pm.expect(pm.response.json().acqUnitIds).to.have.lengthOf(3).and.to.have.members([",
+											"        pm.environment.get(\"fullyProtectedUnitId\"),",
+											"        pm.environment.get(\"unprotectedUnitId\"),",
+											"        pm.environment.get(\"readOpenUnitId\")",
+											"    ]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "Update order adding one more \"deleted\" unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let content = JSON.parse(pm.environment.get(\"softDeleteOrderContent\"));",
+											"content.acqUnitIds.push(pm.environment.get(\"deletedUnitId\"));",
+											"pm.environment.set(\"softDeleteOrderContent\", JSON.stringify(content));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Deleted unit cannot be assigned\",  () => {",
+											"    pm.response.to.have.status(422);",
+											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+											"    let error = pm.response.json().errors[0];",
+											"    pm.expect(error.code).to.eql(\"orderUnitsNotFound\");",
+											"    pm.expect(error.acqUnitIds).to.have.lengthOf(1);",
+											"    pm.expect(error.acqUnitIds[0]).to.eql(pm.environment.get(\"deletedUnitId\"));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{softDeleteOrderContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{softDeleteOrderId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders",
+										"{{softDeleteOrderId}}"
+									]
+								},
+								"description": "There is no any acq unit assigned to this order so view is not restricted"
+							},
+							"response": []
+						},
+						{
+							"name": "\"Undelete\" fully unprotected unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.sendGetRequest(\"/acquisitions-units/units/\" + pm.environment.get(\"unprotectedUnitId\"), (err, res) => {",
+											"    pm.test(\"Unit is successfully retrieved and ready for updates\", () => {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(res).to.be.ok;",
+											"",
+											"        let unit = res.json();",
+											"        unit.isDeleted = false;",
+											"",
+											"        pm.variables.set(\"unitBody\", JSON.stringify(unit));",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Unit \\\"deleted\\\"\", () => pm.response.to.have.status(204));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{unitBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{unprotectedUnitId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units",
+										"{{unprotectedUnitId}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"_postman_isSubFolder": true
@@ -7602,7 +9298,84 @@
 			"name": "Negative Tests",
 			"item": [
 				{
-					"name": "Delete create protect unit",
+					"name": "Try to create order assigning soft-deleted unit",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", function (err, res) {",
+									"    var order = utils.prepareOrder(res.json());",
+									"    order.acqUnitIds = [pm.environment.get(\"deletedUnitId\")];",
+									"    delete order.poNumber;",
+									"    delete order.compositePoLines;",
+									"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(order));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"var error = {};",
+									"pm.test(\"Status code is 422\", function () {",
+									"    pm.response.to.have.status(422);",
+									"});",
+									"",
+									"pm.test(\"Response contains error with orderUnitsNotFound code\", function () {",
+									"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+									"    error = pm.response.json().errors[0];",
+									"    pm.expect(error.code).to.eql(\"orderUnitsNotFound\");",
+									"    pm.expect(error.acqUnitIds).to.have.lengthOf(1);",
+									"    pm.expect(error.acqUnitIds[0]).to.eql(pm.environment.get(\"deletedUnitId\"));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{po_listed_print_monograph}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"orders",
+								"composite-orders"
+							]
+						},
+						"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
+					},
+					"response": []
+				},
+				{
+					"name": "Delete create protect from storage",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -7636,14 +9409,14 @@
 							}
 						],
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{createProtectUnitId}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units-storage/units/{{createProtectUnitId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
 							],
 							"port": "{{okapiport}}",
 							"path": [
-								"acquisitions-units",
+								"acquisitions-units-storage",
 								"units",
 								"{{createProtectUnitId}}"
 							]
@@ -7652,7 +9425,7 @@
 					"response": []
 				},
 				{
-					"name": "Try to create order and assign to deleted unit",
+					"name": "Try to create order assigning hard-deleted unit",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -7726,7 +9499,7 @@
 					"response": []
 				},
 				{
-					"name": "Try to create order line from assigned to deleted unit",
+					"name": "Try to create order line from assigned to hard-deleted unit",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -7800,7 +9573,7 @@
 					"response": []
 				},
 				{
-					"name": "Try to create piece assigned to deleted unit",
+					"name": "Try to create piece assigned to hard-deleted unit",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -8394,6 +10167,12 @@
 					"        pm.environment.unset(\"updateOpenUnitId\");",
 					"        pm.environment.unset(\"deleteProtectUnitId\");",
 					"        pm.environment.unset(\"deleteOpenUnitId\");",
+					"        pm.environment.unset(\"deletedUnitId\");",
+					"        pm.environment.unset(\"unprotectedUnitId\");",
+					"        pm.environment.unset(\"softDeleteOrderId\");",
+					"        pm.environment.unset(\"softDeleteOrderContent\");",
+					"        pm.environment.unset(\"softDeleteLineId\");",
+					"        pm.environment.unset(\"softDeleteLineContent\");",
 					"    };",
 					"",
 					"    /**",


### PR DESCRIPTION
## Purpose
[MODORDERS-294](https://issues.folio.org/browse/MODORDERS-294) Disallow "isDeleted" acq units to be assigned to orders

## Approach
- Creating 2 more units in Setup section: fully unprotected and "soft-deleted"
- Adding set of `Soft delete` positive tests:
  - Creating order with one line assigning fully unprotected and fully protected units
  - Check that order, line and pieces can be retrieved
  - "Delete" fully unprotected unit
  - Check that any operation on order, line or piece is forbidden because user is not a member of fully protected unit
  - Assign a user to fully protected unit
  - Check that order still has reference on "deleted" unit but now user can operate on order and related records
  - Try to update order assigning another "soft-deleted" unit 
  - Negative tests are unchanged -  the cases there are for "hard-deleted" unit

![image](https://user-images.githubusercontent.com/43410167/64413307-f3c72880-d099-11e9-95da-72a8d8affec3.png)
![image](https://user-images.githubusercontent.com/43410167/64413049-769bb380-d099-11e9-933b-c94a8a3bd0f9.png)
![image](https://user-images.githubusercontent.com/43410167/64413191-b6fb3180-d099-11e9-9b88-7fe4eb715040.png)


## Verification
![image](https://user-images.githubusercontent.com/43410167/64412980-51a74080-d099-11e9-910e-f776fabcd769.png)

