### PR TITLE
MODORDERS-298- Fix reverted tests

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a846e689-4eb3-44b5-9d71-c758cb400094",
+		"_postman_id": "236802e5-b1a1-450f-a157-659d19ec7ff7",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -778,6 +778,7 @@
 									"script": {
 										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
 										"exec": [
+											"postman.setNextRequest(null);",
 											"pm.test(\"GET ledger response is ok\", function () {",
 											"    pm.response.to.be.ok;",
 											"    let jsonData = pm.response.json();",
@@ -786,6 +787,8 @@
 											"    } else {",
 											"        createNewRecord();",
 											"    }",
+											"        // All is okay so running further requests",
+											"    postman.setNextRequest();",
 											"});  ",
 											"",
 											"function useAlreadyExistingType(identifierType) {",
@@ -799,7 +802,8 @@
 											"    const type = {",
 											"        \"name\": \"Ledger for orders API Tests\",",
 											"        \"code\": pm.variables.get(\"finance-ledgerCode\"),",
-											"        \"description\": \"Ledger for orders API Tests\"",
+											"        \"description\": \"Ledger for orders API Tests\",",
+											"        \"ledgerStatus\": \"Active\"",
 											"    };",
 											"",
 											"    eval(globals.loadUtils).postRequest(\"/finance-storage/ledgers\", type, (err, res) => {",
@@ -877,6 +881,7 @@
 									"script": {
 										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
 										"exec": [
+											"postman.setNextRequest(null);",
 											"pm.test(\"GET funds response is ok\", function () {",
 											"    pm.response.to.be.ok;",
 											"    let jsonData = pm.response.json();",
@@ -885,6 +890,8 @@
 											"    } else {",
 											"        createNewRecord();",
 											"    }",
+											"            // All is okay so running further requests",
+											"    postman.setNextRequest();",
 											"});  ",
 											"",
 											"function useAlreadyExistingType(identifierType) {",
@@ -6107,7 +6114,7 @@
 											"",
 											"pm.test(\"Each order has these optional fields\", function() {",
 											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.globals.set(\"orderWithoutInventoryRecordsId\", jsonData.id); ",
+											"    pm.globals.set(\"orderWithReceiptNotRequiredId\", jsonData.id); ",
 											"    pm.expect(jsonData.approved).to.exist;",
 											"    pm.expect(jsonData.poNumber).to.exist;",
 											"    pm.expect(jsonData.notes).to.exist;",
@@ -6155,7 +6162,7 @@
 										"composite-orders"
 									]
 								},
-								"description": "Create a purchase order in Open status based on `po_listed_print_monograph.json` from mod-orders. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117))."
+								"description": "Create a purchase order in Open status based on `po_listed_print_monograph.json` from mod-orders. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117)).\n[MODORDERS-304](https://issues.folio.org/browse/MODORDERS-304). Even though Receiving is not required, Inventory interaction happens based on CreateInventory setting"
 							},
 							"response": []
 						},
@@ -7597,7 +7604,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithoutInventoryRecordsId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithReceiptNotRequiredId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -7606,7 +7613,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{orderWithoutInventoryRecordsId}}"
+										"{{orderWithReceiptNotRequiredId}}"
 									]
 								},
 								"description": "Gets order created by `Create Order With receipt not required` request and updates PO Lines' payment status so the system should close the order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
@@ -7807,7 +7814,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithoutInventoryRecordsId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithReceiptNotRequiredId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -7816,7 +7823,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{orderWithoutInventoryRecordsId}}"
+										"{{orderWithReceiptNotRequiredId}}"
 									]
 								},
 								"description": "Gets order created by `Create Order With receipt not required` verifies that it is closed now.  \nIf all is okay, change `paymentStatus` of the first PO Line to `Partially Paid`. This should re-open order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
@@ -8052,7 +8059,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithoutInventoryRecordsId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithReceiptNotRequiredId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -8061,7 +8068,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{orderWithoutInventoryRecordsId}}"
+										"{{orderWithReceiptNotRequiredId}}"
 									]
 								},
 								"description": "Gets order created by `Create Order With receipt not required` verifies that it is closed now.  \nIf all is okay, change `paymentStatus` of the first PO Line to `Partially Paid`. This should re-open order eventually (see [MODORDERS-218](https://issues.folio.org/browse/MODORDERS-218))."
