### PR TITLE
MODORDERS-303 Perform API tests in separate tenant

### DIFF
--- a/mod-orders/README.md
+++ b/mod-orders/README.md
@@ -39,13 +39,14 @@ The collection verifies `orders` APIs and different workflows
 Folder | Description  
 --- | --- 
 `Setup` | Contains various preparation requests/operations required for test runs
-`- Auth` | Authorize user
-`- Verify required modules enabled` | Validate that required modules enabled i.e. mod-orders, mod-configuration etc.
+`- Create tenant and enable modules` | Creates new tenant for API tests, enables required modules and creates admin user for this tenant
 `- Update configs` | Update PO Lines limit (based on variable with default value 10);
 `- Load all schemas for validation` | Loads various schemas for validation
+`- Prepare global data` | Prepares data like `institution`, `campus` etc.
 `- Prepare vendors` | Prepares active and inactive vendors
+`- Prepare finance data` | Prepares active and inactive vendors
 `- Prepare inventory types` | Prepares inventory types to not rely on reference data presence
-`- Setup new tenant` | Create new tenant to verify tenant-specific logic
+`- Create regular user` | Creates user with `acquisitions-units` permissions only
 `Positive Tests` | Contains various requests and tests to verify success cases
 `- Empty Order` | Verifies that an order can be created and deleted without order lines
 `- Pending Order` | Verifies that an order in `Pending` status can be created. Verifies that existing PO Lines can be updated/deleted; new PO Lines can be added/updated/deleted.
@@ -61,6 +62,8 @@ Folder | Description
 `- Receiving History` | Verifies receiving history endpoint
 `- Create Inventory` | Various tests to verify order creation in `Open` status with different tenant configs
 `- Check-in` | Verifies that resources can be successfully checked-in for `Open` orders and item records updated in the Inventory.
+`- Check Order automatically changes workflowStatus` | Various tests to verify automatic workflow transition from Open to Closed based on different PO line's statuses
+`- ISBN validation` | ISBN numbers validation
 `Negative Tests` | Contains various requests and tests to verify expected negative cases e.g. validation of the request etc.
 `- Create Order for tests` | Create order and PO line with content required for negative tests
 `- Order` | Various requests and tests to verify expected negative cases for endpoints managing order 
@@ -73,11 +76,14 @@ Folder | Description
 
 Variable | Initial Value | Description  
  --- | --- | --- 
+`testTenant` | orders_api_tests | Tenant identifier which is going to be used (created) for API tests
 `mod-ordersResourcesURL` | https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources | Path to mod-orders test resources
 `poLines-limit` | 10 | Purchase Order Lines Limit to be used for configuration update
+`inventory-identifierTypeName` | ordersApiTestsIdentifierTypeName | Inventory identifier type name which is going to be used for PO Lines product type
 `inventory-instanceTypeCode` | ordersApiTestsInstanceTypeCode | Inventory instance type code which is going to be used for instance creation when order transits to `Open` status
 `inventory-instanceStatusCode` | ordersApiTestsInstanceStatusCode | Inventory instance status code which is going to be used for instance creation when order transits to `Open` status
 `inventory-loanTypeName` | ordersApiTestsLoanTypeName | Inventory loan type name which is going to be used for item creation when order transits to `Open` status
+`tenant.addresses` | `{"address": "sample address", "name": "sample name"}` | Tenant address
 
 ## [mod-orders-acq-units](mod-orders-acq-units.postman_collection.json)
 The collection verifies `orders` APIs behavior depending on acquisition unit(s) assignment

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "236802e5-b1a1-450f-a157-659d19ec7ff7",
+		"_postman_id": "ea45224d-f872-446f-ab5c-57cdca25eaef",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -10,10 +10,10 @@
 			"name": "Setup",
 			"item": [
 				{
-					"name": "Auth",
+					"name": "Create tenant and enable modules",
 					"item": [
 						{
-							"name": "Login by admin",
+							"name": "Login by existing admin",
 							"event": [
 								{
 									"listen": "test",
@@ -24,7 +24,6 @@
 											"    pm.response.to.have.status(201);",
 											"});",
 											"",
-											"pm.environment.set(\"xokapitoken\", postman.getResponseHeader(\"x-okapi-token\"));",
 											"pm.environment.set(\"xokapitoken-admin\", postman.getResponseHeader(\"x-okapi-token\"));"
 										],
 										"type": "text/javascript"
@@ -61,22 +60,18 @@
 								}
 							},
 							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Verify required modules enabled",
-					"item": [
+						},
 						{
-							"name": "mod-orders is deployed",
+							"name": "Create new tenant",
 							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+										"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
 										"exec": [
-											""
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"tenantData\", JSON.stringify(globals.testData.tenant));"
 										],
 										"type": "text/javascript"
 									}
@@ -84,20 +79,14 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+										"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
 										"exec": [
-											"var jsonData = {};",
+											"// In case the tenant was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
 											"",
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"    jsonData = pm.response.json();",
-											"});",
-											"",
-											"pm.test(\"modules exist\", function () {",
-											"    // In case there is no module no sense to run further requests",
-											"    postman.setNextRequest(null);",
-											"    pm.expect(jsonData).to.have.lengthOf.at.least(1);",
-											"    pm.environment.set(\"modOrdersId\", jsonData[0].id);",
+											"pm.test(\"Tenant created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
 											"    postman.setNextRequest();",
 											"});"
 										],
@@ -106,23 +95,25 @@
 								}
 							],
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
-										"value": "application/json"
+										"value": "application/json",
+										"type": "text"
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-admin}}",
+										"type": "text"
 									}
 								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{tenantData}}"
+								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/modules?filter=mod-orders",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -131,26 +122,441 @@
 									"path": [
 										"_",
 										"proxy",
-										"modules"
-									],
-									"query": [
-										{
-											"key": "filter",
-											"value": "mod-orders"
-										}
+										"tenants"
 									]
