### PR TITLE
API tests for MODINVOICE-89

### DIFF
--- a/mod-invoice/mod-invoice-acq-units.postman_collection.json
+++ b/mod-invoice/mod-invoice-acq-units.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7eb9f23a-0c1a-4c49-b11b-42535062c879",
+		"_postman_id": "cd9b1337-63ef-49c9-96fe-c2a62738c47e",
 		"name": "mod-invoice-acq-units",
 		"description": "Tests for mod-invoice module to verify acqusition unit protections",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1160,6 +1160,139 @@
 											"    let jsonData = pm.response.json();",
 											"    pm.expect(jsonData.id).to.exist;",
 											"    pm.environment.set(\"deleteOpenUnitId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{unitBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Fully unprotected",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.unit;",
+											"body.name += \" - unprotected\";",
+											"body.protectCreate = false;",
+											"body.protectRead = false;",
+											"body.protectUpdate = false;",
+											"body.protectDelete = false;",
+											"",
+											"pm.variables.set(\"unitBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"unprotectedUnitId\", jsonData.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{unitBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"acquisitions-units",
+										"units"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "\"Deleted\" unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let body = globals.testData.unit;",
+											"body.name += \" - deleted\";",
+											"body.isDeleted = true;",
+											"",
+											"pm.variables.set(\"unitBody\", JSON.stringify(body));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"deletedUnitId\", jsonData.id);",
 											"});"
 										],
 										"type": "text/javascript"
