### PR TITLE
mod-invoice - Fix schema changes from finance

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0a7aa9b2-fe50-4c9f-8e0a-06a73ca0229a",
+		"_postman_id": "c7a60bf5-439d-490f-8563-8b0da394d2cb",
 		"name": "mod-invoice",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1362,7 +1362,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\"\r\n}"
+									"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\",\r\n\t\"fiscalYearOneId\": \"d54705ca-6f19-4f48-ab05-228190be3235\"\r\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers",


### PR DESCRIPTION
**Purpose:**
https://issues.folio.org/browse/MODINVOICE-107

**Approach:**
No changes are required in scope of this story but there are few schema changes. So update `Setup`->`Prepare finance data`->`Ledger` with `fiscalYearOneId`

**Verified in folio-testing:**
Login using supertenant tenant and its own credentials
<img width="1671" alt="Screen Shot 2019-10-30 at 2 18 12 PM" src="https://user-images.githubusercontent.com/17807360/68030698-74686680-fc90-11e9-8b6f-1d28697ba8e4.png">

![image](https://user-images.githubusercontent.com/17807360/68030854-c4dfc400-fc90-11e9-8954-317a18ae360b.png)
