### PR TITLE
API tests for MODINVOICE-95: Once an invoice is Paid it should no longer transition to other statuses

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "20f26fe0-5bf6-4577-9147-aa72e3f10179",
+		"_postman_id": "74b9bb99-2f82-4e2b-b051-d3219c42b163",
 		"name": "mod-invoice",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -10849,6 +10849,402 @@
 										}
 									},
 									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Paid",
+							"item": [
+								{
+									"name": "Create paid invoice",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"",
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    invoice = pm.response.json();",
+													"    pm.environment.set(\"negativePaidStatusInvoiceId\", invoice.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
+													"",
+													"invoice.note += \" - transition to Approved\";",
+													"invoice.status = \"Paid\";",
+													"delete invoice.adjustments;",
+													"delete invoice.voucherNumber;",
+													"delete invoice.approvalDate;",
+													"delete invoice.approvedBy;",
+													"",
+													"pm.environment.set(\"negativePaidStatusInvoiceContent\", JSON.stringify(invoice));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{negativePaidStatusInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Approved 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Required properties are missing\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"",
+													"    pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"    pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"    pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Approved\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Reviewed 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Test once an invoice is Paid it should no longer transition to other statuses\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"        pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"        pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"        pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Reviewed\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Cancelled 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Test once an invoice is Paid it should no longer transition to other statuses\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"        pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"        pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"        pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Cancelled\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Open 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Test once an invoice is Paid it should no longer transition to other statuses\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"        pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"        pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"        pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Open\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "d7287fa2-62d4-433c-ba5b-37d308c64eb9",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "41168d58-2c73-4612-95d4-207b24a54c2d",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
 								}
 							],
 							"protocolProfileBehavior": {},

--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "832c2899-ec69-42b9-ae6c-3ff56e3cc2f7",
+		"_postman_id": "291bed7c-55ce-4ee3-84e5-36750e095261",
 		"name": "mod-invoice",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -62,6 +62,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -218,6 +219,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -397,6 +399,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -553,6 +556,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -643,6 +647,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -851,6 +856,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -1154,9 +1160,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Positive Tests",
@@ -1398,6 +1406,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -1615,6 +1624,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -1830,6 +1840,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -2300,6 +2311,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -2480,6 +2492,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -2904,6 +2917,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -3255,6 +3269,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						}
 					],
@@ -3281,6 +3296,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -4952,6 +4968,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -5112,6 +5129,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -5335,6 +5353,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -5540,6 +5559,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -5830,6 +5850,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -6108,6 +6129,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -6394,6 +6416,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -6775,6 +6798,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -7139,6 +7163,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -7502,6 +7527,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -7780,6 +7806,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -8063,6 +8090,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -8126,6 +8154,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -8319,6 +8348,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -8625,6 +8655,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						}
 					],
@@ -8651,6 +8682,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -8790,6 +8822,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -8912,6 +8945,7 @@
 											"response": []
 										}
 									],
+									"protocolProfileBehavior": {},
 									"_postman_isSubFolder": true
 								},
 								{
@@ -9012,6 +9046,7 @@
 											"response": []
 										}
 									],
+									"protocolProfileBehavior": {},
 									"_postman_isSubFolder": true
 								},
 								{
@@ -9114,9 +9149,11 @@
 											"response": []
 										}
 									],
+									"protocolProfileBehavior": {},
 									"_postman_isSubFolder": true
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -9199,6 +9236,7 @@
 											"response": []
 										}
 									],
+									"protocolProfileBehavior": {},
 									"_postman_isSubFolder": true
 								},
 								{
@@ -9309,6 +9347,7 @@
 											"response": []
 										}
 									],
+									"protocolProfileBehavior": {},
 									"_postman_isSubFolder": true
 								},
 								{
@@ -9409,6 +9448,7 @@
 											"response": []
 										}
 									],
+									"protocolProfileBehavior": {},
 									"_postman_isSubFolder": true
 								},
 								{
@@ -9485,13 +9525,16 @@
 											"response": []
 										}
 									],
+									"protocolProfileBehavior": {},
 									"_postman_isSubFolder": true
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						}
 					],
 					"description": "This directory contains various tests related to transition of the invoices/vouchers through the workflow",
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
 			],
