### PR TITLE
MODFIN-61 Define and Implement Budget API

### DIFF
--- a/mod-finance/mod-finance.postman_collection.json
+++ b/mod-finance/mod-finance.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f9bd19f4-a694-4b33-bb03-2dadf4ed44a4",
+		"_postman_id": "104b0598-25af-43ab-a785-f9c934d41b5f",
 		"name": "mod-finance",
 		"description": "Tests for mod-finance",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1118,6 +1118,71 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "Fiscal years",
+					"item": [
+						{
+							"name": "Create fiscal year in storage - required for budgets",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Ledger is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.environment.set(\"fiscalYearId\", pm.response.json().id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.variables.set(\"fyContent\", JSON.stringify(utils.buildFiscalYearMinContent()));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{fyContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/fiscal-years",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"fiscal-years"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "Fund types",
 					"item": [
 						{
@@ -1668,7 +1733,7 @@
 					"name": "Funds",
 					"item": [
 						{
-							"name": "Create first fund",
+							"name": "Create first fund - required for budget",
 							"event": [
 								{
 									"listen": "test",
@@ -2112,7 +2177,7 @@
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund type is deleted\", () => pm.response.to.have.status(204));"
+											"pm.test(\"Fund is deleted\", () => pm.response.to.have.status(204));"
 										],
 										"type": "text/javascript"
 									}
@@ -2209,6 +2274,565 @@
 									"path": [
 										"finance",
 										"funds"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Budgets",
+					"item": [
+						{
+							"name": "Create first budget",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let record = {};",
+											"",
+											"pm.test(\"Budget is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    record = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Budget content is valid\", function() {",
+											"    utils.validateBudget(record);",
+											"    pm.environment.set(\"budgetId\", record.id); ",
+											"    pm.expect(record.name).to.eql(\"FRST-BDGT\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"FRST-BDGT\")));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get budget record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Budget is retrieved\", function () {",
+											"    pm.response.to.be.ok;",
+											"    utils.validateBudget(pm.response.json());",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{budgetId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets",
+										"{{budgetId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create second budget",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let record = {};",
+											"",
+											"pm.test(\"Budget is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    record = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Budget content is valid\", function() {",
+											"    utils.validateBudget(record);",
+											"    pm.environment.set(\"budgetId2\", record.id);",
+											"    pm.environment.set(\"budgetContent2\", record);",
+											"    pm.expect(record.budgetStatus).to.eql(\"Planned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let budget = utils.buildBudgetMinContent(\"SCND-BDGT\");",
+											"budget.budgetStatus = \"Planned\";",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(budget));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get budget records by complex query - 1 record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"One budget record is found\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let records = pm.response.json();",
+											"    pm.expect(records.budgets).to.have.lengthOf(1);",
+											"    utils.validateBudget(records.budgets[0]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets?query=budgetStatus==Planned and fund.fundStatus==Active and ledger.name=test and fiscalYear.periodEnd > 2019-12-12",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "budgetStatus==Planned and fund.fundStatus==Active and ledger.name=test and fiscalYear.periodEnd > 2019-12-12"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update second budget",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budget is updated\", () => pm.response.to.have.status(204));",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let record = pm.environment.get(\"budgetContent2\");",
+											"record.budgetStatus = \"Frozen\";",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(record));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{budgetId2}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets",
+										"{{budgetId2}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get second budget record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Budget is retrieved\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let record = pm.response.json();",
+											"    utils.validateBudget(record);",
+											"    pm.expect(record.budgetStatus).to.eql(\"Frozen\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{budgetId2}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets",
+										"{{budgetId2}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get budget records by complex query- 2 records",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"2 budget records are found\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let collection = pm.response.json();",
+											"    pm.expect(collection.budgets).to.have.lengthOf(2);",
+											"    collection.budgets.forEach(record => utils.validateBudget(record));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets?query=fund.fundStatus==Active and ledger.name=test and fiscalYear.periodEnd > 2019-12-12",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "fund.fundStatus==Active and ledger.name=test and fiscalYear.periodEnd > 2019-12-12"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete second budget record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budget is deleted\", () => pm.response.to.have.status(204));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{budgetId2}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets",
+										"{{budgetId2}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get budget records without query - 1 record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"One budget record is found\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let collection = pm.response.json();",
+											"    pm.expect(collection.budgets).to.have.lengthOf(1);",
+											"    utils.validateBudget(collection.budgets[0]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
 									]
 								}
 							},
@@ -2736,7 +3360,7 @@
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund type is not created\", function () {",
+											"pm.test(\"Fund is not created\", function () {",
 											"    pm.response.to.have.status(422).and.to.be.json;",
 											"    pm.expect(pm.response.json().errors).to.have.lengthOf(4);",
 											"});"
@@ -2794,7 +3418,7 @@
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund type is not created\", function () {",
+											"pm.test(\"Fund is not created\", function () {",
 											"    pm.response.to.have.status(400).and.to.be.json;",
 											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
 											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"duplicate key\");",
@@ -2854,7 +3478,7 @@
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund type is not created\", function () {",
+											"pm.test(\"Fund is not created\", function () {",
 											"    pm.response.to.have.status(400).and.to.be.json;",
 											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
 											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"ledgerid\").and.to.contain(\"foreign key constraint\");",
@@ -2916,7 +3540,7 @@
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund type is not created\", function () {",
+											"pm.test(\"Fund is not created\", function () {",
 											"    pm.response.to.have.status(400).and.to.be.json;",
 											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
 											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"fundtypeid\").and.to.contain(\"foreign key constraint\");",
@@ -2980,7 +3604,7 @@
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund type is not updated\", function () {",
+											"pm.test(\"Fund is not updated\", function () {",
 											"    pm.response.to.have.status(400).and.to.be.json;",
 											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
 											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"duplicate key\");",
@@ -3034,14 +3658,14 @@
 							"response": []
 						},
 						{
-							"name": "Search for types by bad query",
+							"name": "Search for funds by bad query",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund types cannot be found\", function () {",
+											"pm.test(\"Fund cannot be found\", function () {",
 											"    pm.response.to.have.status(400).and.to.be.json;",
 											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
 											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"cql\");",
@@ -3096,51 +3720,150 @@
 						}
 					],
 					"_postman_isSubFolder": true
-				}
-			]
-		},
-		{
-			"name": "Cleanup",
-			"item": [
+				},
 				{
-					"name": "Cleanup test tenant",
+					"name": "Budgets",
 					"item": [
 						{
-							"name": "Purge and disable all module for created tenant",
+							"name": "Create first budget for negative tests",
 							"event": [
 								{
-									"listen": "prerequest",
+									"listen": "test",
 									"script": {
-										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"pm.sendRequest(utils.buildOkapiUrl(\"/_/proxy/tenants/\" + pm.variables.get(\"testTenant\") + \"/modules\"), (err, res) => {",
-											"    pm.test(\"Preparing request to disable modules\", () => {",
-											"        pm.expect(err).to.equal(null);",
-											"        pm.expect(res.code).to.equal(200);",
-											"        let modulesToDisable = res.json();",
-											"        modulesToDisable.forEach(entry => entry.action = \"disable\");",
-											"",
-											"        console.log(modulesToDisable);",
-											"        pm.variables.set(\"modulesToDisable\", JSON.stringify(modulesToDisable));",
-											"    });",
+											"pm.test(\"Budget is created\", function() {",
+											"    pm.response.to.have.status(201);",
+											"    pm.environment.set(\"budgetId\", pm.response.json().id);",
 											"});"
 										],
 										"type": "text/javascript"
 									}
 								},
 								{
-									"listen": "test",
+									"listen": "prerequest",
 									"script": {
-										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.test(\"Disable all modules for test tenant\", function () {",
-											"    pm.response.to.have.status(200);",
-											"    pm.response.to.be.withBody;",
-											"});",
-											"",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"TST1\")));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create second budget for negative tests",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budget is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let record = pm.response.json();",
+											"    pm.environment.set(\"budgetId2\", record.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"TST2\")));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create budget without required field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budget is not created\", function () {",
+											"    pm.response.to.have.status(422).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(5);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
 											""
 										],
 										"type": "text/javascript"
@@ -3151,98 +3874,336 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
 									},
 									{
-										"key": "X-Okapi-Token",
-										"value": "{{xokapitoken-admin}}",
-										"type": "text"
+										"key": "Content-Type",
+										"value": "application/json"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{{modulesToDisable}}"
+									"raw": "{}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install?purge=true",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"_",
-										"proxy",
-										"tenants",
-										"{{testTenant}}",
-										"install"
-									],
-									"query": [
-										{
-											"key": "purge",
-											"value": "true"
-										}
+										"finance",
+										"budgets"
 									]
 								}
 							},
 							"response": []
 						},
 						{
-							"name": "Delete test tenant",
+							"name": "Create budget - name already exists",
 							"event": [
 								{
-									"listen": "prerequest",
+									"listen": "test",
 									"script": {
-										"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											""
+											"pm.test(\"Budget is not created\", function () {",
+											"    pm.response.to.have.status(400).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"duplicate key\");",
+											"});"
 										],
 										"type": "text/javascript"
 									}
 								},
 								{
-									"listen": "test",
+									"listen": "prerequest",
 									"script": {
-										"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
 										"exec": [
-											"pm.test(\"Tenant deleted - Expected Created (204)\", () => {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"// Remove all created variables",
-											"eval(globals.loadUtils).unsetTestVariables();"
+											"let utils = eval(globals.loadUtils);",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"TST1\")));"
 										],
 										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
-								"method": "DELETE",
+								"method": "POST",
 								"header": [
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken-admin}}",
-										"type": "text"
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": ""
+									"raw": "{{budgetContent}}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"_",
-										"proxy",
-										"tenants",
-										"{{testTenant}}"
+										"finance",
+										"budgets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create budget - non existent fund",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budget is not created\", function () {",
+											"    pm.response.to.have.status(400).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"fundid\").and.to.contain(\"foreign key constraint\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var uuid = require('uuid');",
+											"",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"TST3\", uuid.v4())));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create budget - non existent fiscal year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budget is not created\", function () {",
+											"    pm.response.to.have.status(400).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"fiscalyearid\").and.to.contain(\"foreign key constraint\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var uuid = require('uuid');",
+											"",
+											"let record = utils.buildBudgetMinContent(\"TST3\");",
+											"record.fiscalYearId = uuid.v4();",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(record));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update budget - name already exists",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budget is not updated\", function () {",
+											"    pm.response.to.have.status(400).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"duplicate key\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.variables.set(\"budgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"TST1\")));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{budgetContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{budgetId2}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets",
+										"{{budgetId2}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search for budgets by bad query",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Budgets cannot be found\", function () {",
+											"    pm.response.to.have.status(400).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"cql\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets?query=invalid cql",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"budgets"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "invalid cql"
+										}
 									]
 								}
 							},
@@ -3250,6 +4211,154 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				}
+			]
+		},
+		{
+			"name": "Cleanup",
+			"item": [
+				{
+					"name": "Purge and disable all module for created tenant",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"pm.sendRequest(utils.buildOkapiUrl(\"/_/proxy/tenants/\" + pm.variables.get(\"testTenant\") + \"/modules\"), (err, res) => {",
+									"    pm.test(\"Preparing request to disable modules\", () => {",
+									"        pm.expect(err).to.equal(null);",
+									"        pm.expect(res.code).to.equal(200);",
+									"        let modulesToDisable = res.json();",
+									"        modulesToDisable.forEach(entry => entry.action = \"disable\");",
+									"",
+									"        console.log(modulesToDisable);",
+									"        pm.variables.set(\"modulesToDisable\", JSON.stringify(modulesToDisable));",
+									"    });",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"pm.test(\"Disable all modules for test tenant\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken-admin}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{modulesToDisable}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install?purge=true",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"_",
+								"proxy",
+								"tenants",
+								"{{testTenant}}",
+								"install"
+							],
+							"query": [
+								{
+									"key": "purge",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete test tenant",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
+								"exec": [
+									"pm.test(\"Tenant deleted - Expected Created (204)\", () => {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									"",
+									"// Remove all created variables",
+									"eval(globals.loadUtils).unsetTestVariables();"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken-admin}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"_",
+								"proxy",
+								"tenants",
+								"{{testTenant}}"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}
@@ -3479,6 +4588,18 @@
 					"    };",
 					"",
 					"    /**",
+					"     * Build fiscal year record with minimal required fields.",
+					"     */",
+					"    utils.buildFiscalYearMinContent = function(code) {",
+					"        return {",
+					"            \"code\": code || \"TST-FY\",",
+					"            \"name\": \"Test fiscal year\",",
+					"            \"periodStart\": \"2019-01-01T00:00:00Z\",",
+					"            \"periodEnd\": \"2025-12-30T23:59:59Z\",",
+					"        };",
+					"    };",
+					"",
+					"    /**",
 					"     * Build Fund record with minimal required fields.",
 					"     */",
 					"    utils.buildFundMinContent = function(code, ledgerId) {",
@@ -3491,7 +4612,20 @@
 					"    };",
 					"",
 					"    /**",
-					"     * Validates the content of fund type record",
+					"     * Build budget record with minimal required fields.",
+					"     */",
+					"    utils.buildBudgetMinContent = function(name, fundId) {",
+					"        return {",
+					"            \"allocated\": 0,",
+					"            \"name\": name || \"TST-BDGT\",",
+					"            \"budgetStatus\": \"Active\",",
+					"            \"fundId\": fundId || pm.variables.get(\"fundId\"),",
+					"            \"fiscalYearId\": pm.variables.get(\"fiscalYearId\")",
+					"        };",
+					"    };",
+					"",
+					"    /**",
+					"     * Validates the content of the fund type record",
 					"     */",
 					"    utils.validateFundType = function(jsonData) {",
 					"        pm.expect(jsonData.id).to.exist;",
@@ -3500,7 +4634,7 @@
 					"    };",
 					"",
 					"    /**",
-					"     * Validates the content of fund record",
+					"     * Validates the content of the fund record",
 					"     */",
 					"    utils.validateFund = function(jsonData) {",
 					"        pm.expect(jsonData.id).to.exist;",
@@ -3509,6 +4643,19 @@
 					"        pm.expect(jsonData.ledgerId).to.exist;",
 					"        pm.expect(jsonData.name).to.exist;",
 					"        utils._validateAgainstSchema(jsonData, JSON.parse(pm.environment.get(utils.schemaPrefix + \"fund.json\")));",
+					"    };",
+					"",
+					"    /**",
+					"     * Validates the content of the budget record",
+					"     */",
+					"    utils.validateBudget = function(jsonData) {",
+					"        pm.expect(jsonData.id).to.exist;",
+					"        pm.expect(jsonData.allocated).to.exist;",
+					"        pm.expect(jsonData.budgetStatus).to.exist;",
+					"        pm.expect(jsonData.fundId).to.exist;",
+					"        pm.expect(jsonData.fiscalYearId).to.exist;",
+					"        pm.expect(jsonData.name).to.exist;",
+					"        utils._validateAgainstSchema(jsonData, JSON.parse(pm.environment.get(utils.schemaPrefix + \"budget.json\")));",
 					"    };",
 					"",
 					"    /**",
@@ -3524,6 +4671,10 @@
 					"        pm.globals.unset(\"loadUtils\");",
 					"",
 					"        pm.environment.unset(\"enabledModules\");",
+					"        pm.environment.unset(\"budgetId\");",
+					"        pm.environment.unset(\"budgetId2\");",
+					"        pm.environment.unset(\"budgetContent2\");",
+					"        pm.environment.unset(\"fiscalYearId\");",
 					"        pm.environment.unset(\"fundId\");",
 					"        pm.environment.unset(\"fundId2\");",
 					"        pm.environment.unset(\"fundContent2\");",


### PR DESCRIPTION
## Purpose
[MODFIN-61](https://issues.folio.org/browse/MODFIN-61) Define and Implement Budget API

## Approach
- Creating test fiscal year record directly in storage for now as it is required to create budget
- Creating budget records using fund and fiscal year created by preceding requests
- Positive and negative tests to test CRUD basics
- Using complex query to search for budgets like 
  ```
  query=budgetStatus==Planned and fund.fundStatus==Active and ledger.name=test and fiscalYear.periodEnd > 2019-12-12
  ```

![image](https://user-images.githubusercontent.com/43410167/64799054-b593a280-d58c-11e9-9334-0398c843cb81.png)

## Verification

![image](https://user-images.githubusercontent.com/43410167/64963294-b20c5e00-d8a1-11e9-9784-4733952ca929.png)