@@ -10722,7 +10729,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=purchaseOrderId={{orderWithoutInventoryRecordsId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/receiving-history?query=purchaseOrderId={{orderWithReceiptNotRequiredId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -10735,7 +10742,7 @@
 									"query": [
 										{
 											"key": "query",
-											"value": "purchaseOrderId={{orderWithoutInventoryRecordsId}}"
+											"value": "purchaseOrderId={{orderWithReceiptNotRequiredId}}"
 										}
 									]
 								},
@@ -19289,14 +19296,14 @@
 							"response": []
 						},
 						{
-							"name": "Delete order with no created instances",
+							"name": "Delete order with Receipt Not Required",
 							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
 										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 										"exec": [
-											"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.orderWithoutInventoryRecordsId, true);"
+											"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.orderWithReceiptNotRequiredId, true);"
 										],
 										"type": "text/javascript"
 									}
@@ -19330,7 +19337,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithoutInventoryRecordsId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithReceiptNotRequiredId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -19339,7 +19346,7 @@
 									"path": [
 										"orders",
 										"composite-orders",
-										"{{orderWithoutInventoryRecordsId}}"
+										"{{orderWithReceiptNotRequiredId}}"
 									]
 								},
 								"description": "DELETE /orders/composite-orders/id requests that return 204"
@@ -21318,7 +21325,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/po-lines?query=purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{orderWithoutInventoryRecordsId}} or purchaseOrderId=={{receivingHistoryPoId}} or purchaseOrderId=={{negativeTestsPendingOrderId}} or purchaseOrderId=={{negativeTestsOpenOrderId}} or purchaseOrderId=={{negativeTestsClosedOrderId}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/po-lines?query=purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{orderWithReceiptNotRequiredId}} or purchaseOrderId=={{receivingHistoryPoId}} or purchaseOrderId=={{negativeTestsPendingOrderId}} or purchaseOrderId=={{negativeTestsOpenOrderId}} or purchaseOrderId=={{negativeTestsClosedOrderId}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -21331,7 +21338,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{orderWithoutInventoryRecordsId}} or purchaseOrderId=={{receivingHistoryPoId}} or purchaseOrderId=={{negativeTestsPendingOrderId}} or purchaseOrderId=={{negativeTestsOpenOrderId}} or purchaseOrderId=={{negativeTestsClosedOrderId}}"
+									"value": "purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{orderWithReceiptNotRequiredId}} or purchaseOrderId=={{receivingHistoryPoId}} or purchaseOrderId=={{negativeTestsPendingOrderId}} or purchaseOrderId=={{negativeTestsOpenOrderId}} or purchaseOrderId=={{negativeTestsClosedOrderId}}"
 								}
 							]
 						},
@@ -21385,7 +21392,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/purchase-orders?query=id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or id=={{physElecOpenOrderId}} or id=={{orderWithoutInventoryRecordsId}} or id=={{receivingHistoryPoId}} or id=={{negativeTestsPendingOrderId}} or id=={{negativeTestsOpenOrderId}} or id=={{negativeTestsClosedOrderId}} or id=={{automaticallyClosedOrder}} or id=={{automaticallyClosedOpenOrder}} or id=={{automaticallyOpenedOrder}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/purchase-orders?query=id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or id=={{physElecOpenOrderId}} or id=={{orderWithReceiptNotRequiredId}} or id=={{receivingHistoryPoId}} or id=={{negativeTestsPendingOrderId}} or id=={{negativeTestsOpenOrderId}} or id=={{negativeTestsClosedOrderId}} or id=={{automaticallyClosedOrder}} or id=={{automaticallyClosedOpenOrder}} or id=={{automaticallyOpenedOrder}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
@@ -21398,7 +21405,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or id=={{physElecOpenOrderId}} or id=={{orderWithoutInventoryRecordsId}} or id=={{receivingHistoryPoId}} or id=={{negativeTestsPendingOrderId}} or id=={{negativeTestsOpenOrderId}} or id=={{negativeTestsClosedOrderId}} or id=={{automaticallyClosedOrder}} or id=={{automaticallyClosedOpenOrder}} or id=={{automaticallyOpenedOrder}}"
+									"value": "id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or id=={{physElecOpenOrderId}} or id=={{orderWithReceiptNotRequiredId}} or id=={{receivingHistoryPoId}} or id=={{negativeTestsPendingOrderId}} or id=={{negativeTestsOpenOrderId}} or id=={{negativeTestsClosedOrderId}} or id=={{automaticallyClosedOrder}} or id=={{automaticallyClosedOpenOrder}} or id=={{automaticallyOpenedOrder}}"
 								}
 							]
 						},