@@ -9516,7 +9559,8 @@
 						]
 					}
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Negative Tests",
@@ -9626,6 +9670,403 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Paid",
+							"item": [
+								{
+									"name": "Create paid invoice",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let invoice = {};",
+													"",
+													"pm.test(\"Invoice is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    invoice = pm.response.json();",
+													"    pm.environment.set(\"negativePaidStatusInvoiceId\", invoice.id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"let invoice = utils.prepareInvoice(utils.getMockInvoice(1));",
+													"",
+													"invoice.note += \" - transition to Approved\";",
+													"invoice.status = \"Paid\";",
+													"delete invoice.adjustments;",
+													"delete invoice.voucherNumber;",
+													"delete invoice.approvalDate;",
+													"delete invoice.approvedBy;",
+													"",
+													"pm.environment.set(\"negativePaidStatusInvoiceContent\", JSON.stringify(invoice));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{negativePaidStatusInvoiceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Approved 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Required properties are missing\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"",
+													"    pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"    pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"    pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Approved\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Reviewed 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Test once an invoice is Paid it should no longer transition to other statuses\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"        pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"        pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"        pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Reviewed\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Cancelled 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Test once an invoice is Paid it should no longer transition to other statuses\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"        pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"        pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"        pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Cancelled\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update paid invoice to Open 422",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(\"Unprocessable Entity\");",
+													"    var errors = pm.response.json().errors;",
+													"    pm.test(\"Test once an invoice is Paid it should no longer transition to other statuses\", function () {",
+													"        pm.expect(errors).to.have.lengthOf(1);",
+													"        pm.expect(errors[0].code).to.equal(\"invalidInvoiceStatusTransitionOnPaidStatus\");",
+													"        pm.expect(errors[0].parameters[0].key).to.equal(\"invoiceId\");",
+													"        pm.expect(errors[0].parameters[0].value).to.equal(pm.environment.get(\"negativePaidStatusInvoiceId\"));",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"utils.sendGetRequest(\"/invoice/invoices/\" + pm.environment.get(\"negativePaidStatusInvoiceId\"), (err, res) => {",
+													"    let invoice  = res.json();",
+													"    invoice.status = \"Open\";",
+													"    pm.variables.set(\"updatedInvoice\", JSON.stringify(invoice));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedInvoice}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"invoice",
+												"invoices",
+												"{{negativePaidStatusInvoiceId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "d7287fa2-62d4-433c-ba5b-37d308c64eb9",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "41168d58-2c73-4612-95d4-207b24a54c2d",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -9872,9 +10313,11 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -9943,6 +10386,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -10032,6 +10476,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -11214,6 +11659,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -11303,6 +11749,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -12071,6 +12518,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -12186,6 +12634,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -12368,6 +12817,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -12508,6 +12958,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -12665,6 +13116,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -12753,6 +13205,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -13164,6 +13617,7 @@
 									}
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -13363,12 +13817,15 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Cleanup",
@@ -13453,6 +13910,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -13513,6 +13971,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -13817,6 +14276,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -13877,7 +14337,61 @@
 							"response": []
 						},
 						{
-							"name": "Delete Negative Reviewed to Approved invoice Copy",
+							"name": "Delete Negative Paid invoice",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Invoice is deleted\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/invoice/invoices/{{negativePaidStatusInvoiceId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"invoice",
+										"invoices",
+										"{{negativePaidStatusInvoiceId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Negative Reviewed to Approved invoice",
 							"event": [
 								{
 									"listen": "test",
@@ -14117,6 +14631,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -14321,6 +14836,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -14414,6 +14930,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -14486,6 +15003,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -14602,6 +15120,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -14771,9 +15290,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		}
 	],
 	"event": [
@@ -15542,5 +16063,6 @@
 			"value": "{\"voucherNumberPrefix\": \"testPrefix\"}",
 			"type": "string"
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }


### PR DESCRIPTION
**Purpose:**
API test for https://issues.folio.org/browse/MODINVOICE-95

**Approach:**
- Add negative test to verify "Paid" invoice is not allowed to transition to "Approved", "Open", "Reviewed", "Cancelled".
- Unset/CleanUp variable

![image](https://user-images.githubusercontent.com/17807360/65646773-32317280-dfca-11e9-94d3-11e3f0ab653c.png)

**Verified on folio-testing:**
<img width="1670" alt="Screen Shot 2019-10-06 at 1 13 37 PM" src="https://user-images.githubusercontent.com/17807360/66273075-99f38300-e83e-11e9-8f1e-9ffb8fa2d675.png">


