### PR TITLE
MODGOBI-88- Update to latest schema changes in finance

### DIFF
--- a/mod-gobi/mod-gobi.postman_collection.json
+++ b/mod-gobi/mod-gobi.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "333484d8-41bd-44b3-b8c8-db2b4e96612b",
+		"_postman_id": "1b43fb0b-877e-4688-b159-8250ac2bed6e",
 		"name": "mod-gobi",
 		"description": "Tests for mod-gobi",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1110,6 +1110,67 @@
 							"name": "Finance data",
 							"item": [
 								{
+									"name": "Fiscal Year",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+												"exec": [
+													"pm.test(\"Fiscal Year is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    pm.response.to.be.withBody;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken-testAdmin}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"id\": \"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\",\n  \"name\": \"TST-Fiscal Year 2020\",\n  \"code\": \"FY2020\",\n  \"description\": \"January 1 - December 30\",\n  \"periodStart\": \"2020-01-01T00:00:00Z\",\n  \"periodEnd\": \"2020-12-30T23:59:59Z\",\n  \"series\": \"FY\"\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/fiscal-years",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"fiscal-years"
+											]
+										},
+										"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
+									},
+									"response": []
+								},
+								{
 									"name": "Ledger",
 									"event": [
 										{
@@ -1152,7 +1213,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\"\r\n}"
+											"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\",\r\n\t\"fiscalYearOneId\": \"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\"\r\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers",
@@ -3702,19 +3763,19 @@
 	],
 	"variable": [
 		{
-			"id": "134dcc2f-6d03-4875-bd81-517f69ad0e63",
+			"id": "8faeee23-4284-482a-8be5-bf8f8d7c2236",
 			"key": "testTenant",
 			"value": "gobi_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "b766e31c-743d-421c-937e-0771b99f3eec",
+			"id": "705e951d-a706-475f-9a89-b8c7c4bfb485",
 			"key": "testdataBaseURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-gobi/master/src/test/resources/GOBIIntegrationServiceResourceImpl/",
 			"type": "string"
 		},
 		{
-			"id": "488d0b0b-a02c-4220-8725-216bc52adede",
+			"id": "0e524cbc-03d7-40d1-ba79-d9b2e412d3bd",
 			"key": "tenantOverrideConfigURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-gobi/master/src/test/resources/MappingHelper/Custom_ListedElectronicSerial.json",
 			"type": "string"

--- a/mod-gobi/mod-gobi.postman_collection.json
+++ b/mod-gobi/mod-gobi.postman_collection.json
@@ -1166,7 +1166,7 @@
 												"fiscal-years"
 											]
 										},
-										"description": "Gets or creates if not yet exists test identifier type to be used accross the orders while interaction with inventory"
+										"description": "creates Fiscal Year record, which will in turn be used to create ledger"
 									},
 									"response": []
 								},


### PR DESCRIPTION
## PURPOSE
https://issues.folio.org/browse/MODGOBI-88- Though this story deals with changing to use the supertenant to create a test tenant, there are no changes necessary for that in the API tests. Changing the environment file to use supertenant and the creds will suffice. 

The recent changes to finance module schemas(FiscalYearOneId was added as a required field in ledger schema) are failing the API tests. This PR covers those changes

## VERIFICATION
verified on folio testing:
![Screen Shot 2019-11-01 at 9 57 09 AM](https://user-images.githubusercontent.com/41596468/68029990-d45e0d80-fc8e-11e9-985f-dfa954df1f8c.png)

Also, using the super tenant to login initially
![Screen Shot 2019-11-01 at 10 03 38 AM](https://user-images.githubusercontent.com/41596468/68030016-e8a20a80-fc8e-11e9-8c43-0b088d03ddc6.png)