-								},
-								"description": "Check if mod-orders is deployed. If no module available, do not proceed to the next request."
+								}
 							},
 							"response": []
 						},
 						{
-							"name": "mod-configuration is deployed",
+							"name": "Enable modules for new tenant",
 							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
-										"id": "98be8798-dde9-4048-a8f5-b1e0ae4de535",
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.getModuleId(\"mod-orders\", bodyHandler);",
+											"utils.getModuleId(\"mod-finance-storage\", bodyHandler);",
+											"utils.getModuleId(\"mod-login\", bodyHandler);",
+											"utils.getModuleId(\"mod-permissions\", bodyHandler);",
+											"utils.getModuleId(\"mod-configuration\", bodyHandler);",
+											"",
+											"var modulesToEnable = [];",
+											"",
+											"function bodyHandler(moduleId) {",
+											"\tmodulesToEnable.push({",
+											"\t\t\"id\" : moduleId,",
+											"\t\t\"action\": \"enable\"",
+											"\t});",
+											"    pm.variables.set(\"modulesToEnable\", JSON.stringify(modulesToEnable));",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"postman.setNextRequest(null);",
+											"pm.test(\"Enabled required modules\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"enabledModules\", pm.response.json());",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToEnable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create admin user",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "76c0a072-8ef6-4371-b926-f56d6a3218a0",
+										"exec": [
+											"pm.variables.set(\"userData\", JSON.stringify(globals.testData.users.admin.user));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d98143bb-5fc0-4394-ac89-bff8d0df33fe",
+										"exec": [
+											"// In case the user was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"User created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userData}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create credentials for admin user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "5542417e-4b64-431c-8b07-7f5b5e9179ff",
+										"exec": [
+											"pm.test(globals.testData.users.admin.user.username + \" user's credentials created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "de3203a8-0abe-4599-aee0-b34306d051de",
+										"exec": [
+											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.admin.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"credentials"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add all permissions to admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1f1202b1-b74a-46cc-8fcd-e5d9b76d53b7",
+										"exec": [
+											"pm.test(globals.testData.users.admin.user.username + \" user's permissions created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "dded3598-c238-487d-b06c-721c60509cf4",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let pmRq = {",
+											"    url: utils.buildOkapiUrl('/perms/permissions?length=1000&query=(subPermissions=\"\" NOT subPermissions ==/respectAccents []) and (cql.allRecords=1 NOT childOf <>/respectAccents [])'),",
+											"    method: \"GET\",",
+											"    header: {\"X-Okapi-Tenant\": pm.variables.get(\"testTenant\")}",
+											"};",
+											"pm.sendRequest(pmRq, (err, res) => {",
+											"    let userPermissions = globals.testData.users.admin.permissions;",
+											"    userPermissions.permissions = res.json().permissions.map(perm => perm.permissionName);",
+											"    pm.variables.set(\"userPermissions\", JSON.stringify(userPermissions));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userPermissions}}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"perms",
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Enable mod-authtoken for new tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.getModuleId(\"mod-authtoken\", bodyHandler);",
+											"",
+											"var modulesToEnable = [];",
+											"",
+											"function bodyHandler(moduleId) {",
+											"\tmodulesToEnable.push({",
+											"\t\t\"id\" : moduleId,",
+											"\t\t\"action\": \"enable\"",
+											"\t});",
+											"    pm.variables.set(\"modulesToEnable\", JSON.stringify(modulesToEnable));",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"postman.setNextRequest(null);",
+											"pm.test(\"Enabled mod-finance with all dependencies\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"enabledModules\", pm.response.json());",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToEnable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Login by new admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"// In case the new user cannot be logged in no sense to run further tests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});",
+											"",
+											"pm.environment.set(\"xokapitoken-testAdmin\", postman.getResponseHeader(\"x-okapi-token\"));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a59f5097-d5cb-4e46-8bf6-3bddff268e65",
+										"exec": [
+											"pm.variables.set(\"newUserCreds\", JSON.stringify(globals.testData.users.admin.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{newUserCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"login"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create order approve permission",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "76c0a072-8ef6-4371-b926-f56d6a3218a0",
 										"exec": [
 											""
 										],
@@ -160,62 +566,44 @@
 								{
 									"listen": "test",
 									"script": {
-										"id": "d9c7eb4d-544c-4d6e-9e0a-d9d495065b37",
+										"id": "d98143bb-5fc0-4394-ac89-bff8d0df33fe",
 										"exec": [
-											"var jsonData = {};",
-											"",
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"    jsonData = pm.response.json();",
-											"});",
-											"",
-											"pm.test(\"modules exist\", function () {",
-											"    // In case there is no module no sense to run further requests",
-											"    postman.setNextRequest(null);",
-											"    pm.expect(jsonData).to.have.lengthOf.at.least(1);",
-											"    postman.setNextRequest();",
-											"});"
+											"pm.test(\"Permission is created\", () => pm.response.to.have.status(201));"
 										],
 										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
+										"key": "content-type",
+										"type": "text",
 										"value": "application/json"
 									},
 									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"permissionName\": \"orders.item.approve\",\r\n  \"displayName\": \"Permission to approve order\"\r\n}"
+								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/modules?filter=mod-configuration",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/permissions",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"_",
-										"proxy",
-										"modules"
-									],
-									"query": [
-										{
-											"key": "filter",
-											"value": "mod-configuration"
-										}
+										"perms",
+										"permissions"
 									]
-								},
-								"description": "Check if mod-orders is deployed. If no module available, do not proceed to the next request."
+								}
 							},
 							"response": []
 						}
@@ -277,7 +665,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
 								"url": {
@@ -356,7 +744,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
 								"url": {
@@ -446,9 +834,9 @@
 											"\r",
 											"function fetchSchema(path) {\r",
 											"    let getRequest = buildGetSchemaRequest(path);\r",
+											"\r",
 											"    return new Promise((resolve, reject) => {\r",
 											"        pm.sendRequest(getRequest, (err, response) => {\r",
-											"\r",
 											"            if (!err) {\r",
 											"                if (response.code === 200) {\r",
 											"                    let content = replaceResponseRefWithName(response.text());\r",
@@ -491,17 +879,29 @@
 									"script": {
 										"id": "789cccc8-2479-48c7-ac26-5e35328874bd",
 										"exec": [
-											"let utils = eval(globals.loadUtils);\r",
-											"const moduleName = 'mod-orders';\r",
-											"\r",
-											"utils.sendGetRequest('/_/proxy/tenants/' + pm.variables.get(\"xokapitenant\") + '/interfaces/_jsonSchemas', (err, response) => {\r",
-											"    pm.test(\"jsonSchemas provided by \" + moduleName, function () {\r",
-											"        pm.expect(err).to.equal(null);\r",
-											"        pm.expect(response.text()).to.include(moduleName);\r",
-											"        let moduleId = response.json().map(element => element.id).filter(modId => modId.includes(moduleName))[0];\r",
-											"    \tpm.variables.set('modOrdersId', moduleId);\r",
-											"    });\r",
-											"});"
+											"let utils = eval(globals.loadUtils);",
+											"const moduleName = 'mod-orders';",
+											"",
+											"pm.sendRequest(buildPmRequest1(\"/_/proxy/tenants/\" + pm.variables.get(\"testTenant\") + \"/interfaces/_jsonSchemas\"), (err, response) => {",
+											"    pm.test(\"jsonSchemas provided by \" + moduleName, function() {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(response.text()).to.include(moduleName);",
+											"        let moduleId = response.json().map(element => element.id).filter(modId => modId.includes(moduleName))[0];",
+											"        pm.variables.set('modOrdersId', moduleId);",
+											"    });",
+											"});",
+											"",
+											"",
+											"function buildPmRequest1(path) {",
+											"    return {",
+											"        url: utils.buildOkapiUrl(path),",
+											"        method: \"GET\",",
+											"        header: {",
+											"            \"X-Okapi-Tenant\": pm.variables.get(\"xokapitenant\"),",
+											"            \"X-Okapi-Token\": pm.environment.get(\"xokapitoken-admin\")",
+											"        }",
+											"    };",
+											"}"
 										],
 										"type": "text/javascript"
 									}
@@ -518,7 +918,7 @@
 									{
 										"key": "X-Okapi-Tenant",
 										"type": "text",
-										"value": "{{xokapitenant}}"
+										"value": "{{testTenant}}"
 									}
 								],
 								"url": {
@@ -562,24 +962,20 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"name": "Prepare sample data",
+					"name": "Prepare global data",
 					"item": [
 						{
-							"name": "Post active vendor",
+							"name": "Institution",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
 										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.test(\"Storing active vendor\", function () {",
+											"pm.test(\"Record is created\", function () {",
 											"    pm.response.to.have.status(201);",
 											"    pm.response.to.be.withBody;",
-											"});",
-											"",
-											"pm.environment.set(\"activeVendorId\", pm.response.json().id);"
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -601,7 +997,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									},
 									{
 										"key": "Content-Type",
@@ -612,90 +1008,25 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"name\": \"Test active vendor\",\n\t\"code\": \"TAV\",\n\t\"isVendor\": true,\n\t\"status\" : \"Active\"\n}"
+									"raw": "{\n    \"id\": \"40ee00ca-a518-4b49-be01-0638d0a4ac57\",\n    \"name\": \"Universitet\",\n    \"code\": \"TU\"\n}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/location-units/institutions",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"organizations-storage",
-										"organizations"
+										"location-units",
+										"institutions"
 									]
 								}
 							},
 							"response": []
 						},
 						{
-							"name": "Post inactive vendor",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.test(\"Storing inactive vendor\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    pm.response.to.be.withBody;",
-											"});",
-											"",
-											"pm.environment.set(\"inactiveVendorId\", pm.response.json().id);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\t\"name\": \"Test inactive vendor\",\n\t\"code\": \"TIV\",\n\t\"isVendor\": true,\n\t\"status\" : \"Inactive\"\n}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"organizations-storage",
-										"organizations"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Post location",
+							"name": "Campus",
 							"event": [
 								{
 									"listen": "test",
@@ -737,7 +1068,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									},
 									{
 										"key": "Content-Type",
@@ -748,7 +1079,332 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Basement\",\n    \"code\": \"FUS/ROH/DAH\",\n    \"isActive\": true,\n    \"institutionId\": \"40ee00ca-a518-4b49-be01-0638d0a4ac57\",\n    \"campusId\": \"62cf76b7-cca5-4d33-9217-edf42ce1a848\",\n    \"libraryId\": \"5d78803e-ca04-4b4a-aeae-2c63b924518b\",\n    \"primaryServicePoint\": \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\",\n    \"servicePointIds\": [\n        \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\"\n    ]\n}"
+									"raw": "{\n    \"id\": \"62cf76b7-cca5-4d33-9217-edf42ce1a848\",\n    \"institutionId\": \"40ee00ca-a518-4b49-be01-0638d0a4ac57\",\n    \"name\": \" Campus\",\n    \"code\": \"TC\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/location-units/campuses",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"location-units",
+										"campuses"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Library",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"// Most of the request will fail if there is a problem with location",
+											"postman.setNextRequest(null);",
+											"pm.test(\"Storing active location\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    ",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});",
+											"let newLocationId = pm.response.json().id;",
+											"pm.environment.set(\"newLocationId\", newLocationId);",
+											"",
+											"globals.testData.receiving.bodyTemplate.toBeReceived[0].receivedItems[0].locationId = newLocationId;"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"id\": \"5d78803e-ca04-4b4a-aeae-2c63b924518b\",\n    \"campusId\": \"62cf76b7-cca5-4d33-9217-edf42ce1a848\",\n    \"name\": \"Library\",\n    \"code\": \"TL\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/location-units/libraries",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"location-units",
+										"libraries"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Service point",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"// Most of the request will fail if there is a problem with location",
+											"postman.setNextRequest(null);",
+											"pm.test(\"Storing active location\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    ",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});",
+											"let newLocationId = pm.response.json().id;",
+											"pm.environment.set(\"newLocationId\", newLocationId);",
+											"",
+											"globals.testData.receiving.bodyTemplate.toBeReceived[0].receivedItems[0].locationId = newLocationId;"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"id\": \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\",\n    \"name\": \"Service point\",\n    \"code\": \"TSP\",\n    \"discoveryDisplayName\": \"Service point 1\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/service-points",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"service-points"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Location 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"pm.test(\"Location is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"locationId1\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"id\": \"b32c5ce2-6738-42db-a291-2796b1c3c4c6\",\n    \"name\": \"Location 1\",\n    \"code\": \"LOC1\",\n    \"isActive\": true,\n    \"institutionId\": \"40ee00ca-a518-4b49-be01-0638d0a4ac57\",\n    \"campusId\": \"62cf76b7-cca5-4d33-9217-edf42ce1a848\",\n    \"libraryId\": \"5d78803e-ca04-4b4a-aeae-2c63b924518b\",\n    \"primaryServicePoint\": \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\",\n    \"servicePointIds\": [\n        \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\"\n    ]\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"locations"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Location 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"pm.test(\"Location is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"locationId2\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"id\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n    \"name\": \"Location 2\",\n    \"code\": \"LOC2\",\n    \"isActive\": true,\n    \"institutionId\": \"40ee00ca-a518-4b49-be01-0638d0a4ac57\",\n    \"campusId\": \"62cf76b7-cca5-4d33-9217-edf42ce1a848\",\n    \"libraryId\": \"5d78803e-ca04-4b4a-aeae-2c63b924518b\",\n    \"primaryServicePoint\": \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\",\n    \"servicePointIds\": [\n        \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\"\n    ]\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"locations"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Location 3",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"pm.test(\"Location is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"locationId3\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"id\": \"f17914b0-048a-42f2-b6c1-fc6f38edf157\",\n    \"name\": \"Location 3\",\n    \"code\": \"LOC3\",\n    \"isActive\": true,\n    \"institutionId\": \"40ee00ca-a518-4b49-be01-0638d0a4ac57\",\n    \"campusId\": \"62cf76b7-cca5-4d33-9217-edf42ce1a848\",\n    \"libraryId\": \"5d78803e-ca04-4b4a-aeae-2c63b924518b\",\n    \"primaryServicePoint\": \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\",\n    \"servicePointIds\": [\n        \"3a40852d-49fd-4df2-a1f9-6e2641a6e91f\"\n    ]\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations",
@@ -768,56 +1424,153 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "Prepare vendors",
+					"item": [
+						{
+							"name": "Post active vendor",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"pm.test(\"Storing active vendor\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.environment.set(\"activeVendorId\", pm.response.json().id);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"name\": \"Test active vendor\",\n\t\"code\": \"TAV\",\n\t\"isVendor\": true,\n\t\"status\" : \"Active\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"organizations-storage",
+										"organizations"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Post inactive vendor",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
+										"exec": [
+											"pm.test(\"Storing inactive vendor\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											"pm.environment.set(\"inactiveVendorId\", pm.response.json().id);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"name\": \"Test inactive vendor\",\n\t\"code\": \"TIV\",\n\t\"isVendor\": true,\n\t\"status\" : \"Inactive\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"organizations-storage",
+										"organizations"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "Prepare finance data",
 					"item": [
 						{
-							"name": "Get or create ledger",
+							"name": "Ledger",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
 										"exec": [
-											"postman.setNextRequest(null);",
-											"pm.test(\"GET ledger response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.ledgers.length == 1) {",
-											"        useAlreadyExistingType(jsonData.ledgers[0]);",
-											"    } else {",
-											"        createNewRecord();",
-											"    }",
-											"        // All is okay so running further requests",
-											"    postman.setNextRequest();",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(identifierType) {",
-											"    pm.test(\"Ledger already exists\", function () {",
-											"        pm.expect(identifierType.id).to.exist;",
-											"        rememberId(identifierType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewRecord() {",
-											"    const type = {",
-											"        \"name\": \"Ledger for orders API Tests\",",
-											"        \"code\": pm.variables.get(\"finance-ledgerCode\"),",
-											"        \"description\": \"Ledger for orders API Tests\",",
-											"        \"ledgerStatus\": \"Active\"",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/finance-storage/ledgers\", type, (err, res) => {",
-											"        pm.test(\"Ledger created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            rememberId(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function rememberId(id) {",
-											"    pm.environment.set(\"ledgerId\", id);",
-											"}"
+											"pm.test(\"Ledger is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"ledgerId\", pm.response.json().id);",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -834,7 +1587,7 @@
 								}
 							],
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -844,11 +1597,15 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\"\r\n}"
+								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers?query=code=={{finance-ledgerCode}}&limit=1",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -857,16 +1614,6 @@
 									"path": [
 										"finance-storage",
 										"ledgers"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "code=={{finance-ledgerCode}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
 									]
 								},
 								"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
@@ -874,55 +1621,18 @@
 							"response": []
 						},
 						{
-							"name": "Get or create fund",
+							"name": "Fund",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
 										"exec": [
-											"postman.setNextRequest(null);",
-											"pm.test(\"GET funds response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.funds.length == 1) {",
-											"        useAlreadyExistingType(jsonData.funds[0]);",
-											"    } else {",
-											"        createNewRecord();",
-											"    }",
-											"            // All is okay so running further requests",
-											"    postman.setNextRequest();",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(identifierType) {",
-											"    pm.test(\"Fund already exists\", function () {",
-											"        pm.expect(identifierType.id).to.exist;",
-											"        rememberId(identifierType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewRecord() {",
-											"    const type = {",
-											"      \"code\": pm.variables.get(\"finance-fundCode\"),",
-											"      \"description\": \"Fund for orders API Tests\",",
-											"      \"externalAccountNo\": \"1111111111111111111111111\",",
-											"      \"fundStatus\": \"Active\",",
-											"      \"ledgerId\": pm.variables.get(\"ledgerId\"),",
-											"      \"name\": \"Fund for orders API Tests\"",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/finance-storage/funds\", type, (err, res) => {",
-											"        pm.test(\"Fund created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            rememberId(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function rememberId(id) {",
-											"    pm.environment.set(\"fundId\", id);",
-											"}"
+											"pm.test(\"Fund is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"fundId\", pm.response.json().id);",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -939,7 +1649,7 @@
 								}
 							],
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -949,11 +1659,15 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"code\": \"TST-FND\",\r\n  \"description\": \"Fund for orders API Tests\",\r\n  \"externalAccountNo\": \"1111111111111111111111111\",\r\n  \"fundStatus\": \"Active\",\r\n  \"ledgerId\": \"{{ledgerId}}\",\r\n  \"name\": \"Fund for orders API Tests\"\r\n}"
+								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds?query=code=={{finance-fundCode}}&limit=1",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -962,16 +1676,6 @@
 									"path": [
 										"finance-storage",
 										"funds"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "code=={{finance-fundCode}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
 									]
 								},
 								"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
@@ -985,48 +1689,18 @@
 					"name": "Prepare inventory types",
 					"item": [
 						{
-							"name": "Get or create Identifier Type",
+							"name": "Identifier Type",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
 										"exec": [
-											"pm.test(\"GET identifier types response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.identifierTypes.length == 1) {",
-											"        useAlreadyExistingType(jsonData.identifierTypes[0]);",
-											"    } else {",
-											"        createNewType();",
-											"    }",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(identifierType) {",
-											"    pm.test(\"Identifier Type already exists\", function () {",
-											"        pm.expect(identifierType.id).to.exist;",
-											"        rememberId(identifierType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewType() {",
-											"    const type = {",
-											"        \"id\": \"6d6f642d-0010-1111-aaaa-6f7264657273\",",
-											"        \"name\": pm.variables.get(\"inventory-identifierTypeName\")",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/identifier-types\", type, (err, res) => {",
-											"        pm.test(\"Identifier Type created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            rememberId(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function rememberId(id) {",
-											"    pm.environment.set(\"identifierTypeId\", id);",
-											"}"
+											"pm.test(\"Record is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"identifierTypeId\", pm.response.json().id);",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -1043,7 +1717,7 @@
 								}
 							],
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -1053,11 +1727,15 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"6d6f642d-0010-1111-aaaa-6f7264657273\",\r\n  \"name\": \"{{inventory-identifierTypeName}}\"\r\n}"
+								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/identifier-types?query=name=={{inventory-identifierTypeName}}&limit=1",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/identifier-types",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -1065,16 +1743,6 @@
 									"port": "{{okapiport}}",
 									"path": [
 										"identifier-types"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "name=={{inventory-identifierTypeName}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
 									]
 								},
 								"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
@@ -1082,50 +1750,18 @@
 							"response": []
 						},
 						{
-							"name": "Get or create Instance Type",
+							"name": "ISBN Identifier Type",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
 										"exec": [
-											"pm.test(\"GET Instance types response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.instanceTypes.length == 1) {",
-											"        useAlreadyExistingType(jsonData.instanceTypes[0]);",
-											"    } else {",
-											"        createNewType();",
-											"    }",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(instanceType) {",
-											"    pm.test(\"Instance Type already exists\", function () {",
-											"        pm.expect(instanceType.id).to.exist;",
-											"        rememberId(instanceType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewType() {",
-											"    const type = {",
-											"        \"id\": \"6d6f642d-0000-1111-aaaa-6f7264657273\",",
-											"        \"code\": pm.variables.get(\"inventory-instanceTypeCode\"),",
-											"        \"name\": pm.variables.get(\"inventory-instanceTypeCode\"),",
-											"        \"source\": \"apiTests\"",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/instance-types\", type, (err, res) => {",
-											"        pm.test(\"Instance Type created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            rememberId(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function rememberId(id) {",
-											"    pm.environment.set(\"instanceTypeId\", id);",
-											"}"
+											"pm.test(\"Record is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"isbnIdentifierTypeId\", pm.response.json().id);",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -1142,519 +1778,7 @@
 								}
 							],
 							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-types?query=code=={{inventory-instanceTypeCode}}&limit=1",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"instance-types"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "code=={{inventory-instanceTypeCode}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
-									]
-								},
-								"description": "Gets or creates if not yet exists test instance type to be used accross the orders while interaction with inventory"
-							},
-							"response": []
-						},
-						{
-							"name": "Get or create Instance Status",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
-										"exec": [
-											"pm.test(\"GET Instance statuses response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.instanceStatuses.length == 1) {",
-											"        useAlreadyExistingType(jsonData.instanceStatuses[0]);",
-											"    } else {",
-											"        createNewType();",
-											"    }",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(status) {",
-											"    pm.test(\"Instance Status already exists\", function () {",
-											"        pm.expect(status.id).to.exist;",
-											"        rememberId(status.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewType() {",
-											"    const type = {",
-											"        \"id\": \"6d6f642d-0001-1111-aaaa-6f7264657273\",",
-											"        \"code\": pm.variables.get(\"inventory-instanceStatusCode\"),",
-											"        \"name\": pm.variables.get(\"inventory-instanceStatusCode\"),",
-											"        \"source\": \"apiTests\"",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/instance-statuses\", type, (err, res) => {",
-											"        pm.test(\"Instance Status created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            rememberId(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function rememberId(id) {",
-											"    pm.environment.set(\"instanceStatusId\", id);",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-statuses?query=code=={{inventory-instanceStatusCode}}&limit=1",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"instance-statuses"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "code=={{inventory-instanceStatusCode}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
-									]
-								},
-								"description": "Gets or creates if not yet exists test instance status to be used accross the orders while interaction with inventory"
-							},
-							"response": []
-						},
-						{
-							"name": "Get or create Loan Type",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
-										"exec": [
-											"pm.test(\"GET Loan Types response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.loantypes.length == 1) {",
-											"        useAlreadyExistingType(jsonData.loantypes[0]);",
-											"    } else {",
-											"        createNewType();",
-											"    }",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(loanType) {",
-											"    pm.test(\"Loan Type already exists\", function () {",
-											"        pm.expect(loanType.id).to.exist;",
-											"        rememberId(loanType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewType() {",
-											"    const type = {",
-											"        \"id\": \"6d6f642d-0002-1111-aaaa-6f7264657273\",",
-											"        \"name\": pm.variables.get(\"inventory-loanTypeName\")",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/loan-types\", type, (err, res) => {",
-											"        pm.test(\"Instance Status created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            rememberId(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function rememberId(id) {",
-											"    pm.environment.set(\"loanTypeId\", id);",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/loan-types?query=name=={{inventory-loanTypeName}}&limit=1",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"loan-types"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "name=={{inventory-loanTypeName}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
-									]
-								},
-								"description": "Gets or creates if not yet exists test loan type to be used accross the orders while interaction with inventory"
-							},
-							"response": []
-						},
-						{
-							"name": "Get or create Material Type",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
-										"exec": [
-											"pm.test(\"GET Material types response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.mtypes.length == 1) {",
-											"        useAlreadyExistingType(jsonData.mtypes[0]);",
-											"    } else {",
-											"        createNewType();",
-											"    }",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(materialType) {",
-											"    pm.test(\"Material Type already exists\", function () {",
-											"        pm.expect(materialType.id).to.exist;",
-											"        setIdAsGlobalVariable(materialType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewType() {",
-											"    const mtype = {",
-											"        \"id\": \"6d6f642d-0003-1111-aaaa-6f7264657273\",",
-											"        \"name\": pm.variables.get(\"materialTypeName\")",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/material-types\", mtype, (err, res) => {",
-											"        pm.test(\"Material Type created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            setIdAsGlobalVariable(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function setIdAsGlobalVariable(id) {",
-											"    pm.environment.set(\"materialTypeId\", id);",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
-										"exec": [
-											"pm.variables.set(\"materialTypeName\", \"Orders API Tests type\");"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/material-types?query=name=={{materialTypeName}}&limit=1",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"material-types"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "name=={{materialTypeName}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
-									]
-								},
-								"description": "Gets or creates if not yet exists test meterial type to be used accross the orders while interaction with inventory"
-							},
-							"response": []
-						},
-						{
-							"name": "Get or create Contributor name type",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
-										"exec": [
-											"pm.test(\"GET Contributor Name types response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.contributorNameTypes.length == 1) {",
-											"        useAlreadyExistingType(jsonData.contributorNameTypes[0]);",
-											"    } else {",
-											"        createNewType();",
-											"    }",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(materialType) {",
-											"    pm.test(\"Contributor Name Type already exists\", function () {",
-											"        pm.expect(materialType.id).to.exist;",
-											"        setIdAsGlobalVariable(materialType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewType() {",
-											"    const nameType = {",
-											"        \"id\": \"6d6f642d-0005-1111-aaaa-6f7264657273\",",
-											"        \"name\": pm.variables.get(\"contributorNameType\")",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/contributor-name-types\", nameType, (err, res) => {",
-											"        pm.test(\"Contributor Name Type created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            setIdAsGlobalVariable(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function setIdAsGlobalVariable(id) {",
-											"    pm.environment.set(\"contributorNameTypeId\", id);",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
-										"exec": [
-											"pm.variables.set(\"contributorNameType\", \"Orders API Tests type\");"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/contributor-name-types?query=name=={{contributorNameType}}&limit=1",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"contributor-name-types"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "name=={{contributorNameType}}"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
-									]
-								},
-								"description": "Gets or creates if not yet exists test meterial type to be used accross the orders while interaction with inventory"
-							},
-							"response": []
-						},
-						{
-							"name": "Get or create ISBN Identifier Type",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
-										"exec": [
-											"pm.test(\"GET ISBN identifier types response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    let jsonData = pm.response.json();",
-											"    if (jsonData.identifierTypes.length == 1) {",
-											"        useAlreadyExistingType(jsonData.identifierTypes[0]);",
-											"    } else {",
-											"        createNewType();",
-											"    }",
-											"});  ",
-											"",
-											"function useAlreadyExistingType(identifierType) {",
-											"    pm.test(\"ISBN Identifier Type already exists\", function () {",
-											"        pm.expect(identifierType.id).to.exist;",
-											"        rememberId(identifierType.id);",
-											"    });",
-											"}",
-											"",
-											"function createNewType() {",
-											"    const type = {",
-											"        \"id\": \"8261054f-be78-422d-bd51-4ed9f33c3422\",",
-											"        \"name\": \"ISBN\"",
-											"    };",
-											"",
-											"    eval(globals.loadUtils).postRequest(\"/identifier-types\", type, (err, res) => {",
-											"        pm.test(\"Identifier Type created\", () => {",
-											"            pm.expect(err).to.equal(null);",
-											"            pm.expect(res).to.have.property('code', 201);",
-											"            rememberId(res.json().id);",
-											"        });",
-											"    });",
-											"}",
-											"",
-											"function rememberId(id) {",
-											"    pm.environment.set(\"isbnIdentifierTypeId\", id);",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -1664,11 +1788,15 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"8261054f-be78-422d-bd51-4ed9f33c3422\",\r\n  \"name\": \"ISBN\"\r\n}"
+								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/identifier-types?query=name==ISBN&limit=1",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/identifier-types",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -1676,19 +1804,314 @@
 									"port": "{{okapiport}}",
 									"path": [
 										"identifier-types"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "name==ISBN"
-										},
-										{
-											"key": "limit",
-											"value": "1"
-										}
 									]
 								},
 								"description": "Gets or creates ISBN identifier type to be used for ISBN validation"
+							},
+							"response": []
+						},
+						{
+							"name": "Instance Type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Record is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"instanceTypeId\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"6d6f642d-0000-1111-aaaa-6f7264657273\",\r\n  \"code\": \"{{inventory-instanceTypeCode}}\",\r\n  \"name\": \"{{inventory-instanceTypeCode}}\",\r\n  \"source\": \"apiTests\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-types",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"instance-types"
+									]
+								},
+								"description": "Gets or creates if not yet exists test instance type to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						},
+						{
+							"name": "Instance Status",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Record is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"instanceStatusId\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"6d6f642d-0001-1111-aaaa-6f7264657273\",\r\n  \"code\": \"{{inventory-instanceStatusCode}}\",\r\n  \"name\": \"{{inventory-instanceStatusCode}}\",\r\n  \"source\": \"apiTests\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-statuses",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"instance-statuses"
+									]
+								},
+								"description": "Gets or creates if not yet exists test instance status to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						},
+						{
+							"name": "Loan Type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Record is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"loanTypeId\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"6d6f642d-0002-1111-aaaa-6f7264657273\",\r\n  \"name\": \"{{inventory-loanTypeName}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/loan-types",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"loan-types"
+									]
+								},
+								"description": "Gets or creates if not yet exists test loan type to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						},
+						{
+							"name": "Material Type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Record is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"materialTypeId\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"6d6f642d-0003-1111-aaaa-6f7264657273\",\r\n  \"name\": \"materialTypeName\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/material-types",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"material-types"
+									]
+								},
+								"description": "Gets or creates if not yet exists test meterial type to be used accross the orders while interaction with inventory"
+							},
+							"response": []
+						},
+						{
+							"name": "Contributor name type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Record is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"contributorNameTypeId\", pm.response.json().id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"6d6f642d-0005-1111-aaaa-6f7264657273\",\r\n  \"name\": \"contributorNameType\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/contributor-name-types",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"contributor-name-types"
+									]
+								},
+								"description": "Gets or creates if not yet exists test meterial type to be used accross the orders while interaction with inventory"
 							},
 							"response": []
 						}