@@ -21728,7 +21735,7 @@
 					"                utils.validatePoLineAgainstSchema(poLine);",
 					"                poLine.locations.forEach(location => utils.validateLocationQuantity(location));",
 					"",
-					"                if (checkInventory && poLine.receiptStatus !== \"Receipt Not Required\") {",
+					"                if (checkInventory) {",
 					"                    utils.validatePoLinesInventoryLinks(poLine);",
 					"                } else {",
 					"                    utils.verifyNoInventoryItemsExist(poLine);",
@@ -22215,10 +22222,6 @@
 					"     * The logic is based on MODORDERS-178",
 					"     */",
 					"    utils.calculateExpectedItemsQuantity = function(poLine) {",
-					"        // MODORDERS-159: If receipt status is \"Receipt not Required\", no items are created",
-					"        if (poLine.receiptStatus === \"Receipt Not Required\") {",
-					"            return 0;",
-					"        }",
 					"        switch (poLine.orderFormat) {",
 					"            case \"P/E Mix\":",
 					"                let quantity = utils.isItemsUpdateRequiredForEresource(poLine) ? utils.getElectronicItemsQuantity(poLine) : 0;",
@@ -23166,7 +23169,7 @@
 					"        pm.globals.unset(\"completeOpenOrderId\");",
 					"        pm.globals.unset(\"poLineForNegativeTests\");",
 					"        pm.globals.unset(\"completeOrderPoNumber\");",
-					"        pm.globals.unset(\"orderWithoutInventoryRecordsId\");",
+					"        pm.globals.unset(\"orderWithReceiptNotRequiredId\");",
 					"        pm.globals.unset(\"receivingHistoryPoId\");",
 					"        pm.globals.unset(\"poToCheckinItemsId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryNullId1\");",