@@ -4141,6 +4274,2487 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "Test protectDelete",
+					"item": [
+						{
+							"name": "Create invoice with delete protect unit",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "4ed2a9c1-8c08-4771-831b-dce0f9f65d98",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"var invoice = utils.buildInvoiceWithMinContent();",
+											"invoice.acqUnitIds = [pm.environment.get(\"deleteProtectUnitId\")];",
+											"// order.acqUnitIds.push(pm.environment.get(\"fullyProtectedUnitId\"));",
+											"",
+											"pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "0ea9f553-9c22-49c4-86df-7636eb85bce3",
+										"exec": [
+											"pm.test(\"Invoice is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"invoiceForDeleteId\", jsonData.id); ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{invoiceBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									]
+								},
+								"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders"
+							},
+							"response": []
+						},
+						{
+							"name": "Create delete protect invoice line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"minimal_content_line\", JSON.stringify(utils.buildInvoiceLineWithMinContent(pm.environment.get(\"invoiceForDeleteId\"))));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Line is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"lineForDeleteId\", jsonData.id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{minimal_content_line}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines"
+									]
+								},
+								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
+							},
+							"response": []
+						},
+						{
+							"name": "Try to delete \"delete protected\" line by not assigned user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"var error = {};",
+											"pm.test(\"Line deletion is restricted\", function () {",
+											"    pm.response.to.be.forbidden;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+											"    error = pm.response.json().errors[0];",
+											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{lineForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines",
+										"{{lineForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Try to delete \"delete protected\" invoice by not assigned user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"var error = {};",
+											"pm.test(\"Invoice deletion is restricted\", function () {",
+											"    pm.response.to.be.forbidden;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+											"    error = pm.response.json().errors[0];",
+											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{invoiceForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Try to delete \"delete protected\" line by user assigned to another units",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"var error = {};",
+											"pm.test(\"Line deletion is restricted\", function () {",
+											"    pm.response.to.be.forbidden;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+											"    error = pm.response.json().errors[0];",
+											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{lineForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines",
+										"{{lineForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Try to delete \"delete protected\" invoice by user assigned to another units",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"var error = {};",
+											"pm.test(\"Invoice deletion is restricted\", function () {",
+											"    pm.response.to.be.forbidden;",
+											"});",
+											"",
+											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+											"    error = pm.response.json().errors[0];",
+											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{invoiceForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Assign \"delete protect\" and \"fully protected\" units to invoice",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Invoice is updated successfully\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"invoiceForDeleteId\"), (err, res) => {",
+											"    pm.test(\"Invoice is successfully retrieved and ready for updates\", () => {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(res).to.have.property('code', 200);",
+											"",
+											"        // Assign unit to an Invoice",
+											"        let invoice = res.json();",
+											"         invoice.acqUnitIds = [pm.environment.get(\"deleteProtectUnitId\"), pm.environment.get(\"fullyProtectedUnitId\")];",
+											"        pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));",
+											"    });",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{invoiceBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{invoiceForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete \"delete protected\" and \"fully protected\" line by user assigned to fully protected unit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Line is deleted successfully\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines/{{lineForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice-storage",
+										"invoice-lines",
+										"{{lineForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete invoice-line which does not exists",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Line not found\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											"pm.variables.set(\"lineIdNotExists\", \"74f307e3-9e51-4eac-a667-d0a4bf112d5e\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines/{{lineIdNotExists}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice-storage",
+										"invoice-lines",
+										"{{lineIdNotExists}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete \"delete protected\" and \"fully protected\" invoice by user assigned to fully protected unit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Invoice is deleted successfully\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoices/{{invoiceForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice-storage",
+										"invoices",
+										"{{invoiceForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create invoice with delete open unit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "e0e31459-5477-4f72-a9d3-9cc347090686",
+										"exec": [
+											"pm.test(\"Invoice is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"invoiceForDeleteId\", jsonData.id); ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "2e7a1cdc-439f-42da-bbea-3f23e6e474e9",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"var invoice = utils.buildInvoiceWithMinContent();",
+											"invoice.acqUnitIds = [pm.environment.get(\"deleteOpenUnitId\"), pm.environment.get(\"createOpenUnitId\")];",
+											"",
+											"pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{invoiceBody}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices"
+									]
+								},
+								"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders"
+							},
+							"response": []
+						},
+						{
+							"name": "Create delete open invoice line",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"minimal_content_line\", JSON.stringify(utils.buildInvoiceLineWithMinContent(pm.environment.get(\"invoiceForDeleteId\"))));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Line is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let jsonData = pm.response.json();",
+											"    pm.expect(jsonData.id).to.exist;",
+											"    pm.environment.set(\"lineForDeleteId\", jsonData.id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{minimal_content_line}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines"
+									]
+								},
+								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete \"delete open\" line by not assigned user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Line is deleted successfully\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{lineForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoice-lines",
+										"{{lineForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete \"delete open\" invoice by not assigned user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
+										"exec": [
+											"pm.test(\"Invoice is deleted successfully\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-limitedUser}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{invoiceForDeleteId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Test Soft Delete",
+					"item": [
+						{
+							"name": "Invoice with one unit",
+							"item": [
+								{
+									"name": "Assign regular user to fully protected unit",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "92915c1b-6bde-4a36-9433-bc8f257b567d",
+												"exec": [
+													"var jsonData = {};",
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    jsonData = pm.response.json();",
+													"    pm.environment.set(\"protectedUnitMembershipId1\", jsonData.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "0f1a616f-fd38-4215-96ab-50a48a033dec",
+												"exec": [
+													"let body = {};",
+													"",
+													"body.userId = globals.testData.users.regular.user.id;",
+													"body.acquisitionsUnitId = pm.environment.get(\"fullyProtectedUnitId\");",
+													"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{membershipBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"memberships"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create invoice with fully protected unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"var invoice = utils.buildInvoiceWithMinContent();",
+													"invoice.acqUnitIds = [pm.environment.get(\"fullyProtectedUnitId\")];",
+													"",
+													"pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    let jsonData = pm.response.json();",
+													"    pm.expect(jsonData.id).to.exist;",
+													"    pm.environment.set(\"softDeleteInvoiceId\", jsonData.id);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{invoiceBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										},
+										"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders. 2 units are assigned: 1 - fully protected, 2 - fully unprotected"
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoice",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can be viewed\",  () => pm.response.to.be.ok);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Unassign user from fully protected unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships/{{protectedUnitMembershipId1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"memberships",
+												"{{protectedUnitMembershipId1}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoice - forbidden",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can not be viewed\",  () => {",
+													"    pm.response.to.be.forbidden;",
+													"",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors.length).to.eql(1);",
+													"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete invoice - forbidden",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can not be deleted\",  () => {",
+													"    pm.response.to.be.forbidden;",
+													"",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors.length).to.eql(1);",
+													"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "\"Delete\" fully protected unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Unit \\\"deleted\\\"\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{fullyProtectedUnitId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"units",
+												"{{fullyProtectedUnitId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoice - ok",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can be viewed\",  () => pm.response.to.be.ok);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete invoice- ok",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can be deleted\",  () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "\"Undelete\" fully protected unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/acquisitions-units/units/\" + pm.environment.get(\"fullyProtectedUnitId\"), (err, res) => {",
+													"    pm.test(\"Unit is successfully retrieved and ready for updates\", () => {",
+													"        pm.expect(err).to.equal(null);",
+													"        pm.expect(res).to.be.ok;",
+													"",
+													"        let unit = res.json();",
+													"        unit.isDeleted = false;",
+													"",
+													"        pm.variables.set(\"unitBody\", JSON.stringify(unit));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Unit is \\\"undeleted\\\"\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{unitBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{fullyProtectedUnitId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"units",
+												"{{fullyProtectedUnitId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5c596f68-01d0-4356-9bf2-5f751196ef0a",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "43e0a491-d458-4ebb-91ac-35174b393ba4",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Invoice with 2 units",
+							"item": [
+								{
+									"name": "Create invoice with 2 units",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"var invoice = utils.buildInvoiceWithMinContent();",
+													"invoice.acqUnitIds = [pm.environment.get(\"fullyProtectedUnitId\"), pm.environment.get(\"unprotectedUnitId\")];",
+													"invoice.vendorInvoiceNo = \"1568580499\";",
+													"invoice.status = \"Open\";",
+													"pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    let jsonData = pm.response.json();",
+													"    pm.expect(jsonData.id).to.exist;",
+													"    pm.environment.set(\"softDeleteInvoiceId\", jsonData.id);",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{invoiceBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										},
+										"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders. 2 units are assigned: 1 - fully protected, 2 - fully unprotected"
+									},
+									"response": []
+								},
+								{
+									"name": "Get membership - initially empty(user not assigned to any unit)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"// pm.test(\"Status code is 200\", function () {",
+													"//     pm.response.to.have.status(200);",
+													"",
+													"//     var jsonData = pm.response.json();",
+													"",
+													"//     pm.test(\"Verify membership has correct values\", () => {",
+													"    ",
+													"//         // Verify that metadata is presented",
+													"//         pm.expect(jsonData.metadata).to.exist;",
+													"        ",
+													"//         // Verify if id exists",
+													"//         pm.expect(jsonData.id).to.exist;",
+													"",
+													"//         // Verify ",
+													"//         let userId = globals.testData.user.id;",
+													"//         pm.expect(jsonData.userId).to.eql(userId);",
+													"        ",
+													"//         // Verify acquisitionsUnitId == unitId ",
+													"//         let acquisitionsUnitId = pm.environment.get(\"unit1Id\");",
+													"//         pm.expect(jsonData.acquisitionsUnitId).to.eql(acquisitionsUnitId);",
+													"//     });",
+													"// });"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"disabled": true
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"memberships"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoice",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can be viewed\",  () => {",
+													"    pm.response.to.be.ok;",
+													"    pm.environment.set(\"softDeleteInvoiceContent\", pm.response.text());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoices by query",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"1 invoice should be found\", () => pm.expect(pm.response.json().totalRecords).to.eql(1));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices?query=vendorInvoiceNo=1568580499",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "vendorInvoiceNo=1568580499"
+												}
+											]
+										},
+										"description": "There is no any order with assigned acq unit"
+									},
+									"response": []
+								},
+								{
+									"name": "\"Delete\" fully unprotected unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Unit \\\"deleted\\\"\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{unprotectedUnitId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"units",
+												"{{unprotectedUnitId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoices by query - nothing found because fully unprotected unit was deleted",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"No invoices should be found\", () => pm.expect(pm.response.json().totalRecords).to.eql(0));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices?query=vendorInvoiceNo=1568580499",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "vendorInvoiceNo=1568580499"
+												}
+											]
+										},
+										"description": "There is no any order with assigned acq unit"
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoice - forbidden",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can not be viewed\",  () => {",
+													"    pm.response.to.be.forbidden;",
+													"",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors.length).to.eql(1);",
+													"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Update invoice - forbidden",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let content = JSON.parse(pm.environment.get(\"softDeleteInvoiceContent\"));",
+													"delete content.acqUnitIds;",
+													"pm.environment.set(\"softDeleteInvoiceContent\", JSON.stringify(content));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can not be updated\",  () => {",
+													"    pm.response.to.be.forbidden;",
+													"",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors.length).to.eql(1);",
+													"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{softDeleteInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete invoice - forbidden",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can not be deleted\",  () => {",
+													"    pm.response.to.be.forbidden;",
+													"",
+													"    let errors = pm.response.json().errors;",
+													"    pm.expect(errors.length).to.eql(1);",
+													"    pm.expect(errors[0].code).to.eql(\"userHasNoPermission\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Assign regular user to fully protected unit",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "92915c1b-6bde-4a36-9433-bc8f257b567d",
+												"exec": [
+													"var jsonData = {};",
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    jsonData = pm.response.json();",
+													"    pm.environment.set(\"protectedUnitMembershipId\", jsonData.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "0f1a616f-fd38-4215-96ab-50a48a033dec",
+												"exec": [
+													"let body = {};",
+													"",
+													"body.userId = globals.testData.users.regular.user.id;",
+													"body.acquisitionsUnitId = pm.environment.get(\"fullyProtectedUnitId\");",
+													"pm.variables.set(\"membershipBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{membershipBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"memberships"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get membership - not empty (user is assigned to the unit)",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"",
+													"    var jsonData = pm.response.json();",
+													"",
+													"    pm.test(\"Verify membership has correct values\", () => {",
+													"        pm.expect(jsonData.acquisitionsUnitMemberships.length).to.be.above(0);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Okapi-Tenant",
+												"value": "{{xokapitenant}}",
+												"disabled": true
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/memberships",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"memberships"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoice",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can be viewed\", () => {",
+													"    pm.response.to.be.ok;",
+													"    pm.environment.set(\"softDeleteInvoiceContent\", pm.response.text());",
+													"    pm.expect(pm.response.json().acqUnitIds).to.have.lengthOf(2).and.to.have.members([pm.environment.get(\"fullyProtectedUnitId\"), pm.environment.get(\"unprotectedUnitId\")]);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Update invoice adding one more unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let content = JSON.parse(pm.environment.get(\"softDeleteInvoiceContent\"));",
+													"content.acqUnitIds.push(pm.environment.get(\"readOpenUnitId\"));",
+													"pm.environment.set(\"softDeleteInvoiceContent\", JSON.stringify(content));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can be updated\",  () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{softDeleteInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Get invoice with 3 units",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Invoice can be viewed\", () => {",
+													"    pm.response.to.be.ok;",
+													"    pm.environment.set(\"softDeleteInvoiceContent\", pm.response.text());",
+													"    pm.expect(pm.response.json().acqUnitIds).to.have.lengthOf(3).and.to.have.members([",
+													"        pm.environment.get(\"fullyProtectedUnitId\"),",
+													"        pm.environment.get(\"unprotectedUnitId\"),",
+													"        pm.environment.get(\"readOpenUnitId\")",
+													"    ]);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "Update invoice adding one more \"deleted\" unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let content = JSON.parse(pm.environment.get(\"softDeleteInvoiceContent\"));",
+													"content.acqUnitIds.push(pm.environment.get(\"deletedUnitId\"));",
+													"pm.environment.set(\"softDeleteInvoiceContent\", JSON.stringify(content));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Deleted unit cannot be assigned\",  () => {",
+													"    pm.response.to.have.status(422);",
+													"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+													"    let error = pm.response.json().errors[0];",
+													"    pm.expect(error.code).to.eql(\"acqUnitsNotFound\");",
+													"    pm.expect(error.acqUnitIds).to.have.lengthOf(1);",
+													"    pm.expect(error.acqUnitIds[0]).to.eql(pm.environment.get(\"deletedUnitId\"));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{softDeleteInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{softDeleteInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{softDeleteInvoiceId}}"
+											]
+										},
+										"description": "There is no any acq unit assigned to this order so view is not restricted"
+									},
+									"response": []
+								},
+								{
+									"name": "\"Undelete\" fully unprotected unit",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/acquisitions-units/units/\" + pm.environment.get(\"unprotectedUnitId\"), (err, res) => {",
+													"    pm.test(\"Unit is successfully retrieved and ready for updates\", () => {",
+													"        pm.expect(err).to.equal(null);",
+													"        pm.expect(res).to.be.ok;",
+													"",
+													"        let unit = res.json();",
+													"        unit.isDeleted = false;",
+													"",
+													"        pm.variables.set(\"unitBody\", JSON.stringify(unit));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Unit is \\\"undeleted\\\"\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{unitBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/acquisitions-units/units/{{unprotectedUnitId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"acquisitions-units",
+												"units",
+												"{{unprotectedUnitId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "Test protectUpdate",
 					"item": [
 						{
@@ -5224,858 +7838,6 @@
 						}
 					],
 					"_postman_isSubFolder": true
-				},
-				{
-					"name": "Test protectDelete",
-					"item": [
-						{
-							"name": "Create invoice with delete protect unit",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "4ed2a9c1-8c08-4771-831b-dce0f9f65d98",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"var invoice = utils.buildInvoiceWithMinContent();",
-											"invoice.acqUnitIds = [pm.environment.get(\"deleteProtectUnitId\")];",
-											"// order.acqUnitIds.push(pm.environment.get(\"fullyProtectedUnitId\"));",
-											"",
-											"pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "0ea9f553-9c22-49c4-86df-7636eb85bce3",
-										"exec": [
-											"pm.test(\"Invoice is created\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    let jsonData = pm.response.json();",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.environment.set(\"invoiceForDeleteId\", jsonData.id); ",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{invoiceBody}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices"
-									]
-								},
-								"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders"
-							},
-							"response": []
-						},
-						{
-							"name": "Create delete protect invoice line",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.variables.set(\"minimal_content_line\", JSON.stringify(utils.buildInvoiceLineWithMinContent(pm.environment.get(\"invoiceForDeleteId\"))));"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Line is created\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    let jsonData = pm.response.json();",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.environment.set(\"lineForDeleteId\", jsonData.id); ",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{minimal_content_line}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoice-lines"
-									]
-								},
-								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
-							},
-							"response": []
-						},
-						{
-							"name": "Try to delete \"delete protected\" line by not assigned user",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"var error = {};",
-											"pm.test(\"Line deletion is restricted\", function () {",
-											"    pm.response.to.be.forbidden;",
-											"});",
-											"",
-											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
-											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
-											"    error = pm.response.json().errors[0];",
-											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken-limitedUser}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{lineForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoice-lines",
-										"{{lineForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Try to delete \"delete protected\" invoice by not assigned user",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"var error = {};",
-											"pm.test(\"Invoice deletion is restricted\", function () {",
-											"    pm.response.to.be.forbidden;",
-											"});",
-											"",
-											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
-											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
-											"    error = pm.response.json().errors[0];",
-											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken-limitedUser}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices",
-										"{{invoiceForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Try to delete \"delete protected\" line by user assigned to another units",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"var error = {};",
-											"pm.test(\"Line deletion is restricted\", function () {",
-											"    pm.response.to.be.forbidden;",
-											"});",
-											"",
-											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
-											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
-											"    error = pm.response.json().errors[0];",
-											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{lineForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoice-lines",
-										"{{lineForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Try to delete \"delete protected\" invoice by user assigned to another units",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"var error = {};",
-											"pm.test(\"Invoice deletion is restricted\", function () {",
-											"    pm.response.to.be.forbidden;",
-											"});",
-											"",
-											"pm.test(\"Response contains error with userHasNoPermission code\", function () {",
-											"    pm.expect(pm.response.json().errors.length).to.eql(1);",
-											"    error = pm.response.json().errors[0];",
-											"    pm.expect(error.code).to.eql(\"userHasNoPermission\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices",
-										"{{invoiceForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Assign \"delete protect\" and \"fully protected\" units to invoice",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"pm.test(\"Invoice is updated successfully\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"invoiceForDeleteId\"), (err, res) => {",
-											"    pm.test(\"Invoice is successfully retrieved and ready for updates\", () => {",
-											"        pm.expect(err).to.equal(null);",
-											"        pm.expect(res).to.have.property('code', 200);",
-											"",
-											"        // Assign unit to an Invoice",
-											"        let invoice = res.json();",
-											"         invoice.acqUnitIds = [pm.environment.get(\"deleteProtectUnitId\"), pm.environment.get(\"fullyProtectedUnitId\")];",
-											"        pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));",
-											"    });",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken-testAdmin}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{invoiceBody}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices",
-										"{{invoiceForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete \"delete protected\" and \"fully protected\" line by user assigned to fully protected unit",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"pm.test(\"Line is deleted successfully\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines/{{lineForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice-storage",
-										"invoice-lines",
-										"{{lineForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete invoice-line which does not exists",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"pm.test(\"Line not found\", function () {",
-											"    pm.response.to.have.status(404);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											"pm.variables.set(\"lineIdNotExists\", \"74f307e3-9e51-4eac-a667-d0a4bf112d5e\");"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoice-lines/{{lineIdNotExists}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice-storage",
-										"invoice-lines",
-										"{{lineIdNotExists}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete \"delete protected\" and \"fully protected\" invoice by user assigned to fully protected unit",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"pm.test(\"Invoice is deleted successfully\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice-storage/invoices/{{invoiceForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice-storage",
-										"invoices",
-										"{{invoiceForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Create invoice with delete open unit",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "e0e31459-5477-4f72-a9d3-9cc347090686",
-										"exec": [
-											"pm.test(\"Invoice is created\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    let jsonData = pm.response.json();",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.environment.set(\"invoiceForDeleteId\", jsonData.id); ",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "2e7a1cdc-439f-42da-bbea-3f23e6e474e9",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"var invoice = utils.buildInvoiceWithMinContent();",
-											"invoice.acqUnitIds = [pm.environment.get(\"deleteOpenUnitId\"), pm.environment.get(\"createOpenUnitId\")];",
-											"",
-											"pm.variables.set(\"invoiceBody\", JSON.stringify(invoice));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{invoiceBody}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices"
-									]
-								},
-								"description": "Create a purchase order in `Open` status based on `po_listed_print_monograph.json` from mod-orders"
-							},
-							"response": []
-						},
-						{
-							"name": "Create delete open invoice line",
-							"event": [
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-										"exec": [
-											"let utils = eval(globals.loadUtils);",
-											"",
-											"pm.variables.set(\"minimal_content_line\", JSON.stringify(utils.buildInvoiceLineWithMinContent(pm.environment.get(\"invoiceForDeleteId\"))));"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "test",
-									"script": {
-										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-										"exec": [
-											"pm.test(\"Line is created\", function () {",
-											"    pm.response.to.have.status(201);",
-											"    let jsonData = pm.response.json();",
-											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.environment.set(\"lineForDeleteId\", jsonData.id); ",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "x-okapi-token",
-										"value": "{{xokapitoken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{minimal_content_line}}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoice-lines"
-									]
-								},
-								"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete \"delete open\" line by not assigned user",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"pm.test(\"Line is deleted successfully\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken-limitedUser}}"
-									}
-								],
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines/{{lineForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoice-lines",
-										"{{lineForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete \"delete open\" invoice by not assigned user",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "22db4a42-1333-4e75-8b19-cd0a22abd3bf",
-										"exec": [
-											"pm.test(\"Invoice is deleted successfully\", function () {",
-											"    pm.response.to.have.status(204);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "88e653b2-8f2e-4418-95a5-144412c51786",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "x-okapi-token",
-										"type": "text",
-										"value": "{{xokapitoken-limitedUser}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{invoiceForDeleteId}}",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{url}}"
-									],
-									"port": "{{okapiport}}",
-									"path": [
-										"invoice",
-										"invoices",
-										"{{invoiceForDeleteId}}"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -6104,6 +7866,78 @@
 		{
 			"name": "Negative Tests",
 			"item": [
+				{
+					"name": "Try to create invoice assigning soft-deleted unit",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"var invoice = utils.buildInvoiceWithMinContent();",
+									"invoice.acqUnitIds = [pm.environment.get(\"deletedUnitId\")];",
+									"invoice.status = \"Open\";",
+									"pm.variables.set(\"softDeletedInvoiceBody\", JSON.stringify(invoice));"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+								"exec": [
+									"var error = {};",
+									"pm.test(\"Status code is 422\", function () {",
+									"    pm.response.to.have.status(422);",
+									"});",
+									"",
+									"pm.test(\"Response contains error with acqUnitsNotFound code\", function () {",
+									"    pm.expect(pm.response.json().errors.length).to.eql(1);",
+									"    error = pm.response.json().errors[0];",
+									"    pm.expect(error.code).to.eql(\"acqUnitsNotFound\");",
+									"    pm.expect(error.acqUnitIds).to.have.lengthOf(1);",
+									"    pm.expect(error.acqUnitIds[0]).to.eql(pm.environment.get(\"deletedUnitId\"));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{softDeletedInvoiceBody}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"invoice",
+								"invoices"
+							]
+						},
+						"description": "There is no any acq unit assigned to this order so view is not restricted"
+					},
+					"response": []
+				},
 				{
 					"name": "Delete create protect unit",
 					"event": [
@@ -6220,79 +8054,6 @@
 							"path": [
 								"invoice",
 								"invoices"
-							]
-						},
-						"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"
-					},
-					"response": []
-				},
-				{
-					"name": "Try to create invoice line from assigned to deleted unit",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
-								"exec": [
-									"let utils = eval(globals.loadUtils);",
-									"var line = {};",
-									"",
-									"var line = utils.buildInvoiceLineWithMinContent(pm.environment.get(\"protectedInvoiceId\"));",
-									"line.invoiceId = pm.environment.get(\"protectedInvoiceId\");",
-									"",
-									"pm.variables.set(\"minimal_content_line\", JSON.stringify(line));"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
-								"exec": [
-									"var error = {};",
-									"pm.test(\"Status code is 422\", function () {",
-									"    pm.response.to.have.status(422);",
-									"});",
-									"",
-									"pm.test(\"Response contains error with acqUnitsNotFound code\", function () {",
-									"    pm.expect(pm.response.json().errors.length).to.eql(1);",
-									"    error = pm.response.json().errors[0];",
-									"    pm.expect(error.code).to.eql(\"acqUnitsNotFound\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "x-okapi-token",
-								"value": "{{xokapitoken-limitedUser}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{{minimal_content_line}}"
-						},
-						"url": {
-							"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoice-lines",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{url}}"
-							],
-							"port": "{{okapiport}}",
-							"path": [
-								"invoice",
-								"invoice-lines"
 							]
 						},
 						"description": "Create a purchase order in `Pending` status based on `po_listed_print_monograph.json` from mod-orders"


### PR DESCRIPTION
## Purpose
[MODINVOICE-89](https://issues.folio.org/browse/MODINVOICE-89) Disallow "isDeleted" acq units to be assigned to invoice

## Approach
- Creating 2 more units in the Setup section: fully unprotected and "soft-deleted"
- Adding a set of `Soft delete` positive tests:
  - Creating an invoice and assigning fully unprotected and fully protected units
  - Check that invoice can be retrieved
  - "Delete" fully unprotected unit
  - Check that any operation on the invoice is forbidden because the user is not a member of a fully unprotected unit
  - Assign a user to fully protected unit
  - Try to update invoice assigning another "soft-deleted" unit 
  - Negative tests added to create an invoice with soft-deleted unit

![image](https://user-images.githubusercontent.com/17807360/65074659-45f22e80-d963-11e9-921a-ffea10b491dd.png)

## Verification
**folio-snapshot**
![Screen Shot 2019-09-17 at 3 42 51 PM](https://user-images.githubusercontent.com/17807360/65074717-61f5d000-d963-11e9-96bb-b27033f4216b.png)

**folio-testing**
![Screen Shot 2019-09-17 at 12 12 31 PM](https://user-images.githubusercontent.com/17807360/65074862-ac774c80-d963-11e9-9606-6c4176dd8844.png)

![Screen Shot 2019-09-17 at 12 13 25 PM](https://user-images.githubusercontent.com/17807360/65074898-be58ef80-d963-11e9-8555-5cb5ed6465e7.png)