@@ -1696,267 +2119,17 @@
 					"_postman_isSubFolder": true
 				},
 				{
-					"name": "Setup new tenant",
+					"name": "Create regular user",
 					"item": [
 						{
-							"name": "Create tenant and enable orders and orders storage for it",
-							"item": [
-								{
-									"name": "Create new tenant",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"utils.sendGetRequest(\"/_/proxy/tenants/\" + globals.testData.tenant.id, (err, res) => {",
-													"    pm.test(\"Check if tenant for API Tests already exists\", () => {",
-													"        pm.expect(err).to.equal(null);",
-													"        pm.expect(res.code).to.be.oneOf([200, 404]);",
-													"        // If tenant already exists, check if this is for API Tests and delete it",
-													"        if (res.code === 200 && res.json().name) {",
-													"            utils.sendDeleteRequest(\"/_/proxy/tenants/\" + globals.testData.tenant.id, (err, res) => {",
-													"                pm.test(\"Tenant '\" + res.json().name + \"' deleted\", () => {",
-													"                    pm.expect(res.code).to.eql(204);",
-													"                });",
-													"            });",
-													"        }",
-													"    });",
-													"});",
-													"",
-													"pm.variables.set(\"tenantData\", JSON.stringify(globals.testData.tenant));"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
-												"exec": [
-													"// In case the tenant was not created no sense to run further requests",
-													"postman.setNextRequest(null);",
-													"",
-													"pm.test(\"Tenant created - Expected Created (201)\", () => {",
-													"    pm.response.to.have.status(201);",
-													"    pm.globals.set(\"testTenant\", pm.response.json().id)",
-													"    // All is okay so running further requests",
-													"    postman.setNextRequest();",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{tenantData}}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"_",
-												"proxy",
-												"tenants"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Enable mod-orders for new tenant",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"pm.test(\"Enabled mod-orders with dependencies\", function () {",
-													"    pm.response.to.have.status(200);",
-													"    pm.response.to.be.withBody;",
-													"});",
-													"",
-													"pm.globals.set(\"enabledModules\", pm.response.json());"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "[\n\t{\n\t\t\"id\" : \"{{modOrdersId}}\",\n\t\t\"action\": \"enable\"\n\t}\n]"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"_",
-												"proxy",
-												"tenants",
-												"{{testTenant}}",
-												"install"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
-						{
-							"name": "Prepare vendor",
-							"item": [
-								{
-									"name": "Post active vendor",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"pm.test(\"Storing active vendor\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    pm.response.to.be.withBody;",
-													"});",
-													"",
-													"pm.globals.set(\"testTenantActiveVendorId\", pm.response.json().id);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-tenant",
-												"type": "text",
-												"value": "{{testTenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"name\": \"Test active vendor\",\n\t\"code\": \"TAV\",\n\t\"isVendor\": true,\n\t\"status\" : \"Active\"\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"organizations-storage",
-												"organizations"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Create user",
-					"item": [
-						{
-							"name": "Create new user",
+							"name": "Create user",
 							"event": [
 								{
 									"listen": "prerequest",
 									"script": {
 										"id": "76c0a072-8ef6-4371-b926-f56d6a3218a0",
 										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"utils.sendGetRequest(\"/users/\" + globals.testData.user.id, (err, res) => {",
-											"    pm.test(\"Check if user for API Tests already exists\", () => {",
-											"        pm.expect(err).to.equal(null);",
-											"        pm.expect(res.code).to.be.oneOf([200, 404]);",
-											"        // If user already exists, check if this is for API Tests and delete it",
-											"        if (res.code === 200 && res.json().username) {",
-											"            utils.sendDeleteRequest(\"/users/\" + globals.testData.user.id, (err, res) => {",
-											"                pm.test(\"User '\" + globals.testData.user.username + \"' deleted\", () => {",
-											"                    pm.expect(res.code).to.eql(204);",
-											"                });",
-											"            });",
-											"        }",
-											"    });",
-											"});",
-											"",
-											"pm.variables.set(\"userData\", JSON.stringify(globals.testData.user));"
+											"pm.variables.set(\"userData\", JSON.stringify(globals.testData.users.regular.user));"
 										],
 										"type": "text/javascript"
 									}
@@ -1989,14 +2162,9 @@
 										"value": "application/json"
 									},
 									{
-										"key": "x-okapi-tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}",
-										"type": "text"
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
 								"body": {
@@ -2018,14 +2186,14 @@
 							"response": []
 						},
 						{
-							"name": "Create credentials for new user",
+							"name": "Create credentials for user",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "5542417e-4b64-431c-8b07-7f5b5e9179ff",
 										"exec": [
-											"pm.test(globals.testData.user.username + \" user's credentials created\", () => pm.response.to.have.status(201));"
+											"pm.test(globals.testData.users.regular.user.username + \" user's credentials created\", () => pm.response.to.have.status(201));"
 										],
 										"type": "text/javascript"
 									}
@@ -2035,20 +2203,7 @@
 									"script": {
 										"id": "de3203a8-0abe-4599-aee0-b34306d051de",
 										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"utils.sendGetRequest(\"/authn/credentials?query=userId=\" + globals.testData.user.id, (err, res) => {",
-											"    // If user already has credentials and delete them to create fresh each time",
-											"    if (res.code === 200 && res.json().totalRecords > 0) {",
-											"        utils.sendDeleteRequest(\"/authn/credentials/\" + res.json().credentials[0].id, (err, res) => {",
-											"            pm.test(globals.testData.user.username + \" user's credentials deleted\", () => {",
-											"                pm.expect(res.code).to.eql(204);",
-											"            });",
-											"        });",
-											"    }",
-											"});",
-											"",
-											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.credentials));"
+											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
 										],
 										"type": "text/javascript"
 									}
@@ -2063,14 +2218,9 @@
 										"value": "application/json"
 									},
 									{
-										"key": "x-okapi-tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}",
+										"type": "text"
 									}
 								],
 								"body": {
@@ -2093,14 +2243,14 @@
 							"response": []
 						},
 						{
-							"name": "Add only mod-orders permissions",
+							"name": "Add orders permissions to user",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "1f1202b1-b74a-46cc-8fcd-e5d9b76d53b7",
 										"exec": [
-											"pm.test(globals.testData.user.username + \" user's permissions created\", () => pm.response.to.have.status(201));"
+											"pm.test(globals.testData.users.regular.user.username + \" user's permissions created\", () => pm.response.to.have.status(201));"
 										],
 										"type": "text/javascript"
 									}
@@ -2110,20 +2260,7 @@
 									"script": {
 										"id": "dded3598-c238-487d-b06c-721c60509cf4",
 										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"utils.sendGetRequest(\"/perms/users?query=userId==\" + globals.testData.user.id, (err, res) => {",
-											"    // If user already has permissions and delete them to create fresh each time",
-											"    if (res.code === 200 && res.json().totalRecords > 0) {",
-											"        utils.sendDeleteRequest(\"/perms/users/\" + res.json().permissionUsers[0].id, (err, res) => {",
-											"            pm.test(globals.testData.user.username + \" user's permissions deleted\", () => {",
-											"                pm.expect(res.code).to.eql(204);",
-											"            });",
-											"        });",
-											"    }",
-											"});",
-											"",
-											"pm.variables.set(\"orgsUserPermissions\", JSON.stringify(globals.testData.permissions));"
+											"pm.variables.set(\"userPermissions\", JSON.stringify(globals.testData.users.regular.permissions));"
 										],
 										"type": "text/javascript"
 									}
@@ -2138,19 +2275,14 @@
 										"value": "application/json"
 									},
 									{
-										"key": "x-okapi-tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{{orgsUserPermissions}}"
+									"raw": "{{userPermissions}}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
@@ -2194,7 +2326,7 @@
 									"script": {
 										"id": "a59f5097-d5cb-4e46-8bf6-3bddff268e65",
 										"exec": [
-											"pm.variables.set(\"modInvoiceUserCreds\", JSON.stringify(globals.testData.credentials));"
+											"pm.variables.set(\"newUserCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
 										],
 										"type": "text/javascript"
 									}
@@ -2205,7 +2337,7 @@
 								"header": [
 									{
 										"key": "x-okapi-tenant",
-										"value": "{{xokapitenant}}"
+										"value": "{{testTenant}}"
 									},
 									{
 										"key": "Content-Type",
@@ -2214,7 +2346,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{{modInvoiceUserCreds}}"
+									"raw": "{{newUserCreds}}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
@@ -2292,10 +2424,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"value": "application/json"
@@ -2439,10 +2567,6 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -2512,10 +2636,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -2566,14 +2686,6 @@
 							"request": {
 								"method": "DELETE",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -2690,10 +2802,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"name": "Content-Type",
@@ -2845,14 +2953,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -2905,14 +3005,6 @@
 									"request": {
 										"method": "DELETE",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -2980,14 +3072,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -3063,10 +3147,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -3146,14 +3226,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -3297,14 +3369,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -3357,14 +3421,6 @@
 									"request": {
 										"method": "DELETE",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -3448,10 +3504,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -3525,14 +3577,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -3603,14 +3647,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -3750,14 +3786,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -4012,10 +4040,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -4024,18 +4048,6 @@
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -4115,10 +4127,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -4127,24 +4135,6 @@
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -4220,10 +4210,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -4232,24 +4218,6 @@
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -4317,14 +4285,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -4381,10 +4341,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -4393,24 +4349,6 @@
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -4481,14 +4419,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -4545,10 +4475,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -4557,24 +4483,6 @@
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -4636,14 +4544,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -4777,10 +4677,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -4899,10 +4795,6 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -4911,24 +4803,6 @@
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
 									}
 								],
 								"body": {
@@ -5013,10 +4887,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -5086,10 +4956,6 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -5098,24 +4964,6 @@
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
 									}
 								],
 								"body": {
@@ -5171,36 +5019,8 @@
 								"method": "DELETE",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
 									}
 								],
 								"body": {
@@ -5287,10 +5107,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"name": "Content-Type",
@@ -5382,10 +5198,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -5463,10 +5275,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -5475,24 +5283,6 @@
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -5549,14 +5339,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -5620,14 +5402,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -5681,36 +5455,8 @@
 										"method": "DELETE",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -5770,36 +5516,8 @@
 										"method": "DELETE",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -5944,10 +5662,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -6027,10 +5741,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -6132,10 +5842,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -6216,10 +5922,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -6315,10 +6017,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -6427,10 +6125,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -6439,12 +6133,6 @@
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "",
-										"type": "text",
-										"value": "",
-										"disabled": true
 									}
 								],
 								"body": {
@@ -6526,10 +6214,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -6609,10 +6293,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -6694,10 +6374,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -6777,10 +6453,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -6862,10 +6534,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -6945,10 +6613,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -7032,10 +6696,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -7115,10 +6775,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -7200,10 +6856,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -7289,10 +6941,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -7377,10 +7025,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -7461,10 +7105,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -7929,10 +7569,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -8193,10 +7829,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -8250,17 +7882,7 @@
 											"});\r",
 											"\r",
 											"//3.  Verify po number generation process\r",
-											"let endpoint = utils.buildOkapiUrl(\"/orders/po-number\");\r",
-											"\r",
-											"const getPoNumberRequest = {\r",
-											"  url: endpoint,\r",
-											"  method: \"GET\",\r",
-											"  header: [\"X-Okapi-Tenant:\" + pm.environment.get(\"xokapitenant\"),\r",
-											"  \"Content-Type:application/json\",\r",
-											"  \"X-Okapi-Token:\" + pm.environment.get(\"xokapitoken\")],\r",
-											"};\r",
-											"\r",
-											"pm.sendRequest(getPoNumberRequest, function (err, res) {\r",
+											"utils.sendGetRequest(\"/orders/po-number\", function (err, res) {\r",
 											"    pm.test(\"Second response status code is 200\", function () {\r",
 											"        pm.response.to.have.status(200);\r",
 											"        console.log(\"Second request po number : \" + res.json().poNumber);\r",
@@ -8289,14 +7911,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -8358,14 +7972,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -8424,14 +8030,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -8533,14 +8131,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -8635,14 +8225,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -8706,6 +8288,7 @@
 											"pm.test(\"Recieved more than 1 Purchase Order with metadata.createdDate\", function () {",
 											"    let numOfOrdersWithMetadata = 0;",
 											"    for(var i = 0; i < purchaseOrders.length; i++) {",
+											"        pm.expect(purchaseOrders[i]).to.have.property(\"metadata\");",
 											"        if (purchaseOrders[i].hasOwnProperty('metadata') && purchaseOrders[i].metadata.hasOwnProperty('createdDate')) {",
 											"            numOfOrdersWithMetadata++;",
 											"        }",
@@ -8724,12 +8307,7 @@
 											"        pm.expect(new Date(purchaseOrders[i].metadata.createdDate)).to.least(new Date(pm.variables.get(\"minDate\")));",
 											"        pm.expect(new Date(purchaseOrders[i].metadata.createdDate)).to.most(new Date(pm.variables.get(\"maxDate\")));",
 											"    }});",
-											"});",
-											"",
-											"",
-											"",
-											"",
-											""
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -8739,20 +8317,12 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?limit=30&query=workflowStatus==Open AND orderFormat==Electronic Resource AND metadata.createdDate>{{minDate}} AND metadata.createdDate<{{maxDate}}    sortBy metadata.createdDate/sort.ascending",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders?limit=30&query=workflowStatus==Open AND orderFormat==Electronic Resource AND metadata.createdDate>{{minDate}} AND metadata.createdDate<{{maxDate}} sortBy metadata.createdDate/sort.ascending",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -8769,7 +8339,7 @@
 										},
 										{
 											"key": "query",
-											"value": "workflowStatus==Open AND orderFormat==Electronic Resource AND metadata.createdDate>{{minDate}} AND metadata.createdDate<{{maxDate}}    sortBy metadata.createdDate/sort.ascending"
+											"value": "workflowStatus==Open AND orderFormat==Electronic Resource AND metadata.createdDate>{{minDate}} AND metadata.createdDate<{{maxDate}} sortBy metadata.createdDate/sort.ascending"
 										}
 									]
 								},
@@ -8817,14 +8387,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -8846,7 +8408,7 @@
 							"response": []
 						},
 						{
-							"name": "Get list of lines with Pending payment status",
+							"name": "Get list of lines with \"Awaiting Payment\" status",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -8863,15 +8425,11 @@
 									"script": {
 										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
 										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"",
 											"pm.test(\"Validate that response contains orders with proper payment status\", function () {",
-											"    var jsonData = pm.response.json();",
-											"    for(var i = 0; i < jsonData.poLines.length; i++) {",
-											"    \tpm.expect(jsonData.poLines[i].paymentStatus).to.equal(\"Pending\");",
-											"    }",
+											"    pm.response.to.have.status(200);",
+											"    let poLines = pm.response.json().poLines;",
+											"    pm.expect(poLines).to.have.lengthOf.at.least(5);",
+											"    poLines.forEach(pol => pm.expect(pol.paymentStatus).to.equal(\"Awaiting Payment\"));",
 											"});"
 										],
 										"type": "text/javascript"
@@ -8882,20 +8440,12 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?limit=30&query=paymentStatus==Pending",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-lines?limit=10&query=paymentStatus==Awaiting Payment",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -8908,11 +8458,11 @@
 									"query": [
 										{
 											"key": "limit",
-											"value": "30"
+											"value": "10"
 										},
 										{
 											"key": "query",
-											"value": "paymentStatus==Pending"
+											"value": "paymentStatus==Awaiting Payment"
 										}
 									]
 								},
@@ -8987,14 +8537,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -9049,8 +8591,6 @@
 											"let utils = eval(globals.loadUtils);",
 											"var moment = require('moment')",
 											"",
-											"pm.globals.set(\"minDate\", moment().format('YYYY-MM-01'));",
-											"pm.globals.set(\"maxDate\", moment().format('YYYY-MM-28'));",
 											"pm.test(\"PurchaseOrder response status code is 200\", function() {",
 											"    pm.response.to.have.status(200);",
 											"});",
@@ -9075,15 +8615,13 @@
 											"    let date = new Date('1900-01-01T01:01:01.000+0000');",
 											"    let poLines = pm.response.json().poLines;",
 											"    for (var i = 0; i < poLines.length; i++) {",
-											"        pm.test(\"Check if polines sorted by order metadata.createdDate field\", function() {",
-											"            if (poLines[i].hasOwnProperty('metadata')) {",
-											"                pm.expect(new Date(poLines[i].metadata.createdDate)).to.least(date);",
-											"                //check polines date range",
-											"                pm.expect(new Date(poLines[i].metadata.createdDate)).to.least(new Date(pm.variables.get(\"minDate\")));",
-											"                pm.expect(new Date(poLines[i].metadata.createdDate)).to.most(new Date(pm.variables.get(\"maxDate\")));",
-											"                date = new Date(poLines[i].metadata.createdDate);",
-											"            }",
-											"        });",
+											"        pm.expect(poLines[i]).to.have.property(\"metadata\");",
+											"        pm.expect(new Date(poLines[i].metadata.createdDate)).to.least(date);",
+											"        //check polines date range",
+											"        pm.expect(new Date(poLines[i].metadata.createdDate)).to.least(new Date(pm.variables.get(\"minDate\")));",
+											"        pm.expect(new Date(poLines[i].metadata.createdDate)).to.most(new Date(pm.variables.get(\"maxDate\")));",
+											"        date = new Date(poLines[i].metadata.createdDate);",
+											"",
 											"        utils.sendGetRequest(\"/orders/composite-orders?limit=30&query=physical.createInventory==Instance, Holding, Item AND id==\" + poLines[i].purchaseOrderId, (err, res) => {",
 											"            pm.test(\"Validate that POs with sorting criteria exist\", function() {",
 											"                pm.expect(res).to.have.status(200);",
@@ -9100,14 +8638,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -9183,12 +8713,10 @@
 											"    let date = new Date('9999-12-12T00:00:00.000+0000');",
 											"    let poLines = pm.response.json().poLines;",
 											"    for (var i = 0; i < poLines.length; i++) {",
-											"        pm.test(\"Check if polines sorted by order metadata.createdDate field\", function() {",
-											"            if (poLines[i].hasOwnProperty('metadata')) {",
-											"                pm.expect(new Date(poLines[i].metadata.createdDate)).to.most(date);",
-											"                date = new Date(poLines[i].metadata.createdDate);",
-											"            }",
-											"        });",
+											"        pm.expect(poLines[i]).to.have.property(\"metadata\");",
+											"        pm.expect(new Date(poLines[i].metadata.createdDate)).to.most(date);",
+											"        date = new Date(poLines[i].metadata.createdDate);",
+											"",
 											"        utils.sendGetRequest(\"/orders/composite-orders?limit=30&query=workflowStatus==Open AND id==\" + poLines[i].purchaseOrderId, (err, res) => {",
 											"            pm.test(\"PoLines with sorting criteria exist\", function() {",
 											"                pm.expect(res).to.have.status(200);",
@@ -9205,14 +8733,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -9330,10 +8850,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -9409,10 +8925,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -9476,10 +8988,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -9536,10 +9044,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -9548,24 +9052,6 @@
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "X-Okapi-Url",
-												"type": "text",
-												"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "text/plain",
-												"disabled": true
-											},
-											{
-												"key": "Accept",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
 											}
 										],
 										"body": {
@@ -9613,9 +9099,9 @@
 													"    pm.response.to.have.status(200);",
 													"});",
 													"",
-													"var jsonData = {};",
-													"jsonData = pm.response.json();",
 													"pm.test(\"Pieces contains all expected fields\", function(){",
+													"    var jsonData = pm.response.json();",
+													"    pm.expect(jsonData.pieces).to.have.lengthOf(7);",
 													"    jsonData.pieces.forEach(piece => utils.validatePiece(piece));",
 													"});",
 													"",
@@ -9629,20 +9115,12 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
-												"value": "{{xokapitoken-admin}}"
+												"value": "{{xokapitoken-testAdmin}}"
 											}
 										],
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/pieces?query=poLineId=={{poLineIdPEMix}} or poLineId=={{poLine2IdPEMix}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/pieces?query=poLineId==({{poLineIdPEMix}} or {{poLine2IdPEMix}})",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -9655,7 +9133,7 @@
 											"query": [
 												{
 													"key": "query",
-													"value": "poLineId=={{poLineIdPEMix}} or poLineId=={{poLine2IdPEMix}}"
+													"value": "poLineId==({{poLineIdPEMix}} or {{poLine2IdPEMix}})"
 												}
 											]
 										},