@@ -23273,61 +23276,61 @@
 	],
 	"variable": [
 		{
-			"id": "529675cc-ace4-4049-8d97-860791559847",
+			"id": "28e55ec2-2ebc-4b4c-93f1-8f3d947c9832",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "b45ba7b8-ab09-4cfe-88db-9bed5c6fd122",
+			"id": "aa73dbae-c8ee-4de4-96c6-da68ea50fc62",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "fec66939-83d9-4244-bc47-be892ed5dc38",
+			"id": "67a3429a-f79f-4c31-9747-1f422e53ecde",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "9e7d0b32-d371-464b-ab4b-a7ec7e895749",
+			"id": "31be82fd-01da-43f0-adcb-4c15e4df0151",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "c1d9f1bd-472d-404b-a97c-8ef12c011c21",
+			"id": "1bb2bab2-8e21-4d92-be18-790c1cf2bc22",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "e773f8fb-b5cb-409e-8263-1bde60a6d984",
+			"id": "e31a2232-fdaa-418f-a2b4-0cdc9acdf343",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "3a135157-1903-45dc-bd71-4f77b461d05c",
+			"id": "88ee02b1-2095-4f3a-9611-3c67f26b57e8",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "623ed099-696a-4216-ade0-02447e38b0a5",
+			"id": "b23f9190-9d2d-44fa-aec0-68be841c006a",
 			"key": "finance-ledgerCode",
 			"value": "ordersApiTestsLedgerCode",
 			"type": "string"
 		},
 		{
-			"id": "81ab8c24-ac98-4477-b38d-ff0443091fd9",
+			"id": "c9d8594a-d03b-401e-a34a-56281d56f412",
 			"key": "finance-fundCode",
 			"value": "ordersApiTestsFundCode",
 			"type": "string"
 		},
 		{
-			"id": "86169520-4bd8-4d83-ac7a-35fb934e8289",
+			"id": "180dda70-17c8-4ed7-b6d0-6369d2b9587e",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "11e63090-4e94-4876-9a23-2036cb8b56c3",
+		"_postman_id": "a846e689-4eb3-44b5-9d71-c758cb400094",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -14862,100 +14862,7 @@
 						},
 						{
 							"name": "Encumbrance creation failure",
-							"item": [
-								{
-									"name": "Create Open order with lines pointing to unexisting fund",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"var uuid = require('uuid');",
-													"",
-													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", (err, res) => {",
-													"    let order  = utils.prepareOrder(res.json());",
-													"    order.workflowStatus = \"Open\";",
-													"    // Setting specific PO Number to delete this order in cleanup",
-													"    order.poNumber = \"APIFAILENCUMB1\";",
-													"    order.compositePoLines.forEach(poLine => {",
-													"        poLine.receiptStatus = \"Receipt Not Required\";",
-													"        // Setting random fund id",
-													"        poLine.fundDistribution.forEach(distrib => distrib.fundId = uuid.v4());",
-													"    });",
-													"    pm.variables.set(\"order_with_unexisting_fund\", JSON.stringify(order));",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"pm.test(\"Server error is expected: encumbranceCreationFailure\", function () {",
-													"    pm.response.to.have.status(500);",
-													"    let errors = pm.response.json().errors;",
-													"    pm.expect(errors).to.have.lengthOf(1);",
-													"    pm.expect(errors[0].code).to.equal(\"encumbranceCreationFailure\");",
-													"});",
-													"",
-													"utils.sendGetRequest(\"/orders/order-lines?query=poNumber==APIFAILENCUMB1\", function (err, res) {",
-													"    pm.expect(err).to.equal(null);",
-													"",
-													"    res.json().poLines.forEach(poLine => {",
-													"        utils.validateEncumbranceRecords(poLine, \"Pending\");",
-													"        pm.globals.set(\"negativeTestsFailedEncumbrances\", poLine.purchaseOrderId);",
-													"    });",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{order_with_unexisting_fund}}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders"
-											]
-										},
-										"description": "Create a purchase order in Open status based on `po_listed_print_monograph.json` from mod-orders. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117)).\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `true`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`."
-									},
-									"response": []
-								}
-							],
+							"item": [],
 							"_postman_isSubFolder": true
 						},
 						{
@@ -18166,6 +18073,7 @@
 											"",
 											"let line = utils.buildPoLineWithMinContent(null);",
 											"line.physical.createInventory = \"Instance\";",
+											"delete line.purchaseOrderId;",
 											"order.compositePoLines = [line];",
 											"order.vendor = pm.globals.get(\"testTenantActiveVendorId\");",
 											"pm.variables.set(\"orderBody\", JSON.stringify(order));"
@@ -18198,6 +18106,11 @@
 									{
 										"key": "x-okapi-tenant",
 										"value": "{{testTenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}",
+										"type": "text"
 									}
 								],
 								"body": {
@@ -20120,72 +20033,6 @@
 							"response": []
 						},
 						{
-							"name": "Delete Pending order (encumbrance creation failure)",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsFailedEncumbrances}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{negativeTestsFailedEncumbrances}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
 							"name": "Delete Pending order Copy",
 							"event": [
 								{
@@ -22051,7 +21898,8 @@
 					"     * Validate encumbrances for PO Line",
 					"     */",
 					"    utils.validateEncumbranceRecords = function(poLine, orderStatus) {",
-					"        let expectedQuantity = orderStatus === \"Pending\" ? 0 : poLine.fundDistribution.length;",
+					"//MODORDERS-298 Temporarily disable interaction with encumbrance APIs",
+					"/*        let expectedQuantity = orderStatus === \"Pending\" ? 0 : poLine.fundDistribution.length;",
 					"        utils.sendGetRequest(\"/finance-storage/encumbrances?limit=\" + expectedQuantity + \"&query=poLineId==\" + poLine.id, (err, res) => {",
 					"            let testMsg = expectedQuantity > 0 ? expectedQuantity : \"No\";",
 					"            pm.test(testMsg + \" encumbrance record(s) found for PO Line with number=\" + poLine.poLineNumber, function() {",
@@ -22061,7 +21909,7 @@
 					"                    res.json().encumbrances.forEach(encumbrance => utils.validateEncumbrance(encumbrance, poLine.fundDistribution));",
 					"                }",
 					"            });",
-					"        });",
+					"        });*/",
 					"    };",
 					"",
 					"    /**",
@@ -23158,7 +23006,8 @@
 					"     * Delete encumbrances related to PoLine in order",
 					"     */",
 					"    utils.deleteEncumbranceRecords = function(line) {",
-					"        return new Promise((resolve) => {",
+					"        //MODORDERS-298 disable encumbrances interaction",
+					"/*        return new Promise((resolve) => {",
 					"            utils.sendGetRequest(\"/finance-storage/encumbrances?limit=1000&query=poLineId==\" + line.id, (err, res) => {",
 					"                let promises = [];",
 					"                res.json().encumbrances.forEach(encumbrance => {",
@@ -23173,7 +23022,7 @@
 					"                        resolve([]);",
 					"                    });",
 					"            });",
-					"        });",
+					"        });*/",
 					"    };",
 					"",
 					"    /**",
@@ -23424,61 +23273,61 @@
 	],
 	"variable": [
 		{
-			"id": "7ba1d86c-9a25-4cfd-85ab-ce903279071d",
+			"id": "529675cc-ace4-4049-8d97-860791559847",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "da4983d5-172e-4674-bbaa-ebc88a69c0f7",
+			"id": "b45ba7b8-ab09-4cfe-88db-9bed5c6fd122",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "15559aa8-b117-405a-95a3-4321b0317d13",
+			"id": "fec66939-83d9-4244-bc47-be892ed5dc38",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "8041ff5f-bff4-4894-9552-04c7dc0538f9",
+			"id": "9e7d0b32-d371-464b-ab4b-a7ec7e895749",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "34e426f6-984e-45d9-a07d-8bd592d9155e",
+			"id": "c1d9f1bd-472d-404b-a97c-8ef12c011c21",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "010eee67-b99f-4692-9e89-844a6f1c93bc",
+			"id": "e773f8fb-b5cb-409e-8263-1bde60a6d984",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "2a0ff733-f2ac-4d75-8ba3-a773fff596a3",
+			"id": "3a135157-1903-45dc-bd71-4f77b461d05c",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "44163560-ffc9-4faf-a1ae-3fdb945e6559",
+			"id": "623ed099-696a-4216-ade0-02447e38b0a5",
 			"key": "finance-ledgerCode",
 			"value": "ordersApiTestsLedgerCode",
 			"type": "string"
 		},
 		{
-			"id": "96fed43d-dbe3-482a-9356-94b10f1659b3",
+			"id": "81ab8c24-ac98-4477-b38d-ff0443091fd9",
 			"key": "finance-fundCode",
 			"value": "ordersApiTestsFundCode",
 			"type": "string"
 		},
 		{
-			"id": "4ea7e680-3431-46df-8c29-171d3aca562b",
+			"id": "86169520-4bd8-4d83-ac7a-35fb934e8289",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"


### PR DESCRIPTION
Adding the missing changes in master from https://github.com/folio-org/folio-api-tests/tree/MODORDERS-298/mod-orders
and 
https://issues.folio.org/browse/MODORDERS-304
## PURPOSE:

- Because of the merge conflicts in  https://github.com/folio-org/folio-api-tests/pull/292, the changes were reverted to an old version of the tests, revived the branch and applied the changes here

- Also added test for https://issues.folio.org/browse/MODORDERS-304
 Tests are present for both the scenarios
1) CreateInventory = Instance, Holding ReceiptStatus= Receipt Not Required
<img width="1665" alt="Screen Shot 2019-09-12 at 10 23 00 PM" src="https://user-images.githubusercontent.com/41596468/64833664-d1a73c00-d5ac-11e9-84ad-dd3068b8c9e9.png">

2) CreateInventory = None, ReceiptStatus= Receipt Not Required
<img width="1680" alt="Screen Shot 2019-09-12 at 10 24 58 PM" src="https://user-images.githubusercontent.com/41596468/64833689-dec42b00-d5ac-11e9-981d-11bcf6205e6f.png">


Passes on folio-testing:
<img width="1282" alt="Screen Shot 2019-09-12 at 10 22 36 PM" src="https://user-images.githubusercontent.com/41596468/64833716-00251700-d5ad-11e9-8f42-a838da23afba.png">

