### PR TITLE
MODFIN-63

### DIFF
--- a/mod-finance/mod-finance.postman_collection.json
+++ b/mod-finance/mod-finance.postman_collection.json
@@ -2840,6 +2840,572 @@
 						}
 					],
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Group Fund Fiscal Years",
+					"item": [
+						{
+							"name": "Prepare data for testing",
+							"item": [
+								{
+									"name": "Create Group",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"",
+													"pm.test(\"Group is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"    pm.environment.set(\"gffyGroupId\", record.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"code\": \"HIST-Test\",\n    \"description\": \"Test\",\n    \"name\": \"History-Test\",\n    \"status\": \"Active\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/groups",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"groups"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Ledger",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"",
+													"pm.test(\"Ledger is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"    pm.environment.set(\"gffyLedgerId\", record.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"code\": \"LDGR-TEST\",\n    \"ledgerStatus\": \"Active\",\n    \"name\": \"Test ledger for GFFY\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"ledgers"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Fiscal Year",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"",
+													"pm.test(\"Fiscal year is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"    pm.environment.set(\"gffyFiscalYearId\", record.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"code\": \"TST-FY-GFFY\",\n    \"name\": \"Test fiscal year\",\n    \"periodStart\": \"2019-01-01\",\n    \"periodEnd\": \"2020-01-01\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/fiscal-years",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"fiscal-years"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Fund Type",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"",
+													"pm.test(\"Fund type is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"    pm.environment.set(\"gffyFundTypeId\", record.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\": \"Test fund type\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/fund-types",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"fund-types"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create Fund",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"",
+													"pm.test(\"Fund is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"    pm.environment.set(\"gffyFundId\", record.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken-testAdmin}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"code\": \"TST-FND-GFFY\",\n    \"fundStatus\": \"Active\",\n    \"ledgerId\": \"{{gffyLedgerId}}\",\n    \"fundTypeId\": \"{{gffyFundTypeId}}\",\n    \"name\": \"Test fund for GFFY\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"funds"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create group fund fiscal year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let record = {};",
+											"",
+											"pm.test(\"Group fund fiscal year is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    record = pm.response.json();",
+											"    pm.environment.set(\"groupFundFiscalYearId\", record.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"groupId\": \"{{gffyGroupId}}\",\r\n  \"fiscalYearId\": \"{{gffyFiscalYearId}}\",\r\n  \"fundId\": \"{{gffyFundId}}\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get group fund fiscal year by query",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Group fund fiscal year founded\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let records = pm.response.json();",
+											"    pm.expect(records.groupFundFiscalYears).to.have.lengthOf(1);",
+											"    pm.expect(records.totalRecords).to.equal(1);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years?query=id={{groupFundFiscalYearId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "id={{groupFundFiscalYearId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete group fund fiscal year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Group fund fiscal year type is deleted\", () => pm.response.to.have.status(204));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years/{{groupFundFiscalYearId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years",
+										"{{groupFundFiscalYearId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get group fund fiscal year by query",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Group fund fiscal year founded - deleted\", function () {",
+											"    pm.response.to.be.ok;",
+											"    let records = pm.response.json();",
+											"    pm.expect(records.groupFundFiscalYears).to.have.lengthOf(0);",
+											"    pm.expect(records.totalRecords).to.equal(0);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years?query=id=={{groupFundFiscalYearId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "id=={{groupFundFiscalYearId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -4210,9 +4776,315 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Group fund fiscal year",
+					"item": [
+						{
+							"name": "Create group fund fiscal year without required field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Group fund fiscal year is not created\", function () {",
+											"    pm.response.to.have.status(422).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].parameters).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].parameters[0].key).to.eql(\"groupId\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"78872d8a-bf16-420b-829f-206da38f6c10\",\r\n  \"fiscalYearId\": \"684b5dc5-92f6-4db7-b996-b549d88f5e4e\",\r\n  \"fundId\": \"68872d8a-bf16-420b-829f-206da38f6c10\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create group fund fiscal year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Group fund fiscal year is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"a8bf1036-502c-42e4-8783-00a60beeae24\",\r\n  \"groupId\": \"{{gffyGroupId}}\",\r\n  \"fiscalYearId\": \"{{gffyFiscalYearId}}\",\r\n  \"fundId\": \"{{gffyFundId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create group fund fiscal year - already exists",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Group fund fiscal year is not created\", function () {",
+											"    pm.response.to.have.status(400).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"duplicate key\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"a8bf1036-502c-42e4-8783-00a60beeae24\",\r\n  \"groupId\": \"{{gffyGroupId}}\",\r\n  \"fiscalYearId\": \"{{gffyFiscalYearId}}\",\r\n  \"fundId\": \"{{gffyFundId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update group fund fiscal year - name already exists",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Fund type is not updated\", function () {",
+											"    pm.response.to.have.status(404).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"Not found\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years/d65969c5-1887-4801-8024-486502bd2a1b",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fund-fiscal-years",
+										"d65969c5-1887-4801-8024-486502bd2a1b"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search for group fund fiscal year by bad query",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Fund types cannot be found\", function () {",
+											"    pm.response.to.have.status(400).and.to.be.json;",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"cql\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/fund-types?query=invalid cql",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"fund-types"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "invalid cql"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Cleanup",
@@ -4685,6 +5557,12 @@
 					"        pm.environment.unset(\"xokapitoken\");",
 					"        pm.environment.unset(\"xokapitoken-admin\");",
 					"        pm.environment.unset(\"xokapitoken-testAdmin\");",
+					"        pm.environment.unset(\"gffyGroupId\");",
+					"        pm.environment.unset(\"gffyLedgerId\");",
+					"        pm.environment.unset(\"gffyFiscalYearId\");",
+					"        pm.environment.unset(\"gffyFundTypeId\");",
+					"        pm.environment.unset(\"gffyFundId\");",
+					"        pm.environment.unset(\"groupFundFiscalYearId\");",
 					"    };",
 					"",
 					"",
@@ -4749,5 +5627,6 @@
 			"value": "finance_api_tests",
 			"type": "string"
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }


### PR DESCRIPTION
API Tests for GROUP FUND FISCAL YEARS API.
1) Positive tests
1-1. Prepare Group, Ledger, Fiscal Year, Fund Type, Fund
1-2. Execute positive tests
![image](https://user-images.githubusercontent.com/42964285/65446112-58c1a300-de3c-11e9-99f8-757668071d65.png)
2) Negative tests:
![image](https://user-images.githubusercontent.com/42964285/65446169-77c03500-de3c-11e9-8157-7975220b0cbb.png)
3) Variables: gffyGroupId, gffyLedgerId, gffyFiscalYearId, gffyFundTypeId, gffyFundId, groupFundFiscalYearId deleted.