@@ -9715,14 +9193,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -9799,10 +9269,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"name": "Content-Type",
@@ -9883,10 +9349,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"name": "Content-Type",
@@ -9991,10 +9453,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -10007,7 +9465,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"vendor\": \"{{activeVendorId}}\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"{{identifierTypeId}}\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"f34d27c6-a8eb-461b-acd6-5dea81771e70\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialTypeId}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": \"API\",\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
+											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"vendor\": \"{{activeVendorId}}\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"{{identifierTypeId}}\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\",\n                    \"percentage\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n                    \"percentage\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"{{locationId1}}\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"{{locationId2}}\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialTypeId}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": \"API\",\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -10068,10 +9526,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -10136,14 +9590,6 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
 											}
@@ -10203,10 +9649,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -10264,6 +9706,7 @@
 													"",
 													"pm.test(\"Pieces contains all expected fields\", function(){",
 													"    let jsonData = pm.response.json();",
+													"    pm.expect(jsonData.pieces).to.have.lengthOf(3);",
 													"    jsonData.pieces.forEach(piece => {",
 													"        utils.validatePiece(piece);",
 													"        pm.expect(piece.format).to.equal(\"Physical\");",
@@ -10279,16 +9722,8 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
-												"value": "{{xokapitoken-admin}}"
+												"value": "{{xokapitoken-testAdmin}}"
 											}
 										],
 										"url": {
@@ -10358,14 +9793,6 @@
 									"request": {
 										"method": "GET",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
 											{
 												"key": "x-okapi-token",
 												"value": "{{xokapitoken}}"
@@ -10443,10 +9870,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"name": "Content-Type",
 												"type": "text",
@@ -10503,6 +9926,7 @@
 													"",
 													"pm.test(\"Pieces contains all expected fields\", function(){",
 													"    let jsonData = pm.response.json();",
+													"    pm.expect(jsonData.pieces).to.have.lengthOf(3);",
 													"    jsonData.pieces.forEach(piece => {",
 													"        utils.validatePiece(piece);",
 													"        pm.expect(piece.format).to.equal(\"Physical\");",
@@ -10519,16 +9943,8 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
 												"key": "x-okapi-token",
-												"value": "{{xokapitoken-admin}}"
+												"value": "{{xokapitoken-testAdmin}}"
 											}
 										],
 										"url": {
@@ -10648,14 +10064,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -10716,14 +10124,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -10760,7 +10160,7 @@
 							"name": "Test createInventory defaults",
 							"item": [
 								{
-									"name": "Create order with createInventory system value from config(createInventory config removed)",
+									"name": "Create order with createInventory system value from config (createInventory config removed)",
 									"event": [
 										{
 											"listen": "prerequest",
@@ -10768,14 +10168,8 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"let originalConfigs = pm.environment.get(\"mod-orders-configs\") ? JSON.parse(pm.environment.get(\"mod-orders-configs\")) : [];",
 													"",
 													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/print_monograph_for_create_inventory_test.json\", (err, res) => {",
-													"    let originalConfig = utils.getConfigByName(originalConfigs, \"createInventory\");",
-													"    if (originalConfig) {",
-													"        console.log(originalConfig);",
-													"        utils.deleteConfig(originalConfig.id);",
-													"    }",
 													"    let order = res.json();",
 													"    order.workflowStatus = \"Open\";",
 													"    order.poNumber = \"CR34TE1NV5\";",
@@ -10817,10 +10211,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -10910,10 +10300,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -10986,7 +10372,7 @@
 											{
 												"key": "x-okapi-token",
 												"type": "text",
-												"value": "{{xokapitoken-admin}}"
+												"value": "{{xokapitoken-testAdmin}}"
 											}
 										],
 										"url": {
@@ -11008,6 +10394,186 @@
 											]
 										},
 										"description": "Delete configs to excercise next step. The case when order created with empty configuration"
+									},
+									"response": []
+								},
+								{
+									"name": "Instance Type - zzz",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+												"exec": [
+													"pm.test(\"Record is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.response.to.be.withBody;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"id\": \"30fffe0e-e985-4144-b2e2-1e8179bdb41f\",\r\n  \"code\": \"zzz\",\r\n  \"name\": \"unspecified\",\r\n  \"source\": \"apiTests\"\r\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"instance-types"
+											]
+										},
+										"description": "Gets or creates if not yet exists test instance type to be used accross the orders while interaction with inventory"
+									},
+									"response": []
+								},
+								{
+									"name": "Instance Status - temp",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+												"exec": [
+													"pm.test(\"Record is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.response.to.be.withBody;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"id\": \"daf2681c-25af-4202-a3fa-e58fdf806183\",\r\n  \"code\": \"temp\",\r\n  \"name\": \"Temporary\",\r\n  \"source\": \"folio\"\r\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-statuses",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"instance-statuses"
+											]
+										},
+										"description": "Gets or creates if not yet exists test instance status to be used accross the orders while interaction with inventory"
+									},
+									"response": []
+								},
+								{
+									"name": "Loan Type - Can circulate",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+												"exec": [
+													"pm.test(\"Record is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.response.to.be.withBody;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"id\":\"2b94c631-fca9-4892-a730-03ee529ffe27\",\r\n  \"name\":\"Can circulate\"\r\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/loan-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"loan-types"
+											]
+										},
+										"description": "Gets or creates if not yet exists test loan type to be used accross the orders while interaction with inventory"
 									},
 									"response": []
 								},
@@ -11063,10 +10629,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -11177,10 +10739,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -11261,10 +10819,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"value": "application/json"
@@ -11347,10 +10901,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -11432,10 +10982,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -11515,7 +11061,7 @@
 									{
 										"key": "x-okapi-token",
 										"type": "text",
-										"value": "{{xokapitoken-admin}}"
+										"value": "{{xokapitoken-testAdmin}}"
 									}
 								],
 								"url": {
@@ -11603,11 +11149,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json",
 										"type": "text"
@@ -11692,11 +11233,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json",
 										"type": "text"
@@ -11780,11 +11316,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"type": "text",
@@ -11877,11 +11408,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json",
 										"type": "text"
@@ -11966,11 +11492,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}",
-										"type": "text"
-									},
 									{
 										"key": "Content-Type",
 										"value": "application/json",
@@ -12126,10 +11647,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -12215,10 +11732,6 @@
 							"request": {
 								"method": "PUT",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -12342,10 +11855,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -12439,10 +11948,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -12528,10 +12033,6 @@
 							"request": {
 								"method": "PUT",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -12641,10 +12142,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -12709,10 +12206,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -12772,14 +12265,6 @@
 							"request": {
 								"method": "DELETE",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -12869,10 +12354,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -12952,10 +12433,6 @@
 							"request": {
 								"method": "PUT",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -13311,10 +12788,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -13397,10 +12870,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -13477,10 +12946,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -13561,10 +13026,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -13647,10 +13108,6 @@
 									"request": {
 										"method": "POST",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -13740,10 +13197,6 @@
 										"method": "POST",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -13830,10 +13283,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -13918,10 +13367,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -14000,10 +13445,6 @@
 									"request": {
 										"method": "PUT",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -14086,10 +13527,6 @@
 									"request": {
 										"method": "PUT",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -14174,10 +13611,6 @@
 									"request": {
 										"method": "PUT",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -14268,10 +13701,6 @@
 									"request": {
 										"method": "PUT",
 										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
 											{
 												"key": "Content-Type",
 												"value": "application/json"
@@ -14440,7 +13869,7 @@
 											{
 												"key": "x-okapi-token",
 												"type": "text",
-												"value": "{{xokapitoken-admin}}"
+												"value": "{{xokapitoken-testAdmin}}"
 											}
 										],
 										"url": {
@@ -14461,6 +13890,81 @@
 												}
 											]
 										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Open order - missingInstanceType error",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let order = utils.buildOrderWithMinContent();",
+													"order.workflowStatus = \"Open\";",
+													"order.notes = [\"Open Order for missingInstanceType error test\"];",
+													"",
+													"let line = utils.buildPoLineWithMinContent(null);",
+													"line.physical.createInventory = \"Instance\";",
+													"order.compositePoLines = [line];",
+													"pm.variables.set(\"orderBody\", JSON.stringify(order));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 500 and one error\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    error = pm.response.json().errors[0];",
+													"    pm.expect(error.code).to.equal(\"missingInstanceType\");",
+													"    pm.expect(error.parameters[0].value).to.equal(\"missing-type\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{testTenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{orderBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"composite-orders"
+											]
+										},
+										"description": "Create an order with minimal required fields (update based on [MODORDERS-136](https://issues.folio.org/browse/MODORDERS-136) and [MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145)."
 									},
 									"response": []
 								},
@@ -14599,7 +14103,7 @@
 											{
 												"key": "x-okapi-token",
 												"type": "text",
-												"value": "{{xokapitoken-admin}}"
+												"value": "{{xokapitoken-testAdmin}}"
 											}
 										],
 										"url": {
@@ -14620,6 +14124,81 @@
 												}
 											]
 										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Open order - missingInstanceStatus error",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let order = utils.buildOrderWithMinContent();",
+													"order.workflowStatus = \"Open\";",
+													"order.notes = [\"Open Order for missingInstanceStatus error test\"];",
+													"",
+													"let line = utils.buildPoLineWithMinContent(null);",
+													"line.physical.createInventory = \"Instance\";",
+													"order.compositePoLines = [line];",
+													"pm.variables.set(\"orderBody\", JSON.stringify(order));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 500 and one error\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    error = pm.response.json().errors[0];",
+													"    pm.expect(error.code).to.equal(\"missingInstanceStatus\");",
+													"    pm.expect(error.parameters[0].value).to.equal(\"missing-status\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{testTenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{orderBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"composite-orders"
+											]
+										},
+										"description": "Create an order with minimal required fields (update based on [MODORDERS-136](https://issues.folio.org/browse/MODORDERS-136) and [MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145)."
 									},
 									"response": []
 								},
@@ -14753,7 +14332,7 @@
 											{
 												"key": "x-okapi-token",
 												"type": "text",
-												"value": "{{xokapitoken-admin}}"
+												"value": "{{xokapitoken-testAdmin}}"
 											}
 										],
 										"url": {
@@ -14778,6 +14357,95 @@
 									"response": []
 								},
 								{
+									"name": "Create Open order - missingLoanType error",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/print_monograph_for_create_inventory_test.json\", (err, res) => {",
+													"    let order  = res.json();",
+													"    order.workflowStatus = \"Open\";",
+													"    order.poNumber = \"loanType1\";",
+													"    ",
+													"    //set createInventory value",
+													"    order.compositePoLines[0].id = JSON.parse(globals.poLineForNegativeTests).id;",
+													"    order.compositePoLines[0].eresource.createInventory = \"Instance, Holding, Item\";",
+													"    order.compositePoLines[0].physical.createInventory = \"Instance, Holding, Item\";",
+													"    order.compositePoLines[0].title = \"Test title\";",
+													"    order.compositePoLines[0].details.productIds[0].productType = \"Vendor Title Number\";",
+													"    ",
+													"    pm.variables.set(\"orderBody\", JSON.stringify(utils.prepareOrder(order)));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 500 and one error\", function () {",
+													"    pm.response.to.have.status(500);",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    error = pm.response.json().errors[0];",
+													"    pm.expect(error.code).to.equal(\"missingLoanType\");",
+													"    pm.expect(error.parameters[0].value).to.equal(\"missing-type\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											},
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{testTenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{orderBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"composite-orders"
+											]
+										},
+										"description": "Create an order with minimal required fields (update based on [MODORDERS-136](https://issues.folio.org/browse/MODORDERS-136) and [MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145)."
+									},
+									"response": []
+								},
+								{
 									"name": "Update pending order to open with missingLoanType error",
 									"event": [
 										{
@@ -14790,7 +14458,7 @@
 													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/print_monograph_for_create_inventory_test.json\", (err, res) => {",
 													"    let order  = res.json();",
 													"    order.workflowStatus = \"Open\";",
-													"    order.poNumber = \"loanType\";",
+													"    order.poNumber = \"loanType2\";",
 													"    ",
 													"    //set createInventory value",
 													"    order.compositePoLines[0].id = JSON.parse(globals.poLineForNegativeTests).id;",
@@ -14923,10 +14591,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -15003,10 +14667,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -15082,10 +14742,6 @@
 										"method": "PUT",
 										"header": [
 											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
 												"key": "Content-Type",
 												"value": "application/json"
 											},
@@ -15148,14 +14804,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -15221,10 +14869,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -15287,10 +14931,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"value": "application/json"
@@ -15597,16 +15237,13 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "eyJhbGciOiJIUzUxMiJ999999.eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiJlZjY3NmRiOS1kMjMxLTQ3OWEtYWE5MS1mNjVlYjRiMTc4NzIiLCJ0ZW5hbnQiOiJmczAwMDAwMDAwIn2.KC0RbgafcMmR5Mc3-I7a6SQPKeDSr0SkJlLMcqQz3nwI0lwPTlxw0wJgidxDq-qjCR0wurFRn5ugd9_SVadSxg"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{testTenant}}",
+										"type": "text"
 									}
 								],
 								"url": {
@@ -15656,14 +15293,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -15719,14 +15348,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -16582,14 +16203,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -16650,14 +16263,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -16712,14 +16317,6 @@
 							"request": {
 								"method": "DELETE",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -16779,14 +16376,6 @@
 							"request": {
 								"method": "GET",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
 									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
@@ -17038,14 +16627,6 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
 									}
@@ -17226,10 +16807,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"value": "application/json"
@@ -17428,10 +17005,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -17493,10 +17066,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -17542,15 +17111,7 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.sendRequest({",
-											"    url: utils.buildOkapiUrl(\"/orders/receiving-history?limit=10&query=receivingStatus==Received and purchaseOrderId=\" + globals.physElecOpenOrderId),",
-											"        method: \"GET\",",
-											"        header: {",
-											"            \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-											"            \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\")",
-											"        }",
-											"},",
-											"function (err, res) {",
+											"utils.sendGetRequest(\"/orders/receiving-history?limit=10&query=receivingStatus==Received and purchaseOrderId=\" + globals.physElecOpenOrderId, (err, res) => {",
 											"    let receivingRq = utils.prepareReceivingRequest(res.json().receivingHistory);",
 											"    pm.variables.set(\"receivingRqBody\", JSON.stringify(receivingRq));",
 											"});",
@@ -17596,12 +17157,7 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
-										"name": "Content-Type",
 										"type": "text",
 										"value": "application/json"
 									},
@@ -17688,11 +17244,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"type": "text",
 										"value": "application/json"
@@ -17757,10 +17308,6 @@
 							"request": {
 								"method": "PUT",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"name": "Content-Type",
@@ -17841,10 +17388,6 @@
 								"method": "PUT",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -17924,36 +17467,8 @@
 								"method": "DELETE",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
 										"key": "x-okapi-token",
 										"value": "{{xokapitoken}}"
-									},
-									{
-										"key": "X-Okapi-Url",
-										"type": "text",
-										"value": "http://internal-fse-lb-pvt-1993629965.us-east-1.elb.amazonaws.com:9130",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "text/plain",
-										"disabled": true
-									},
-									{
-										"key": "Accept",
-										"type": "text",
-										"value": "application/json",
-										"disabled": true
 									}
 								],
 								"body": {
@@ -18027,10 +17542,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -18056,87 +17567,6 @@
 									]
 								},
 								"description": "Create a piece with empty body"
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Create order for new tenant",
-					"item": [
-						{
-							"name": "Create Open order for new tenant, missingInstanceType error",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"let order = utils.buildOrderWithMinContent();",
-											"order.workflowStatus = \"Open\";",
-											"order.notes = [\"Open Order for Negative API Tests\"];",
-											"",
-											"let line = utils.buildPoLineWithMinContent(null);",
-											"line.physical.createInventory = \"Instance\";",
-											"delete line.purchaseOrderId;",
-											"order.compositePoLines = [line];",
-											"order.vendor = pm.globals.get(\"testTenantActiveVendorId\");",
-											"pm.variables.set(\"orderBody\", JSON.stringify(order));"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"pm.test(\"Status code is 500 and one error\", function () {",
-											"    pm.response.to.have.status(500);",
-											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-tenant",
-										"value": "{{testTenant}}"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{orderBody}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders"
-									]
-								},
-								"description": "Create an order with minimal required fields (update based on [MODORDERS-136](https://issues.folio.org/browse/MODORDERS-136) and [MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145)."
 							},
 							"response": []
 						}
@@ -18197,10 +17627,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"name": "Content-Type",
 										"type": "text",
@@ -18256,14 +17682,14 @@
 											"",
 											"    ",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/order_without_po_lines.json\", (err, res) => {",
-											"    let order = res.json();",
+											"    let order = utils.prepareOrder(res.json());",
 											"    order.poNumber = \"TSTAPPROVAL\";",
 											"    order.approved = false;",
 											"    order.workflowStatus = \"Open\";",
 											"    ",
 											"    order.id = \"00000001-1111-5555-8888-888888888888\";",
-											"        pm.globals.set(\"orderWithApprovalReqTrueId\", order.id); ",
 											"",
+											"    pm.globals.set(\"orderWithApprovalReqTrueId\", order.id); ",
 											"    pm.variables.set(\"orderWithApprovalReqTrue\", JSON.stringify(order));",
 											"});"
 										],
