### PR TITLE
MODORDERS-302 - Create order-templates API

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -12982,6 +12982,344 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Order Templates",
+					"item": [
+						{
+							"name": "Create order template",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.orderTemplate;",
+											"pm.variables.set(\"orderTemplateBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let expectedOrderTemplate = globals.testData.orderTemplate;",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    var orderTemplate = pm.response.json();",
+											"",
+											"    pm.test(\"Verify order template\", () => {",
+											"        pm.expect(orderTemplate.id).to.exist;",
+											"        pm.expect(orderTemplate.templateCode).to.eql(expectedOrderTemplate.templateCode);",
+											"        pm.expect(orderTemplate.templateDescription).to.eql(expectedOrderTemplate.templateDescription);",
+											"        pm.expect(orderTemplate.templateName).to.eql(expectedOrderTemplate.templateName);",
+											"        pm.expect(orderTemplate.acquisitionMethod).to.eql(expectedOrderTemplate.acquisitionMethod);",
+											"        pm.expect(orderTemplate.approved).to.be.true;",
+											"        pm.environment.set(\"orderTemplateId\", orderTemplate.id);",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{orderTemplateBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get order template by id",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let expectedOrderTemplate = globals.testData.orderTemplate;",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var orderTemplate = pm.response.json();",
+											"",
+											"    pm.test(\"Verify order template\", () => {",
+											"        pm.expect(orderTemplate.id).to.exist;",
+											"        pm.expect(orderTemplate.templateCode).to.eql(expectedOrderTemplate.templateCode);",
+											"        pm.expect(orderTemplate.templateDescription).to.eql(expectedOrderTemplate.templateDescription);",
+											"        pm.expect(orderTemplate.templateName).to.eql(expectedOrderTemplate.templateName);",
+											"        pm.expect(orderTemplate.acquisitionMethod).to.eql(expectedOrderTemplate.acquisitionMethod);",
+											"        pm.expect(orderTemplate.approved).to.be.true;",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/{{orderTemplateId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates",
+										"{{orderTemplateId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update order template",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.orderTemplate;",
+											"body.templateCode = \"Amazon-LLL\";",
+											"pm.variables.set(\"updatedTemplateCode\", body.templateCode);",
+											"pm.variables.set(\"updatedOrderTemplateBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    utils.sendGetRequest(\"/orders/order-templates/\" + pm.environment.get(\"orderTemplateId\"), (err, res) => {",
+											"        pm.test(\"Order template is updated\", () => {",
+											"            pm.expect(res.code).to.eql(200);",
+											"            var orderTemplate = res.json();",
+											"            pm.expect(orderTemplate.templateCode).to.eql(pm.variables.get(\"updatedTemplateCode\"));",
+											"        });",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedOrderTemplateBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/{{orderTemplateId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates",
+										"{{orderTemplateId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get updated order templates collection",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let expectedOrderTemplate = globals.testData.orderTemplate;",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var orderTemplatesCollection = pm.response.json();",
+											"",
+											"    pm.test(\"Verify order templates collection contains order templates\", () => {",
+											"        orderTemplatesCollection.totalRecords > 0;",
+											"        pm.expect(orderTemplatesCollection.orderTemplates.length).to.eql(orderTemplatesCollection.totalRecords);",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete order template",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    utils.sendGetRequest(\"/orders/order-templates/\" + pm.environment.get(\"orderTemplateId\"), (err, res) => {",
+											"        pm.test(\"Order template is deleted\", () => {",
+											"             pm.expect(res.code).to.eql(404);",
+											"        });",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/{{orderTemplateId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates",
+										"{{orderTemplateId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
 			],
@@ -18550,8 +18888,248 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Order Templates",
+					"item": [
+						{
+							"name": "Get updated order templates collection - invalid query",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates?query=invalid-query",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "invalid-query"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get order template - not found",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/776df59b-d7d8-4ef9-bb11-cf1b53be09ea",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates",
+										"776df59b-d7d8-4ef9-bb11-cf1b53be09ea"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update order template - id mismatch",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.orderTemplate;",
+											"body.id = \"776df59b-d7d8-4ef9-bb11-cf1b53be09ea\";",
+											"pm.variables.set(\"updatedOrderTemplateBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.test(\"Status code is 422\", function () {",
+											"    pm.response.to.have.status(422);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedOrderTemplateBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates",
+										"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete order template - not found",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{updatedOrderTemplateBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"order-templates",
+										"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Cleanup",
@@ -21707,7 +22285,15 @@
 					"            \"enabled\": true,",
 					"            \"value\": \"\"",
 					"        }",
-					"    }    ",
+					"    },",
+					"    orderTemplate: {",
+					"        id: \"f5b6ad51-58a3-44cd-88e3-b612ea8ff15b\",",
+					"        templateCode: \"Amazon-L\",",
+					"        templateDescription: \"Use to create orders in FOLIO after they are placed on Amazon\",",
+					"        templateName: \"Amazon orders\",",
+					"        acquisitionMethod: \"Purchase At Vendor System\",",
+					"        approved: true",
+					"    },",
 					"",
 					"};",
 					"",


### PR DESCRIPTION
API Tests for [MODORDERS-302](https://issues.folio.org/browse/MODORDERS-302) - Create order-templates API
The following tests are implemented.

**Positive:**
1. Create order template
2. Get order template by id
3. Update order template and verify that it is updated
4. Delete order template and verify that it is deleted
![positive-tests](https://user-images.githubusercontent.com/42964285/64946002-9772be80-d87a-11e9-9e5c-31d02f760ae3.png)

**Negative:**
1. Get order templates by invalid query
2. Order template not found
3. Update order template - id mismatch
4. Delete non-existed order template
![negative-tests](https://user-images.githubusercontent.com/42964285/64946030-a2c5ea00-d87a-11e9-8554-cf1c3758f45e.png)