@@ -18294,10 +17720,6 @@
 							"request": {
 								"method": "POST",
 								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
 									{
 										"key": "Content-Type",
 										"value": "application/json"
@@ -18351,11 +17773,11 @@
 										"exec": [
 											"let utils = eval(globals.loadUtils);",
 											"",
-											"utils.sendDeleteRequest(\"/perms/users/\"+ globals.testData.user.id + \"/permissions/orders.item.approve?indexField=userId\", (err, res) => {",
+											"utils.sendDeleteRequest(\"/perms/users/\"+ globals.testData.users.regular.user.id + \"/permissions/orders.item.approve?indexField=userId\", (err, res) => {",
 											"    pm.expect(res.code).to.eql(204);",
 											"});",
 											"",
-											"pm.variables.set(\"modInvoiceUserCreds\", JSON.stringify(globals.testData.credentials));"
+											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
 										],
 										"type": "text/javascript"
 									}
@@ -18366,7 +17788,7 @@
 								"header": [
 									{
 										"key": "x-okapi-tenant",
-										"value": "{{xokapitenant}}"
+										"value": "{{testTenant}}"
 									},
 									{
 										"key": "Content-Type",
@@ -18375,7 +17797,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{{modInvoiceUserCreds}}"
+									"raw": "{{userCreds}}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
@@ -18436,10 +17858,6 @@
 								"method": "POST",
 								"header": [
 									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
 										"key": "Content-Type",
 										"value": "application/json"
 									},
@@ -18477,2745 +17895,25 @@
 			"name": "Cleanup",
 			"item": [
 				{
-					"name": "Delete orders for positive tests",
-					"item": [
-						{
-							"name": "Delete orders of createInventory testing",
-							"item": [
-								{
-									"name": "Delete order with createInventory NONE",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.orderWithCreateInventoryNoneId, true);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});",
-													"",
-													"let utils = eval(globals.loadUtils);",
-													"utils.verifyAllPieceRecordsDeleted();"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithCreateInventoryNoneId}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{orderWithCreateInventoryNoneId}}"
-											]
-										},
-										"description": "DELETE /orders/composite-orders/id requests that return 204"
-									},
-									"response": []
-								},
-								{
-									"name": "Delete order with createInventory INSTANCE",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"utils.deleteOrderRelatedRecords(globals.orderWithCreateInventoryInstanceId, true);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});",
-													"",
-													"",
-													"let utils = eval(globals.loadUtils);",
-													"utils.verifyAllPieceRecordsDeleted();"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithCreateInventoryInstanceId}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{orderWithCreateInventoryInstanceId}}"
-											]
-										},
-										"description": "DELETE /orders/composite-orders/id requests that return 204"
-									},
-									"response": []
-								},
-								{
-									"name": "Delete order with createInventory INSTANCE_HOLDING",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"utils.deleteOrderRelatedRecords(globals.orderWithCreateInventoryInstanceHoldingId, true);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});",
-													"",
-													"let utils = eval(globals.loadUtils);",
-													"utils.verifyAllPieceRecordsDeleted();"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithCreateInventoryInstanceHoldingId}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{orderWithCreateInventoryInstanceHoldingId}}"
-											]
-										},
-										"description": "DELETE /orders/composite-orders/id requests that return 204"
-									},
-									"response": []
-								},
-								{
-									"name": "Delete order with createInventory INSTANCE_HOLDING_ITEM",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"utils.deleteOrderRelatedRecords(globals.orderWithCreateInventoryInstanceHoldingItemId, true);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithCreateInventoryInstanceHoldingItemId}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{orderWithCreateInventoryInstanceHoldingItemId}}"
-											]
-										},
-										"description": "DELETE /orders/composite-orders/id requests that return 204"
-									},
-									"response": []
-								},
-								{
-									"name": "Delete order with createInventory system default",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"utils.deleteOrderRelatedRecords(globals.orderWithCreateInventoryNullId1, false);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});",
-													"",
-													"let utils = eval(globals.loadUtils);",
-													"utils.verifyAllPieceRecordsDeleted();"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithCreateInventoryNullId1}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{orderWithCreateInventoryNullId1}}"
-											]
-										},
-										"description": "DELETE /orders/composite-orders/id requests that return 204"
-									},
-									"response": []
-								},
-								{
-									"name": "Delete order with createInventory config default",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"utils.deleteOrderRelatedRecords(globals.orderWithCreateInventoryNullId2, false);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});",
-													"",
-													"let utils = eval(globals.loadUtils);",
-													"utils.verifyAllPieceRecordsDeleted();"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithCreateInventoryNullId2}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{orderWithCreateInventoryNullId2}}"
-											]
-										},
-										"description": "DELETE /orders/composite-orders/id requests that return 204"
-									},
-									"response": []
-								},
-								{
-									"name": "Delete order with createInventory and empty config",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"utils.deleteOrderRelatedRecords(globals.orderWithCreateInventoryNullId3, false);"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-												"exec": [
-													"pm.test(\"Status code is 204\", function () {",
-													"    pm.response.to.have.status(204);",
-													"});",
-													"",
-													"let utils = eval(globals.loadUtils);",
-													"utils.verifyAllPieceRecordsDeleted();"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "X-Okapi-Tenant",
-												"value": "{{xokapitenant}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithCreateInventoryNullId3}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"orders",
-												"composite-orders",
-												"{{orderWithCreateInventoryNullId3}}"
-											]
-										},
-										"description": "DELETE /orders/composite-orders/id requests that return 204"
-									},
-									"response": []
-								}
-							],
-							"_postman_isSubFolder": true
-						},
-						{
-							"name": "Delete Pending order",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{completeOrderId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Pending to Open order",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"// The po_listed_print_monograph.json was used to create this order and one more Open order. Some instances will not be deleted now but with deletion of the next order",
-											"utils.deleteOrderRelatedRecords(globals.anotherCompleteOrderId, false);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{anotherCompleteOrderId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{anotherCompleteOrderId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Open order for receiving history test",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"utils.deleteOrderRelatedRecords(globals.receivingHistoryPoId, false);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{receivingHistoryPoId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{receivingHistoryPoId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Open order with P/E Mix and Electronic lines",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"// The instances should be deleted at this point for all orders created based on po_listed_print_monograph.json",
-											"utils.deleteOrderRelatedRecords(globals.completeOpenOrderId, true);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOpenOrderId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{completeOpenOrderId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Open order with physical and electronic lines",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"utils.deleteOrderRelatedRecords(globals.physElecOpenOrderId, true);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{physElecOpenOrderId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{physElecOpenOrderId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete order with Receipt Not Required",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.orderWithReceiptNotRequiredId, true);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithReceiptNotRequiredId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{orderWithReceiptNotRequiredId}}"
-									]
-								},
-								"description": "DELETE /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete order with checkinItems = true",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.poToCheckinItemsId, true);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{poToCheckinItemsId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{poToCheckinItemsId}}"
-									]
-								},
-								"description": "DELETE /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Pieces PE Mix - Delete Open order P/E Mix",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"// Delete created inventory records",
-											"let utils = eval(globals.loadUtils);",
-											"utils.deleteOrderRelatedRecords(globals.orderIdPEMix, false);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();",
-											"// Clean-Up",
-											"pm.globals.unset(\"poLineIdPEMix\");",
-											"pm.globals.unset(\"poLine2IdPEMix\");",
-											"pm.globals.unset(\"orderIdPEMix\");",
-											"pm.globals.unset(\"requestBodyToBeUpdated\");",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderIdPEMix}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{orderIdPEMix}}"
-									]
-								},
-								"description": "DELETE /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Pieces Phy - Delete Open order Physical",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"// Delete created inventory records",
-											"let utils = eval(globals.loadUtils);",
-											"utils.deleteOrderRelatedRecords(globals.randomUUId, false);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();",
-											"// Clean-Up",
-											"pm.globals.unset(\"randomUUId\");",
-											"pm.globals.unset(\"poLineIdPhysical\");",
-											"pm.globals.unset(\"requestBodyPhysical\");"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{randomUUId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{randomUUId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete pending order automatically changes workflowStatus from Open to Close",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"// The po_listed_print_monograph.json was used to create this order and one more Open order. Some instances will not be deleted now but with deletion of the next order",
-											"utils.deleteOrderRelatedRecords(globals.automaticallyClosedOrder, false);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{automaticallyClosedOrder}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{automaticallyClosedOrder}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete open order automatically changes workflowStatus from Open to Close",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"",
-											"utils.deleteOrderRelatedRecords(globals.automaticallyClosedOpenOrder, false);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{automaticallyClosedOpenOrder}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{automaticallyClosedOpenOrder}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete automatically from Open to Close opene order",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{automaticallyOpenedOrder}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{automaticallyOpenedOrder}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete order all polines checkin",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"eval(globals.loadUtils).deleteOrderRelatedRecords(globals.poAllPoLineCheckin, true);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Status code is 204\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();",
-											"",
-											"// Clean-Up",
-											"pm.globals.unset(\"checkin_electronic_poLine\");",
-											"pm.globals.unset(\"checkin_physical_poLine\");",
-											"pm.globals.unset(\"poAllPoLineCheckin\");"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{poAllPoLineCheckin}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{poAllPoLineCheckin}}"
-									]
-								},
-								"description": "DELETE /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Delete orders for negative tests",
-					"item": [
-						{
-							"name": "Delete Un Approved Order",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "638ecd6c-ee91-4b54-a37d-487714653b72",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"utils.deleteOrderRelatedRecords(globals.orderWithApprovalReqTrueId, true);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "ccbbd9a9-875f-4851-a9af-2df76cfc098e",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{orderWithApprovalReqTrueId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{orderWithApprovalReqTrueId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Open order",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsOpenOrderId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{negativeTestsOpenOrderId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Closed order",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsClosedOrderId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{negativeTestsClosedOrderId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Pending order Copy",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "638ecd6c-ee91-4b54-a37d-487714653b72",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "ccbbd9a9-875f-4851-a9af-2df76cfc098e",
-										"exec": [
-											"pm.test(\"Order has been successfully deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});",
-											"",
-											"let utils = eval(globals.loadUtils);",
-											"utils.verifyAllPieceRecordsDeleted();"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "X-Okapi-Tenant",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{negativeTestsPendingOrderId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"orders",
-										"composite-orders",
-										"{{negativeTestsPendingOrderId}}"
-									]
-								},
-								"description": "GET /orders/composite-orders/id requests that return 204"
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Delete user with mod-orders permissions only",
-					"item": [
-						{
-							"name": "Delete user's credentials",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "d4e68cd5-eca2-4427-ba8b-6f059a5fc130",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"utils.sendGetRequest(\"/authn/credentials?query=userId=\" + globals.testData.user.id, (err, res) => {",
-											"    // If user already has credentials and delete them to create fresh each time",
-											"    if (res.code === 200 && res.json().totalRecords > 0) {",
-											"        pm.variables.set(\"credentialsId\", res.json().credentials[0].id);",
-											"    }",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "1ff89363-4db6-40bc-a848-e7532b2a7bc0",
-										"exec": [
-											"let testFunc = pm.variables.get(\"credentialsId\") ? pm.test : pm.test.skip;",
-											"testFunc(\"Credentials deleted - Expected No Content (204)\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials/{{credentialsId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"authn",
-										"credentials",
-										"{{credentialsId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete user's permissions",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "234a882a-edd7-4bac-8bc2-7f89c8a7a713",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"utils.sendGetRequest(\"/perms/users?query=userId==\" + globals.testData.user.id, (err, res) => {",
-											"    // If user already has permissions and delete them to create fresh each time",
-											"    if (res.code === 200 && res.json().totalRecords > 0) {",
-											"        pm.variables.set(\"permissionsId\", res.json().permissionUsers[0].id);",
-											"    }",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "f74eb5c8-1652-480c-9fac-356b3a3ffc56",
-										"exec": [
-											"let testFunc = pm.variables.get(\"permissionsId\") ? pm.test : pm.test.skip;",
-											"testFunc(\"Permissions deleted - Expected No Content (204)\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users/{{permissionsId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"perms",
-										"users",
-										"{{permissionsId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete user",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "123459a0-b737-4767-a32c-1c5692b8d920",
-										"exec": [
-											"pm.variables.set(\"userId\", pm.globals.get(\"testData\").user.id);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "ac493f0c-3e8c-4c07-94d2-6105617f0384",
-										"exec": [
-											"pm.test(\"User deleted - Expected No Content (204)\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-Okapi-Tenant",
-										"type": "text",
-										"value": "{{xokapitenant}}"
-									},
-									{
-										"key": "X-Okapi-Token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/users/{{userId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"users",
-										"{{userId}}"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"description": "The authorithation token from `xokapitoken-admin` environment variable is set to `xokapitoken` one to allow remaining requests to work.",
+					"name": "Purge and disable all module for created tenant",
 					"event": [
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "51550a77-35a8-45ab-bf74-f093a8202d42",
-								"type": "text/javascript",
-								"exec": [
-									"pm.environment.set(\"xokapitoken\", pm.environment.get(\"xokapitoken-admin\"));"
-								]
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "0decf5ff-c87f-4041-a8cd-ef1a9f2003bd",
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Revert configs",
-					"item": [
-						{
-							"name": "Get configs and revert",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let currentConfigs;",
-											"pm.test(\"Storing current configs\", function() {",
-											"    pm.response.to.be.ok;",
-											"",
-											"    currentConfigs = pm.response.json().configs;",
-											"    console.log(\"Current configs: \", currentConfigs);",
-											"});",
-											"",
-											"let configsToProcess = globals.testData.configs.configNames;",
-											"",
-											"let originalConfigs = pm.environment.get(\"mod-orders-configs\") ? JSON.parse(pm.environment.get(\"mod-orders-configs\")) : [];",
-											"for (var i = 0; i < configsToProcess.length; i++) {",
-											"    let configName = configsToProcess[i];",
-											"    let originalConfig = utils.getConfigByName(originalConfigs, configName);",
-											"",
-											"    if (originalConfig) {",
-											"        originalConfig.id = utils.getConfigByName(currentConfigs, configName).id;",
-											"        utils.updateConfig(originalConfig);",
-											"    } else if (currentConfigs.length > 0) {",
-											"        let configId = utils.getConfigByName(currentConfigs, configName).id;",
-											"        utils.deleteConfig(configId);",
-											"    } else {",
-											"        console.log(\"The config cannot be reverted. Config name =\" + configName);",
-											"    }",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=module==ORDERS",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"configurations",
-										"entries"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "module==ORDERS"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Get TENANT configs and revert",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "4bae1c04-6f38-4b77-bdea-a918b637e5bd",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let currentConfigs;",
-											"pm.test(\"Storing current tenant configs\", function() {",
-											"    pm.response.to.be.ok;",
-											"",
-											"    currentConfigs = pm.response.json().configs;",
-											"    console.log(\"Current configs: \", currentConfigs);",
-											"});",
-											"",
-											"let configsToProcess = globals.testData.tenantConfig.configNames;",
-											"",
-											"let originalConfigs = pm.environment.get(\"mod-tenant-configs\") ? JSON.parse(pm.environment.get(\"mod-tenant-configs\")) : [];",
-											"for (var i = 0; i < configsToProcess.length; i++) {",
-											"    let configName = configsToProcess[i];",
-											"    // Get configs existed before API tests by name",
-											"    let originalFilteredConfigs = utils.getConfigsByName(originalConfigs, configName);",
-											"    let currentFilteredConfigs = utils.getConfigsByName(currentConfigs, configName);",
-											"    if (originalFilteredConfigs.length > 0) {",
-											"        currentConfigs.forEach(currentConf => {",
-											"            let originalConfig = originalFilteredConfigs.find(conf => currentConf.id === conf.id);",
-											"            if (originalConfig) {",
-											"                utils.updateConfig(originalConfig);",
-											"            } else {",
-											"                utils.deleteConfig(currentConf.id);",
-											"            }",
-											"        });",
-											"    } else {",
-											"        currentFilteredConfigs.forEach(conf => utils.deleteConfig(conf.id));",
-											"    }",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "39c6d609-c5de-49cf-aa6c-7cc022346e87",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/configurations/entries?query=module==TENANT",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"configurations",
-										"entries"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "module==TENANT"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Inventory types",
-					"item": [
-						{
-							"name": "Verify and delete inventory records",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "444f69e9-e0af-4666-aa84-bb56caad1141",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"let instances = [];",
-											"",
-											"pm.test(\"Get instances response is ok\", function () {",
-											"    pm.response.to.be.ok;",
-											"    instances = pm.response.json().instances;",
-											"});",
-											"",
-											"for (let i = 0; i < instances.length; i++) {",
-											"    utils.deleteInventoryRecordsByInstanceId(instances[i].id);",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-storage/instances?query=identifiers == \"*\\\"identifierTypeId\\\": \\\"{{identifierTypeId}}\\\"*\"",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"instance-storage",
-										"instances"
-									],
-									"query": [
-										{
-											"key": "query",
-											"value": "identifiers == \"*\\\"identifierTypeId\\\": \\\"{{identifierTypeId}}\\\"*\""
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete identifier type",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Identifier type deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/identifier-types/{{identifierTypeId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"identifier-types",
-										"{{identifierTypeId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete instance type",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Instance type deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-types/{{instanceTypeId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"instance-types",
-										"{{instanceTypeId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete instance status",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Instance status deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/instance-statuses/{{instanceStatusId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"instance-statuses",
-										"{{instanceStatusId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete loan type",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Loan type deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/loan-types/{{loanTypeId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"loan-types",
-										"{{loanTypeId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete material type",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Material type deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/material-types/{{materialTypeId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"material-types",
-										"{{materialTypeId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete contributor name type",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Contributor name type deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/contributor-name-types/{{contributorNameTypeId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"contributor-name-types",
-										"{{contributorNameTypeId}}"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Cleanup test tenant",
-					"item": [
-						{
-							"name": "Purge and disable all module for created tenant",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
-										"exec": [
-											"let modulesToDisable = pm.globals.get(\"enabledModules\");",
-											"console.log(modulesToDisable);",
-											"for (let i=0; i < modulesToDisable.length; i++) {",
-											"    console.log(modulesToDisable[i]);",
-											"    modulesToDisable[i].action = \"disable\";",
-											"}",
-											"console.log(modulesToDisable);",
-											"pm.variables.set(\"modulesToDisable\", JSON.stringify(modulesToDisable));"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.test(\"Disable all modules for test tenant\", function () {",
-											"    pm.response.to.have.status(200);",
-											"    pm.response.to.be.withBody;",
-											"});",
-											"",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-Okapi-Token",
-										"value": "{{xokapitoken}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{modulesToDisable}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install?purge=true",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"proxy",
-										"tenants",
-										"{{testTenant}}",
-										"install"
-									],
-									"query": [
-										{
-											"key": "purge",
-											"value": "true"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete test tenant",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
-										"exec": [
-											"pm.test(\"Tenant deleted - Expected Created (204)\", () => {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"_",
-										"proxy",
-										"tenants",
-										"{{testTenant}}"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Finance data",
-					"item": [
-						{
-							"name": "Delete fund",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Test fund deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds/{{fundId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"finance-storage",
-										"funds",
-										"{{fundId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete ledger",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Test ledger deleted\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers/{{ledgerId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"finance-storage",
-										"ledgers",
-										"{{ledgerId}}"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Delete location",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-								"exec": [
-									"pm.test(\"Location has been successfully deleted\", function () {",
-									"    pm.response.to.have.status(204);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "X-Okapi-Tenant",
-								"value": "{{xokapitenant}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/locations/{{newLocationId}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"locations",
-								"{{newLocationId}}"
-							]
-						},
-						"description": "GET /orders/composite-orders/id requests that return 204"
-					},
-					"response": []
-				},
-				{
-					"name": "Delete and verify test vendors deletion",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
 								"exec": [
 									"let utils = eval(globals.loadUtils);",
+									"pm.sendRequest(utils.buildOkapiUrl(\"/_/proxy/tenants/\" + pm.variables.get(\"testTenant\") + \"/modules\"), (err, res) => {",
+									"    pm.test(\"Preparing request to disable modules\", () => {",
+									"        pm.expect(err).to.equal(null);",
+									"        pm.expect(res.code).to.equal(200);",
+									"        let modulesToDisable = res.json();",
+									"        modulesToDisable.forEach(entry => entry.action = \"disable\");",
 									"",
-									"sendDeleteVendorRequest = function(vendorId) {",
-									"    utils.sendDeleteRequest(\"/organizations-storage/organizations/\" + vendorId, function (err, res) {",
-									"        if (err) {",
-									"            console.log(err);",
-									"        }",
-									"        pm.test('Piece successfully deleted from storage', function () {",
-									"            pm.expect(res).to.have.property('code', 204);",
-									"        });",
+									"        console.log(modulesToDisable);",
+									"        pm.variables.set(\"modulesToDisable\", JSON.stringify(modulesToDisable));",
 									"    });",
-									"};",
-									"",
-									"// Deletion test vendors",
-									"sendDeleteVendorRequest(pm.variables.get(\"activeVendorId\"));",
-									"sendDeleteVendorRequest(pm.variables.get(\"inactiveVendorId\"));"
+									"});"
 								],
 								"type": "text/javascript"
 							}
@@ -21223,55 +17921,57 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
 								"exec": [
-									"pm.test(\"All vendors are deleted\", function () {",
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"pm.test(\"Disable all modules for test tenant\", function () {",
 									"    pm.response.to.have.status(200);",
-									"    pm.response.to.have.jsonBody(\"totalRecords\", 0);",
-									"});"
+									"    pm.response.to.be.withBody;",
+									"});",
+									"",
+									""
 								],
 								"type": "text/javascript"
 							}
 						}
 					],
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
 					"request": {
-						"method": "GET",
+						"method": "POST",
 						"header": [
 							{
-								"key": "X-Okapi-Tenant",
-								"value": "{{xokapitenant}}"
-							},
-							{
 								"key": "Content-Type",
+								"type": "text",
 								"value": "application/json"
 							},
 							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
+								"key": "X-Okapi-Token",
+								"value": "{{xokapitoken-admin}}",
+								"type": "text"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": ""
+							"raw": "{{modulesToDisable}}"
 						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/organizations-storage/organizations?query=id=={{activeVendorId}} or id=={{inactiveVendorId}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install?purge=true",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
 							],
 							"port": "{{okapiport}}",
 							"path": [
-								"organizations-storage",
-								"organizations"
+								"_",
+								"proxy",
+								"tenants",
+								"{{testTenant}}",
+								"install"
 							],
 							"query": [
 								{
-									"key": "query",
-									"value": "id=={{activeVendorId}} or id=={{inactiveVendorId}}"
+									"key": "purge",
+									"value": "true"
 								}
 							]
 						}
@@ -21279,80 +17979,12 @@
 					"response": []
 				},
 				{
-					"name": "Verify no lines left in storage",
+					"name": "Delete test tenant",
 					"event": [
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-								"exec": [
-									"let utils = eval(globals.loadUtils);",
-									"let lineId = utils.getLastPoLineId();",
-									"if (lineId) {",
-									"    pm.variables.set(\"complete_poLineId\", lineId);",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-								"exec": [
-									"pm.test(\"Verify that no lines found\", function () {",
-									"    pm.expect(pm.response.json().totalRecords).to.equal(0);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "X-Okapi-Tenant",
-								"value": "{{xokapitenant}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
-							}
-						],
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/po-lines?query=purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{orderWithReceiptNotRequiredId}} or purchaseOrderId=={{receivingHistoryPoId}} or purchaseOrderId=={{negativeTestsPendingOrderId}} or purchaseOrderId=={{negativeTestsOpenOrderId}} or purchaseOrderId=={{negativeTestsClosedOrderId}}",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"orders-storage",
-								"po-lines"
-							],
-							"query": [
-								{
-									"key": "query",
-									"value": "purchaseOrderId=={{completeOrderId}} or purchaseOrderId=={{anotherCompleteOrderId}} or purchaseOrderId=={{completeOpenOrderId}} or purchaseOrderId=={{physElecOpenOrderId}} or purchaseOrderId=={{orderWithReceiptNotRequiredId}} or purchaseOrderId=={{receivingHistoryPoId}} or purchaseOrderId=={{negativeTestsPendingOrderId}} or purchaseOrderId=={{negativeTestsOpenOrderId}} or purchaseOrderId=={{negativeTestsClosedOrderId}}"
-								}
-							]
-						},
-						"description": "GET /orders/id requests that return 200"
-					},
-					"response": []
-				},
-				{
-					"name": "Verify that orders deleted in storage",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
 								"exec": [
 									""
 								],
@@ -21362,10 +17994,10 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
 								"exec": [
-									"pm.test(\"Verify that no orders found\", function () {",
-									"    pm.expect(pm.response.json().totalRecords).to.equal(0);",
+									"pm.test(\"Tenant deleted - Expected Created (204)\", () => {",
+									"    pm.response.to.have.status(204);",
 									"});",
 									"",
 									"// Remove all created variables",
@@ -21376,40 +18008,32 @@
 						}
 					],
 					"request": {
-						"method": "GET",
+						"method": "DELETE",
 						"header": [
 							{
-								"key": "X-Okapi-Tenant",
-								"value": "{{xokapitenant}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
 								"key": "x-okapi-token",
-								"value": "{{xokapitoken}}"
+								"value": "{{xokapitoken-admin}}",
+								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders-storage/purchase-orders?query=id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or id=={{physElecOpenOrderId}} or id=={{orderWithReceiptNotRequiredId}} or id=={{receivingHistoryPoId}} or id=={{negativeTestsPendingOrderId}} or id=={{negativeTestsOpenOrderId}} or id=={{negativeTestsClosedOrderId}} or id=={{automaticallyClosedOrder}} or id=={{automaticallyClosedOpenOrder}} or id=={{automaticallyOpenedOrder}}",
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{url}}"
 							],
 							"port": "{{okapiport}}",
 							"path": [
-								"orders-storage",
-								"purchase-orders"
-							],
-							"query": [
-								{
-									"key": "query",
-									"value": "id=={{completeOrderId}} or id=={{anotherCompleteOrderId}} or id=={{completeOpenOrderId}} or id=={{physElecOpenOrderId}} or id=={{orderWithReceiptNotRequiredId}} or id=={{receivingHistoryPoId}} or id=={{negativeTestsPendingOrderId}} or id=={{negativeTestsOpenOrderId}} or id=={{negativeTestsClosedOrderId}} or id=={{automaticallyClosedOrder}} or id=={{automaticallyClosedOpenOrder}} or id=={{automaticallyOpenedOrder}}"
-								}
+								"_",
+								"proxy",
+								"tenants",
+								"{{testTenant}}"
 							]
-						},
-						"description": "GET /orders-storage/purchaseOrders returns a 404 after delete"
+						}
 					},
 					"response": []
 				}
@@ -21426,7 +18050,13 @@
 					"const testData = {",
 					"    // mod-configuration",
 					"    configs: {",
-					"        configNames: [\"poLines-limit\", \"inventory-instanceTypeCode\", \"inventory-instanceStatusCode\", \"inventory-loanTypeName\", \"approvals\"],",
+					"        configNames: [",
+					"            \"poLines-limit\",",
+					"            \"inventory-instanceTypeCode\",",
+					"            \"inventory-instanceStatusCode\",",
+					"            \"inventory-loanTypeName\",",
+					"            \"approvals\"",
+					"        ],",
 					"        bodyTemplate: {",
 					"            \"module\": \"ORDERS\",",
 					"            \"configName\": \"Test Config\",",
@@ -21435,120 +18065,6 @@
 					"            \"enabled\": true,",
 					"            \"value\": \"\"",
 					"        }",
-					"    },",
-					"    // User template with hardcoded id",
-					"    user: {",
-					"        \"id\": \"00000001-1111-5555-9999-999999999999\",",
-					"        \"username\": \"mod-orders-user\",",
-					"        \"active\": true,",
-					"        \"personal\": {",
-					"            \"firstName\": \"Orders API\",",
-					"            \"lastName\": \"Orders Tests\"",
-					"        }",
-					"    },",
-					"    credentials: {",
-					"        \"username\": \"mod-orders-user\",",
-					"        \"password\": \"mod-orders-user-password\"",
-					"    },",
-					"    permissions: {",
-					"        \"userId\": \"00000001-1111-5555-9999-999999999999\",",
-					"        \"permissions\": [",
-					"            \"orders.all\",",
-					"            \"orders.item.approve\",",
-					"            \"inventory-storage.items.collection.get\",",
-					"            \"inventory-storage.items.item.get\",",
-					"            \"orders-storage.pieces.collection.get\"",
-					"        ]",
-					"    },",
-					"    limited_user: {",
-					"        \"id\": \"00000001-1111-5555-8888-888888888888\",",
-					"        \"username\": \"mod-orders-user\",",
-					"        \"active\": true,",
-					"        \"personal\": {",
-					"            \"firstName\": \"Orders API Limited\",",
-					"            \"lastName\": \"Orders Tests Limited\"",
-					"        }",
-					"    },",
-					"    limited_credentials: {",
-					"        \"username\": \"mod-orders-user-limited\",",
-					"        \"password\": \"mod-orders-user-password\"",
-					"    },",
-					"    limited_permissions: {",
-					"        \"userId\": \"00000001-1111-5555-9999-999999999999\",",
-					"        \"permissions\": [",
-					"            \"orders.all\",",
-					"            \"inventory-storage.items.collection.get\",",
-					"            \"inventory-storage.items.item.get\",",
-					"            \"orders-storage.pieces.collection.get\"",
-					"        ]",
-					"    },",
-					"    receiving: {",
-					"        bodyTemplate: {",
-					"            \"toBeReceived\": [{",
-					"                \"poLineId\": \"\",",
-					"                \"received\": 1,",
-					"                \"receivedItems\": [{",
-					"                    \"barcode\": \"11111111111\",",
-					"                    \"comment\": \"Very important note\",",
-					"                    \"caption\": \"Vol. 1\",",
-					"                    \"itemStatus\": \"Received\",",
-					"                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",",
-					"                    \"pieceId\": \"\"",
-					"                }]",
-					"            }],",
-					"            \"totalRecords\": 1",
-					"        }",
-					"    },",
-					"    piece: {",
-					"        bodyTemplate: {",
-					"                 \"caption\": \"Volume\",",
-					"                 \"comment\": \"creating Piece from API test\",",
-					"                 \"format\": \"\",",
-					"                 \"locationId\": \"\",",
-					"                 \"poLineId\": \"\",",
-					"                 \"receivingStatus\": \"Expected\",",
-					"                 \"supplement\": true",
-					"            }",
-					"    },",
-					"    checkin: {",
-					"        bodyTemplate: {",
-					"            \"toBeCheckedIn\": [",
-					"              {",
-					"                \"poLineId\": \"\",",
-					"                \"checkedIn\": \"\",",
-					"                \"checkInPieces\": [",
-					"                    {",
-					"                        \"id\": \"\",",
-					"                        \"barcode\": Math.floor(Math.random() * 1000),",
-					"                        \"comment\": \"checkedin from API test\",",
-					"                        \"caption\": \"Vol. 1\",",
-					"                        \"createItem\": true,",
-					"                        \"supplement\": false,",
-					"                        \"locationId\": \"\",",
-					"                        \"accessionNumber\": \"1956.1\",",
-					"                        \"itemDescription\": \"This is the piece item checkin\",",
-					"                        \"electronicBookplate\": \"This item is from API tests\",",
-					"                        \"itemStatus\": \"\"",
-					"                    }]",
-					"              }],",
-					"              \"totalRecords\":1",
-					"        }",
-					"    },",
-					"    item: {",
-					"        bodyTemplate: {",
-					"                 \"holdingsRecordId\": \"\",",
-					"                 \"permanentLoanTypeId\": pm.variables.get(\"loanTypeId\"),",
-					"                 \"materialTypeId\": pm.variables.get(\"materialTypeId\"),",
-					"                 \"status\": {",
-					"                        \"name\": \"On Order\"",
-					"                    },",
-					"                 \"purchaseOrderLineIdentifier\":\"\"",
-					"            }",
-					"    },",
-					"    tenant: {",
-					"        \"id\": \"orders_test_tenant\",",
-					"        \"name\": \"Test orders tenant\",",
-					"        \"description\": \"Tenant for test purpose\"",
 					"    },",
 					"    tenantConfig: {",
 					"        configNames: [\"tenant.addresses\"],",
@@ -21561,7 +18077,123 @@
 					"            \"enabled\": true,",
 					"            \"value\": \"\"",
 					"        }",
-					"    }    ",
+					"    },",
+					"    // User template with hardcoded id",
+					"    users: {",
+					"        admin: {",
+					"            user: {",
+					"                \"id\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"username\": \"admin-user\",",
+					"                \"active\": true,",
+					"                \"personal\": {",
+					"                    \"firstName\": \"Admin\",",
+					"                    \"lastName\": \"Orders API Tests\"",
+					"                }",
+					"            },",
+					"            credentials: {",
+					"                \"username\": \"admin-user\",",
+					"                \"password\": \"admin-user-password\"",
+					"            },",
+					"            permissions: {",
+					"                \"userId\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"permissions\": [ ]",
+					"            }",
+					"        },",
+					"        regular: {",
+					"            user: {",
+					"                \"id\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"username\": \"mod-orders-user\",",
+					"                \"active\": true,",
+					"                \"personal\": {",
+					"                    \"firstName\": \"Regular\",",
+					"                    \"lastName\": \"User\"",
+					"                }",
+					"            },",
+					"            credentials: {",
+					"                \"username\": \"mod-orders-user\",",
+					"                \"password\": \"mod-orders-user-password\"",
+					"            },",
+					"            permissions: {",
+					"                \"userId\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"permissions\": [",
+					"                    \"orders.all\",",
+					"                    \"orders.item.approve\",",
+					"                    \"orders-storage.pieces.collection.get\",",
+					"                    // To be removed when MODINV-120 is resolved",
+					"                    \"inventory-storage.items.collection.get\",",
+					"                    \"inventory-storage.items.item.get\"",
+					"                ]",
+					"            }",
+					"        }",
+					"    },",
+					"    tenant: {",
+					"        \"id\": pm.variables.get(\"testTenant\"),",
+					"        \"name\": \"Test orders tenant\",",
+					"        \"description\": \"Tenant for test purpose\"",
+					"    },",
+					"    receiving: {",
+					"        bodyTemplate: {",
+					"            \"toBeReceived\": [{",
+					"                \"poLineId\": \"\",",
+					"                \"received\": 1,",
+					"                \"receivedItems\": [{",
+					"                    \"barcode\": \"11111111111\",",
+					"                    \"comment\": \"Very important note\",",
+					"                    \"caption\": \"Vol. 1\",",
+					"                    \"itemStatus\": \"Received\",",
+					"                    \"locationId\": pm.variables.get(\"locationId2\"),",
+					"                    \"pieceId\": \"\"",
+					"                }]",
+					"            }],",
+					"            \"totalRecords\": 1",
+					"        }",
+					"    },",
+					"    piece: {",
+					"        bodyTemplate: {",
+					"            \"caption\": \"Volume\",",
+					"            \"comment\": \"creating Piece from API test\",",
+					"            \"format\": \"\",",
+					"            \"locationId\": \"\",",
+					"            \"poLineId\": \"\",",
+					"            \"receivingStatus\": \"Expected\",",
+					"            \"supplement\": true",
+					"        }",
+					"    },",
+					"    checkin: {",
+					"        bodyTemplate: {",
+					"            \"toBeCheckedIn\": [",
+					"                {",
+					"                    \"poLineId\": \"\",",
+					"                    \"checkedIn\": \"\",",
+					"                    \"checkInPieces\": [",
+					"                        {",
+					"                            \"id\": \"\",",
+					"                            \"barcode\": Math.floor(Math.random() * 1000),",
+					"                            \"comment\": \"checkedin from API test\",",
+					"                            \"caption\": \"Vol. 1\",",
+					"                            \"createItem\": true,",
+					"                            \"supplement\": false,",
+					"                            \"locationId\": \"\",",
+					"                            \"accessionNumber\": \"1956.1\",",
+					"                            \"itemDescription\": \"This is the piece item checkin\",",
+					"                            \"electronicBookplate\": \"This item is from API tests\",",
+					"                            \"itemStatus\": \"\"",
+					"                        }]",
+					"                }],",
+					"            \"totalRecords\":1",
+					"        }",
+					"    },",
+					"    item: {",
+					"        bodyTemplate: {",
+					"            \"holdingsRecordId\": \"\",",
+					"            \"permanentLoanTypeId\": pm.variables.get(\"loanTypeId\"),",
+					"            \"materialTypeId\": pm.variables.get(\"materialTypeId\"),",
+					"            \"status\": {",
+					"                \"name\": \"On Order\"",
+					"            },",
+					"            \"purchaseOrderLineIdentifier\":\"\"",
+					"        }",
+					"    }",
 					"",
 					"};",
 					"",
@@ -21611,10 +18243,27 @@
 					"            url: utils.buildOkapiUrl(path),",
 					"            method: method,",
 					"            header: {",
-					"                \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
-					"                \"X-Okapi-Token\": xokapitoken || pm.environment.get(\"xokapitoken-admin\")",
+					"                \"X-Okapi-Tenant\": pm.environment.get(\"testTenant\"),",
+					"                \"X-Okapi-Token\": xokapitoken || pm.environment.get(\"xokapitoken-testAdmin\")",
 					"            }",
 					"        };",
+					"    };",
+					"",
+					"    utils.getModuleId = function(moduleName, bodyHandler) {",
+					"        pm.sendRequest({",
+					"            url: utils.buildOkapiUrl(\"/_/proxy/modules?latest=1&filter=\" + moduleName),",
+					"            method: \"GET\",",
+					"            header: {",
+					"                \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
+					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken-admin\")",
+					"            }",
+					"        }, (err, res) => {",
+					"            pm.test(moduleName + \" module is available\", () => {",
+					"                pm.expect(err).to.equal(null);",
+					"                pm.expect(res.code).to.equal(200);",
+					"                bodyHandler(res.json()[0].id);",
+					"            });",
+					"        });",
 					"    };",
 					"",
 					"    /**",
@@ -21625,8 +18274,8 @@
 					"        delete order.totalItems;",
 					"        order.vendor = pm.environment.get(\"activeVendorId\");",
 					"",
-					"        for (var i = 0; i < order.compositePoLines.length; i++) {",
-					"            utils.preparePoLine(order.compositePoLines[i]);",
+					"        if (order.hasOwnProperty(\"compositePoLines\")) {",
+					"            order.compositePoLines.forEach(line => utils.preparePoLine(line));",
 					"        }",
 					"",
 					"        return order;",
@@ -21660,6 +18309,12 @@
 					"                contributor.contributorNameTypeId = pm.environment.get(\"contributorNameTypeId\");",
 					"            });",
 					"        }",
+					"        if (poLine.hasOwnProperty(\"locations\")) {",
+					"            poLine.locations.forEach((location, index) => {",
+					"                location.locationId = pm.environment.get(\"locationId\" + (index + 1));",
+					"            });",
+					"        }",
+					"",
 					"",
 					"        delete poLine.id;",
 					"        delete poLine.purchaseOrderId;",
@@ -21701,14 +18356,14 @@
 					"            \"source\": \"User\",",
 					"            \"orderFormat\": \"Physical Resource\",",
 					"            \"physical\":{",
-					"\t             \"createInventory\": \"None\"",
-					"\t        },",
-					"\t        \"cost\":{",
-					"\t            \"currency\":\"USD\",",
-					"\t            \"listUnitPrice\": 1,",
-					"\t            \"quantityPhysical\":1",
-					"\t        },",
-					"\t        \"title\": \"Kayak Fishing in the Northern Gulf Coast\"",
+					"                \"createInventory\": \"None\"",
+					"            },",
+					"            \"cost\":{",
+					"                \"currency\":\"USD\",",
+					"                \"listUnitPrice\": 1,",
+					"                \"quantityPhysical\":1",
+					"            },",
+					"            \"title\": \"Kayak Fishing in the Northern Gulf Coast\"",
 					"        };",
 					"    };",
 					"",
@@ -21906,17 +18561,17 @@
 					"     */",
 					"    utils.validateEncumbranceRecords = function(poLine, orderStatus) {",
 					"//MODORDERS-298 Temporarily disable interaction with encumbrance APIs",
-					"/*        let expectedQuantity = orderStatus === \"Pending\" ? 0 : poLine.fundDistribution.length;",
-					"        utils.sendGetRequest(\"/finance-storage/encumbrances?limit=\" + expectedQuantity + \"&query=poLineId==\" + poLine.id, (err, res) => {",
-					"            let testMsg = expectedQuantity > 0 ? expectedQuantity : \"No\";",
-					"            pm.test(testMsg + \" encumbrance record(s) found for PO Line with number=\" + poLine.poLineNumber, function() {",
-					"                pm.expect(res.code).to.eql(200);",
-					"                pm.expect(res.json().totalRecords, \"Number of created encumbrances does not match to expected\").to.eql(expectedQuantity);",
-					"                if (expectedQuantity > 0) {",
-					"                    res.json().encumbrances.forEach(encumbrance => utils.validateEncumbrance(encumbrance, poLine.fundDistribution));",
-					"                }",
-					"            });",
-					"        });*/",
+					"        /*        let expectedQuantity = orderStatus === \"Pending\" ? 0 : poLine.fundDistribution.length;",
+					"                utils.sendGetRequest(\"/finance-storage/encumbrances?limit=\" + expectedQuantity + \"&query=poLineId==\" + poLine.id, (err, res) => {",
+					"                    let testMsg = expectedQuantity > 0 ? expectedQuantity : \"No\";",
+					"                    pm.test(testMsg + \" encumbrance record(s) found for PO Line with number=\" + poLine.poLineNumber, function() {",
+					"                        pm.expect(res.code).to.eql(200);",
+					"                        pm.expect(res.json().totalRecords, \"Number of created encumbrances does not match to expected\").to.eql(expectedQuantity);",
+					"                        if (expectedQuantity > 0) {",
+					"                            res.json().encumbrances.forEach(encumbrance => utils.validateEncumbrance(encumbrance, poLine.fundDistribution));",
+					"                        }",
+					"                    });",
+					"                });*/",
 					"    };",
 					"",
 					"    /**",
@@ -21973,28 +18628,28 @@
 					"            });",
 					"        });",
 					"    };",
-					"    ",
+					"",
 					"    utils.verifyItemsReceivedIntoAppropriateHolding = function(line, receivingResult) {",
-					"     for (i = 0; i < receivingResult.receivingItemResults.length; i++) {",
-					"        utils.sendGetRequest(\"/orders-storage/pieces/\" + receivingResult.receivingItemResults[i].pieceId, (err, piece) => {",
-					"            //check if piece has changed location",
-					"            if (piece.json().locationId === pm.environment.get(\"newLocationId\")) {",
-					"                utils.sendGetRequest(\"/holdings-storage/holdings?limit=1&query=instanceId==\" + line.instanceId + \" and permanentLocationId==\" + piece.json().locationId, (err, holding) => {",
-					"                    pm.test(\"created holding for location \" +  piece.json().locationId , function() {",
-					"                        pm.expect(holding.json().holdingsRecords.length).to.be.above(0);",
-					"                    });",
-					"                    ",
-					"                    if(utils.isItemsUpdateRequired(line)){",
-					"                        utils.sendGetRequest(\"/item-storage/items?limit=1&query=holdingsRecordId==\" + holding.json().holdingsRecords[0].id + \" and id==\" + piece.json().itemId, (err, items) => {",
-					"                            pm.test(\"item \" + items.json().items[0].id + \" received into holding \" + holding.json().holdingsRecords[0].id , function() {",
-					"                                pm.expect(items.json().items.length).to.be.above(0);",
+					"        for (i = 0; i < receivingResult.receivingItemResults.length; i++) {",
+					"            utils.sendGetRequest(\"/orders-storage/pieces/\" + receivingResult.receivingItemResults[i].pieceId, (err, piece) => {",
+					"                //check if piece has changed location",
+					"                if (piece.json().locationId === pm.environment.get(\"locationId1\")) {",
+					"                    utils.sendGetRequest(\"/holdings-storage/holdings?limit=1&query=instanceId==\" + line.instanceId + \" and permanentLocationId==\" + piece.json().locationId, (err, holding) => {",
+					"                        pm.test(\"created holding for location \" +  piece.json().locationId , function() {",
+					"                            pm.expect(holding.json().holdingsRecords.length).to.be.above(0);",
+					"                        });",
+					"",
+					"                        if(utils.isItemsUpdateRequired(line)){",
+					"                            utils.sendGetRequest(\"/item-storage/items?limit=1&query=holdingsRecordId==\" + holding.json().holdingsRecords[0].id + \" and id==\" + piece.json().itemId, (err, items) => {",
+					"                                pm.test(\"item \" + items.json().items[0].id + \" received into holding \" + holding.json().holdingsRecords[0].id , function() {",
+					"                                    pm.expect(items.json().items.length).to.be.above(0);",
+					"                                });",
 					"                            });",
-					"                    });                    ",
-					"                    }",
-					"                });",
-					"            }",
-					"        });",
-					"      }",
+					"                        }",
+					"                    });",
+					"                }",
+					"            });",
+					"        }",
 					"    };",
 					"",
 					"",
@@ -22162,9 +18817,9 @@
 					"                receivedItem.pieceId = pieceIds[i];",
 					"                //set new location ids for the half of the pieces",
 					"                if (i%2 == 0){",
-					"                    receivedItem.locationId = pm.environment.get(\"newLocationId\");    ",
+					"                    receivedItem.locationId = pm.environment.get(\"locationId1\");",
 					"                }",
-					"                ",
+					"",
 					"                if (!isRevertCase) {",
 					"                    // Inventory requires unique barcodes",
 					"                    receivedItem.barcode = ++barcode;",
@@ -22521,7 +19176,7 @@
 					"                }",
 					"            }",
 					"        });",
-					"    }",
+					"    };",
 					"",
 					"    utils.isCompletedAllPoLines = function(poLines) {",
 					"        for (let i = 0; i < poLines.length; i++) {",
@@ -22529,109 +19184,12 @@
 					"            let receiptStatus = poLines[i].receiptStatus;",
 					"            if (!(paymentStatus === \"Payment Not Required\" || paymentStatus === \"Fully Paid\") || !(receiptStatus === \"Fully Received\" || receiptStatus === \"Receipt Not Required\")) {",
 					"                return false;",
-					"            };",
+					"            }",
 					"        }",
 					"        return true;",
-					"    }",
-					"",
-					"    /**",
-					"     * Deletes Instance from Inventory by id linked to PO line",
-					"     */",
-					"    utils.deleteInventoryInstance = function(instanceId) {",
-					"        return utils.processDeleteRequest(\"/instance-storage/instances/\" + instanceId)",
-					"            .then(code => {",
-					"                return new Promise((resolve) => {",
-					"                    resolve(code);",
-					"                    utils.validateResultOfDeleteRequest(code, \"Instance should be successfully deleted. Instance id=\" + instanceId)",
-					"                });",
-					"            });",
 					"    };",
 					"",
-					"    /**",
-					"     * Deletes Holdings from Inventory",
-					"     */",
-					"    utils.deleteHoldingsRecords = function(lineId, holdingsIds) {",
-					"        let promises = [];",
-					"        holdingsIds.forEach(holdingId => {",
-					"            promises.push(",
-					"                utils.searchForItemsByHoldingId(holdingId)",
-					"                    .then(itemsQty => {",
-					"                        if (itemsQty === 0) {",
-					"                            return utils.processDeleteRequest(\"/holdings-storage/holdings/\" + holdingId);",
-					"                        } else {",
-					"                            pm.test(itemsQty + \" item record(s) referenced by holding with id=\" + holdingId + \". The holding deletion is skipped!\", function() {});",
-					"                            return -1;",
-					"                        }",
-					"                    })",
-					"            );",
-					"        });",
-					"",
-					"        return new Promise((resolve) => {",
-					"            Promise.all(promises)",
-					"                .then(results => {",
-					"                    resolve(results);",
-					"",
-					"                    let skippedQty = results.filter(code => code === -1).length;",
-					"                    let deletedQty = results.filter(code => code === 204).length;",
-					"                    pm.test(holdingsIds.length - skippedQty + \" holding(s) without items should be deleted for PO Line with id=\" + lineId, () => {",
-					"                        pm.expect(skippedQty + deletedQty).to.eql(holdingsIds.length);",
-					"                    });",
-					"                });",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Searches for item records in Inventory by holding id.",
-					"     * The function returns Promise which holds quantity of found items",
-					"     */",
-					"    utils.searchForItemsByHoldingId = function(holdingsId) {",
-					"        return new Promise((resolve) => {",
-					"            utils.sendGetRequest(\"/item-storage/items?limit=0&query=holdingsRecordId==\" + holdingsId, (err, response) => {",
-					"                if (response.code !== 200) {",
-					"                    resolve(-1);",
-					"                }",
-					"                pm.expect(response.code, \"Inventory cannot return items\").to.eql(200);",
-					"                resolve(response.json().totalRecords);",
-					"            });",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Searches for item records in Inventory by PO Line id.",
-					"     * The function returns Promise which holds found items.",
-					"     */",
-					"    utils.getItemsByPoLine = function(line) {",
-					"        return new Promise((resolve) => {",
-					"            let expectedCount;",
-					"            //we donot know the checkin count before, so use a default",
-					"            if (line.checkinItems === true) {",
-					"                expectedCount = 100;",
-					"            } else {",
-					"                expectedCount = utils.calculateExpectedItemsQuantity(line);",
-					"            }",
-					"            utils.getItemsByPoLineId(line.id, expectedCount, (err, response) => {",
-					"                pm.test(\"Search for item records by PO Line id=\" + line.id, function() {",
-					"                    if (response.code !== 200) {",
-					"                        resolve([]);",
-					"                    }",
-					"                    pm.expect(response.code, \"Inventory cannot return items\").to.eql(200);",
-					"",
-					"                    resolve(response.json().items);",
-					"",
-					"                    // Test expected items count as the last step to make sure delete requests are sent",
-					"                    // in case of checkin we do not know the item count",
-					"                    if (!line.checkinItems === true) {",
-					"                        let foundItems = response.json().totalRecords;",
-					"                        pm.expect(foundItems, \"Expected items count does not match to found\").to.equal(expectedCount);",
-					"                    }",
-					"                });",
-					"            });",
-					"        });",
-					"    };",
-					"    /**",
-					"     * check-in methods",
-					"     */",
-					"     utils.postRequest = function (path, postBody, handler) {",
+					"    utils.postRequest = function (path, postBody, handler) {",
 					"        let pmRq = utils.buildPmRequest(path, \"POST\");",
 					"        pmRq.body = JSON.stringify(postBody);",
 					"        pmRq.header[\"Content-type\"] = \"application/json\";",
@@ -22639,7 +19197,7 @@
 					"    };",
 					"",
 					"    /**",
-					"     *This method creates a piece and also calls the prepares the check-in body.",
+					"     * This method creates a piece and also calls the prepares the check-in body.",
 					"     * If itemId is not provided the check-in flow just updates the piece record",
 					"     */",
 					"    utils.createPieceAndCheckInBody = function(compPoLine, itemId) {",
@@ -22669,7 +19227,7 @@
 					"    /**",
 					"     * This method is used for both checking in a piece and also reverting it,",
 					"     * If the checkinstatus is not provided by default it is set to check-in item",
-					"     * ",
+					"     *",
 					"     */",
 					"    utils.prepareCheckinBody = function(compPoLine, pieceId, checkinStatus) {",
 					"        let checkinRq = globals.testData.checkin.bodyTemplate;",
@@ -22678,8 +19236,8 @@
 					"        toBeCheckedInTemplate.poLineId = compPoLine.id;",
 					"        toBeCheckedInTemplate.checkedIn = 1;",
 					"        checkinPiecesTemplate.id = pieceId;",
-					"        checkinPiecesTemplate.locationId = pm.environment.get(\"newLocationId\");",
-					"         if (typeof checkinStatus === \"undefined\") {",
+					"        checkinPiecesTemplate.locationId = pm.environment.get(\"locationId1\");",
+					"        if (typeof checkinStatus === \"undefined\") {",
 					"            checkinPiecesTemplate.itemStatus = \"In Process\";",
 					"        } else {",
 					"            checkinPiecesTemplate.itemStatus = checkinStatus;",
@@ -22693,7 +19251,7 @@
 					"    /**",
 					"     * Get the holding where the item needs to be created , create an item",
 					"     * and then use the item id to create a piece",
-					"     * ",
+					"     *",
 					"     */",
 					"    utils.prepareCheckinBodyWithItems = function(compPoLine) {",
 					"        utils.sendGetRequest(\"/holdings-storage/holdings?limit=1&query=instanceId==\" + compPoLine.instanceId + \" and permanentLocationId==\" + compPoLine.locations[0].locationId, (err, res) => {",
@@ -22711,321 +19269,6 @@
 					"        itemTemplate.holdingsRecordId = holdingsRecordId;",
 					"        itemTemplate.purchaseOrderLineIdentifier = poLineId;",
 					"        utils.postRequest(\"/item-storage/items\", itemTemplate, handler);",
-					"    };",
-					"",
-					"    /**",
-					"     * Deletes Item records from Inventory. The function returns Promise which holds holdings ids once completed",
-					"     */",
-					"    utils.deleteInventoryItemRecords = function(line) {",
-					"        return new Promise((resolve) => {",
-					"            // Get",
-					"            utils.getItemsByPoLine(line)",
-					"                .then(items => {",
-					"                    let holdingsIds = [];",
-					"                    if (!utils.isItemsUpdateRequired(line)) {",
-					"                        pm.test(\"No item(s) expected to exist for PO line with id=\" + line.id, () => {",
-					"                            pm.expect(items.length).to.eql(0);",
-					"                        });",
-					"                    }",
-					"",
-					"                    //for checkin there can be a case where the items are not created but holdings are created",
-					"                    if (items.length === 0) {",
-					"                        utils.sendGetRequest(\"/holdings-storage/holdings?limit=100&query=instanceId==\" + line.instanceId, (err, res) => {",
-					"                            let body = res.json();",
-					"                            body.holdingsRecords.forEach(hld => {",
-					"                                holdingsIds.push(hld.id);",
-					"                            });",
-					"                            resolve(holdingsIds);",
-					"                        });",
-					"                        return;",
-					"                    }",
-					"",
-					"",
-					"                    let promises = [];",
-					"                    items.forEach(item => {",
-					"                        // Using array because Set is not working for some reason",
-					"                        if (!holdingsIds.includes(item.holdingsRecordId)) {",
-					"                            holdingsIds.push(item.holdingsRecordId);",
-					"                        }",
-					"                        promises.push(utils.processDeleteRequest(\"/item-storage/items/\" + item.id));",
-					"                    });",
-					"",
-					"                    //to cover a scenario where items do not exist for a holding but it is created while check-in order",
-					"                    promises.push(",
-					"                        new Promise((resolve) => {",
-					"                            utils.sendGetRequest(\"/holdings-storage/holdings?limit=100&query=instanceId==\" + line.instanceId, (err, res) => {",
-					"                                let body = res.json();",
-					"                                body.holdingsRecords.forEach(hld => {",
-					"                                    if (!holdingsIds.includes(hld.id)) {",
-					"                                        holdingsIds.push(hld.id);",
-					"                                    }",
-					"                                });",
-					"                                resolve(res.code);",
-					"                            });",
-					"                        }));",
-					"",
-					"                    // Wait for items to be deleted and then return holdings ids as a result of the promise defined in the top",
-					"                    Promise.all(promises)",
-					"                        // The promisses will be always resolved so not handling reject case",
-					"                        .then(itemDelResults => {",
-					"                            // Returning the holding ids regardless of the result of the item deletion jut to try to delete holdings in any case",
-					"",
-					"                            resolve(holdingsIds);",
-					"",
-					"                            let deletedQty = itemDelResults.filter(code => code === 204).length;",
-					"                            pm.test(items.length + \" item(s) should be deleted for PO Line with id=\" + line.id, () => {",
-					"                                pm.expect(deletedQty).to.eql(items.length);",
-					"                            });",
-					"                        });",
-					"",
-					"                    // Test expected items count as the last step to make sure that delete requests are sent",
-					"                    let foundItems = response.json().totalRecords;",
-					"                    let expectedCount = utils.calculateExpectedItemsQuantity(line);",
-					"                    pm.expect(foundItems, \"Expected items count does not match to found\").to.equal(expectedCount);",
-					"                });",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Deletes Item records from Inventor by holding id",
-					"     */",
-					"    utils.deleteInventoryItemRecordsByHoldingId = function(holdingId) {",
-					"        return new Promise((resolve) => {",
-					"            // Get",
-					"            utils.getItemsByHoldingId(holdingId, (err, res) => {",
-					"                let items = res.json().items;",
-					"                let promises = [];",
-					"                items.forEach(item => {",
-					"                    promises.push(utils.processDeleteRequest(\"/item-storage/items/\" + item.id));",
-					"                });",
-					"",
-					"                Promise.all(promises)",
-					"                    // The promisses will be always resolved so not handling reject case",
-					"                    .then(itemDelResults => {",
-					"                        // Returning the holding ids regardless of the result of the item deletion jut to try to delete holdings in any case",
-					"",
-					"                        resolve(itemDelResults);",
-					"",
-					"                        let deletedQty = itemDelResults.filter(code => code === 204).length;",
-					"                        pm.test(items.length + \" item(s) should be deleted for PO Line with id=\" + line.id, () => {",
-					"                            pm.expect(deletedQty).to.eql(items.length);",
-					"                        });",
-					"                    });",
-					"            })",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Delete pieces related to PoLine in order",
-					"     */",
-					"    utils.deletePieceRecords = function(line) {",
-					"        return new Promise((resolve) => {",
-					"            utils.sendGetRequest(\"/orders-storage/pieces?limit=1000&query=poLineId==\" + line.id, (err, res) => {",
-					"                let promises = [];",
-					"                res.json().pieces.forEach(piece => {",
-					"                    promises.push(utils.processDeleteRequest(\"/orders-storage/pieces/\" + piece.id));",
-					"                });",
-					"                Promise.all(promises)",
-					"                    .then(deletionCodes => {",
-					"                        resolve(deletionCodes);",
-					"                    })",
-					"                    .catch(err => {",
-					"                        console.log(\"Error happened on Piece Records deletion:\", err);",
-					"                        resolve([]);",
-					"                    });",
-					"            });",
-					"        });",
-					"    };",
-					"    ",
-					"    utils.verifyAllPieceRecordsDeleted = function() {",
-					"        let lineIds = pm.globals.get(\"deletedLineIds\") || [];",
-					"        console.log(\"deletedLineIds = \" + lineIds);",
-					"        lineIds.forEach(lineId => {",
-					"            let path = \"/orders-storage/pieces?limit=0&query=poLineId==\" + lineId;",
-					"            utils.sendGetRequest(path, (err, response) => {",
-					"                let pieces = response.json().totalRecords;",
-					"                pm.test(\"No pieces found for poline \" + lineId, ()=> pm.expect(pieces).to.eql(0));",
-					"            });",
-					"        });",
-					"        pm.globals.unset(\"deletedLineIds\");",
-					"    };",
-					"",
-					"    /**",
-					"     * Cascasde Deletes Inventory Records and Pieces created for PO lines",
-					"     * Starting with Delete items-> holdings -> Instances",
-					"     *",
-					"     * Note: The timeout is required when Promise is used. See https://community.getpostman.com/t/using-native-javascript-promises-in-postman/636",
-					"     */",
-					"    utils.deleteOrderRelatedRecords = function(orderId, verifyRecordsDeletion) {",
-					"        utils.sendGetRequest(\"/orders/composite-orders/\" + orderId, (err, res) => {",
-					"            let order = res.json();",
-					"            if (typeof order.id === \"undefined\") {",
-					"                pm.test(\"Inventory records might be not fully cleaned up. Order cannot be found by id=\" + orderId, () => pm.expect(order.id).to.exist);",
-					"                return;",
-					"            }",
-					"",
-					"            const timerId = setTimeout(() => {}, 60000);",
-					"            let deletedLineIds = [];",
-					"",
-					"            let promises = [];",
-					"            order.compositePoLines.forEach(line => {",
-					"                deletedLineIds.push(line.id);",
-					"                promises.push(utils.deleteEncumbranceRecords(line));",
-					"                // The function returns Promise",
-					"                promises.push(",
-					"                    utils.deleteInventoryItemRecords(line)",
-					"                    .then(holdingsIds => {",
-					"                        return holdingsIds.length > 0 ? utils.deleteHoldingsRecords(line.id, holdingsIds) : [];",
-					"                    })",
-					"                    .then(holdingsDelResult => {",
-					"                        // delete instance if there is an instance id and there is no holdings linked to any item",
-					"                        if (line.instanceId) {",
-					"                            // skip if no instance was created",
-					"                            if (utils.inventoryUpdateNotRequired(line)) {",
-					"                                return -1;",
-					"                            }",
-					"                            // see utils.deleteHoldingsRecords()",
-					"                            let holdingsQty = holdingsDelResult.filter(code => code === -1).length;",
-					"                            if (holdingsQty === 0) {",
-					"                                return utils.deleteInventoryInstance(line.instanceId);",
-					"                            } else {",
-					"                                pm.test(holdingsQty + \" holdings record(s) referenced by instance id=\" + line.instanceId + \". The instance deletion is skipped!\", () => {});",
-					"                            }",
-					"                        }",
-					"                        return -1;",
-					"                    })",
-					"                );",
-					"            });",
-					"",
-					"            Promise.all(promises)",
-					"                .then(success => {",
-					"                    pm.globals.set(\"deletedLineIds\", deletedLineIds);",
-					"",
-					"                    return verifyRecordsDeletion ? utils.verifyInventoryRecordsDeleted(order) : success;",
-					"                })",
-					"                .then(result => clearTimeout(timerId))",
-					"                .catch(err => {",
-					"                    console.log(\"Error happened on Inventory Records deletion:\", err);",
-					"                    clearTimeout(timerId);",
-					"                });",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Cascasde Deletes Inventory Records by instanceId",
-					"     * Starting with Delete items-> holdings -> Instances",
-					"     *",
-					"     * Note: The timeout is required when Promise is used. See https://community.getpostman.com/t/using-native-javascript-promises-in-postman/636",
-					"     */",
-					"    utils.deleteInventoryRecordsByInstanceId = function(instanceId) {",
-					"        utils.sendGetRequest(\"/holdings-storage/holdings?query=instanceId==\" + instanceId, (err, res) => {",
-					"            let holdings = res.json().holdingsRecords;",
-					"",
-					"            const timerId = setTimeout(() => {}, 60000);",
-					"",
-					"            let promises = [];",
-					"            holdings.forEach(holding => {",
-					"                let holdingId = holding.id;",
-					"                // The function returns Promise",
-					"                promises.push(",
-					"                    utils.deleteInventoryItemRecordsByHoldingId(holdingId)",
-					"                    .then(itemsDelResult => {",
-					"                        return utils.processDeleteRequest(\"/holdings-storage/holdings/\" + holdingId);",
-					"                    })",
-					"",
-					"                );",
-					"            });",
-					"",
-					"            Promise.all(promises)",
-					"                .then(success => {",
-					"                    return utils.deleteInventoryInstance(instanceId);",
-					"                })",
-					"                .then(result => clearTimeout(timerId))",
-					"                .catch(err => {",
-					"                    console.log(\"Error happened on Inventory Records deletion:\", err);",
-					"                    clearTimeout(timerId);",
-					"                });",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Verifies if instance, holding(s) and item(s) have been removed for the PO Line",
-					"     */",
-					"    utils.verifyInventoryRecordsDeleted = function(order) {",
-					"        let promises = [];",
-					"        order.compositePoLines.forEach(line => {",
-					"            promises.push(utils.verifyInventoryInstanceDeleted(line));",
-					"            promises.push(utils.verifyInventoryHoldingsDeleted(line));",
-					"            promises.push(utils.verifyInventoryItemsDeleted(line));",
-					"        });",
-					"        return Promise.all(promises);",
-					"    };",
-					"",
-					"    /**",
-					"     * Verifies if instance associated with the PO Line has been deleted",
-					"     */",
-					"    utils.verifyInventoryInstanceDeleted = function(line) {",
-					"        return new Promise((resolve) => {",
-					"            if (line.instanceId) {",
-					"                utils.sendGetRequest(\"/instance-storage/instances/\" + line.instanceId, (err, res) => {",
-					"                    resolve();",
-					"                    pm.test(\"No Instance Record found for PO Line with id=\" + line.id + \" and instance id=\" + line.instanceId, function() {",
-					"                        pm.expect(res.code).to.eql(404);",
-					"                    });",
-					"                });",
-					"            } else {",
-					"                resolve();",
-					"            }",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Verifies if holdings associated with the PO Line have been deleted",
-					"     */",
-					"    utils.verifyInventoryItemsDeleted = function(line) {",
-					"        return new Promise((resolve) => utils.verifyNoInventoryItemsExist(line, resolve));",
-					"    };",
-					"",
-					"    /**",
-					"     * Verifies if holdings associated with the PO Line have been deleted",
-					"     */",
-					"    utils.verifyInventoryHoldingsDeleted = function(line) {",
-					"        return new Promise((resolve) => {",
-					"            if (line.instanceId) {",
-					"                utils.sendGetRequest(\"/holdings-storage/holdings?limit=0&query=instanceId==\" + line.instanceId, (err, res) => {",
-					"                    resolve();",
-					"                    pm.test(\"No Holding Records found for PO Line with id=\" + line.id, function() {",
-					"                        pm.expect(res.code).to.eql(200);",
-					"                        pm.expect(res.json().totalRecords).to.eql(0);",
-					"                    });",
-					"                });",
-					"            } else {",
-					"                resolve();",
-					"            }",
-					"        });",
-					"    };",
-					"",
-					"    /**",
-					"     * Delete encumbrances related to PoLine in order",
-					"     */",
-					"    utils.deleteEncumbranceRecords = function(line) {",
-					"        //MODORDERS-298 disable encumbrances interaction",
-					"/*        return new Promise((resolve) => {",
-					"            utils.sendGetRequest(\"/finance-storage/encumbrances?limit=1000&query=poLineId==\" + line.id, (err, res) => {",
-					"                let promises = [];",
-					"                res.json().encumbrances.forEach(encumbrance => {",
-					"                    promises.push(utils.processDeleteRequest(\"/finance-storage/encumbrances/\" + encumbrance.id));",
-					"                });",
-					"                Promise.all(promises)",
-					"                    .then(deletionCodes => {",
-					"                        resolve(deletionCodes);",
-					"                    })",
-					"                    .catch(err => {",
-					"                        console.log(\"Error happened on encumbrance records deletion:\", err);",
-					"                        resolve([]);",
-					"                    });",
-					"            });",
-					"        });*/",
 					"    };",
 					"",
 					"    /**",
@@ -23154,24 +19397,37 @@
 					"            .filter(variable => variable.key.startsWith(utils.schemaPrefix))",
 					"            .forEach(schemaVar => pm.environment.unset(schemaVar.key));",
 					"",
+					"        pm.globals.unset(\"emptyOrderWithoutPoLinesId\");",
 					"        pm.globals.unset(\"testData\");",
 					"        pm.globals.unset(\"loadUtils\");",
 					"        pm.globals.unset(\"emptyOrderId\");",
+					"        pm.globals.unset(\"isbnOrderId\");",
+					"        pm.globals.unset(\"isbn_Order_content\");",
 					"        pm.globals.unset(\"po_listed_print_monograph\");",
 					"        pm.globals.unset(\"completePolineIds\");",
 					"        pm.globals.unset(\"completeOrderId\");",
+					"        pm.globals.unset(\"completeOrderPoNumber\");",
 					"        pm.globals.unset(\"physElecOpenOrderId\");",
 					"        pm.globals.unset(\"negativeTestsPendingOrderId\");",
 					"        pm.globals.unset(\"negativeTestsOpenOrderId\");",
 					"        pm.globals.unset(\"negativeTestsClosedOrderId\");",
 					"        pm.globals.unset(\"negativeTestsFailedEncumbrances\");",
+					"        pm.globals.unset(\"negativeTestsOpenPOLineId\");",
 					"        pm.globals.unset(\"anotherCompleteOrderId\");",
 					"        pm.globals.unset(\"completeOpenOrderId\");",
+					"        pm.globals.unset(\"checkin_physical_poLine\");",
+					"        pm.globals.unset(\"checkin_electronic_poLine\");",
 					"        pm.globals.unset(\"poLineForNegativeTests\");",
-					"        pm.globals.unset(\"completeOrderPoNumber\");",
-					"        pm.globals.unset(\"orderWithReceiptNotRequiredId\");",
+					"        pm.globals.unset(\"randomUUId\");",
 					"        pm.globals.unset(\"receivingHistoryPoId\");",
+					"        pm.globals.unset(\"requestBodyPhysical\");",
+					"        pm.globals.unset(\"requestBodyToBeUpdated\");",
+					"        pm.globals.unset(\"poAllPoLineCheckin\");",
+					"        pm.globals.unset(\"poLineIdPhysical\");",
 					"        pm.globals.unset(\"poToCheckinItemsId\");",
+					"        pm.globals.unset(\"orderIdPEMix\");",
+					"        pm.globals.unset(\"orderWithApprovalReqTrueId\");",
+					"        pm.globals.unset(\"orderWithReceiptNotRequiredId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryNullId1\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryNullId2\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryNullId3\");",
@@ -23179,36 +19435,46 @@
 					"        pm.globals.unset(\"orderWithCreateInventoryInstanceId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryInstanceHoldingId\");",
 					"        pm.globals.unset(\"orderWithCreateInventoryInstanceHoldingItemId\");",
+					"        pm.globals.unset(\"order_isbn_validation\");",
 					"        pm.globals.unset(\"automaticallyClosedOrder\");",
 					"        pm.globals.unset(\"automaticallyClosedOpenOrder\");",
 					"        pm.globals.unset(\"automaticallyOpenedOrder\");",
 					"        pm.globals.unset(\"newEmptyPoLine\");",
 					"        pm.globals.unset(\"poNumber\");",
+					"        pm.globals.unset(\"poLineIdPEMix\");",
+					"        pm.globals.unset(\"poLine2IdPEMix\");",
 					"        pm.globals.unset(\"loanType\");",
 					"        pm.globals.unset(\"materialType\");",
 					"        pm.globals.unset(\"testTenant\");",
-					"        pm.globals.unset(\"enabledModules\");",
 					"        pm.globals.unset(\"testTenantActiveVendorId\");",
 					"        pm.globals.unset(\"pieceIdToUpdate\");",
 					"        pm.globals.unset(\"pieceRecord\");",
 					"",
-					"        pm.environment.unset(\"xokapitoken\");",
-					"        pm.environment.unset(\"xokapitoken-admin\");",
-					"        pm.environment.unset(\"mod-orders-configs\");",
-					"        pm.environment.unset(\"receivingItemBarcode\");",
 					"        pm.environment.unset(\"activeVendorId\");",
 					"        pm.environment.unset(\"contributorNameTypeId\");",
-					"        pm.environment.unset(\"inactiveVendorId\");",
+					"        pm.environment.unset(\"current-orders-configs\");",
+					"        pm.environment.unset(\"current-tenant-configs\");",
+					"        pm.environment.unset(\"enabledModules\");",
+					"        pm.environment.unset(\"fundId\");",
 					"        pm.environment.unset(\"identifierTypeId\");",
+					"        pm.environment.unset(\"isbnIdentifierTypeId\");",
+					"        pm.environment.unset(\"inactiveVendorId\");",
 					"        pm.environment.unset(\"instanceTypeId\");",
 					"        pm.environment.unset(\"instanceStatusId\");",
-					"        pm.environment.unset(\"loanTypeId\");",
-					"        pm.environment.unset(\"materialTypeId\");",
-					"        pm.environment.unset(\"uniqueProductId\");",
 					"        pm.environment.unset(\"ledgerId\");",
-					"        pm.environment.unset(\"fundId\");",
-					"         pm.environment.unset(\"temp-orders-configs\");",
-					"        pm.environment.unset(\"current-orders-configs\");",
+					"        pm.environment.unset(\"loanTypeId\");",
+					"        pm.environment.unset(\"locationId1\");",
+					"        pm.environment.unset(\"locationId2\");",
+					"        pm.environment.unset(\"locationId3\");",
+					"        pm.environment.unset(\"materialTypeId\");",
+					"        pm.environment.unset(\"mod-orders-configs\");",
+					"        pm.environment.unset(\"mod-tenant-configs\");",
+					"        pm.environment.unset(\"receivingItemBarcode\");",
+					"        pm.environment.unset(\"temp-orders-configs\");",
+					"        pm.environment.unset(\"uniqueProductId\");",
+					"        pm.environment.unset(\"xokapitoken\");",
+					"        pm.environment.unset(\"xokapitoken-admin\");",
+					"        pm.environment.unset(\"xokapitoken-testAdmin\");",
 					"    };",
 					"",
 					"    /**",
@@ -23276,7 +19542,13 @@
 	],
 	"variable": [
 		{
-			"id": "28e55ec2-2ebc-4b4c-93f1-8f3d947c9832",
+			"id": "78e33816-5354-4f28-b0c9-1cd5e5b17c50",
+			"key": "testTenant",
+			"value": "orders_api_tests",
+			"type": "string"
+		},
+		{
+			"id": "8462b6d6-060e-4e98-9512-9d48aec17797",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
@@ -23318,22 +19590,11 @@
 			"type": "string"
 		},
 		{
-			"id": "b23f9190-9d2d-44fa-aec0-68be841c006a",
-			"key": "finance-ledgerCode",
-			"value": "ordersApiTestsLedgerCode",
-			"type": "string"
-		},
-		{
-			"id": "c9d8594a-d03b-401e-a34a-56281d56f412",
-			"key": "finance-fundCode",
-			"value": "ordersApiTestsFundCode",
-			"type": "string"
-		},
-		{
-			"id": "180dda70-17c8-4ed7-b6d0-6369d2b9587e",
+			"id": "e3f08af6-f407-4608-95c0-831ed183d3a4",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-303](https://issues.folio.org/browse/MODORDERS-303) Perform API tests in separate tenant

## Approach
- Creating test tenant to execute all the tests
- Setup "global" data which is required to create locations (like institution, campus etc.)
- Update all the requests to `orders` endpoints to be sent under regular user
- Update all the requests to other modules' endpoints to be sent under test tenant admin (all permissions)
- Removing all the utility functions which were dealing with removal of the records from other modules

## Verification

![image](https://user-images.githubusercontent.com/43410167/65060148-084fce80-d980-11e9-9afd-3e1f822017f9.png)
