### PR TITLE
MODORDERS-318: Update according to latest finance schemas

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "fd94f804-ff64-4140-9d96-efa888b5e890",
+		"_postman_id": "06336210-4527-4b17-a756-c310866a0ac1",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1564,6 +1564,67 @@
 					"name": "Prepare finance data",
 					"item": [
 						{
+							"name": "Fiscal Year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "26b15fda-7df4-473f-9ce4-ccfc4924460c",
+										"exec": [
+											"pm.test(\"Fiscal Year is created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.be.withBody;",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "fa42b974-2ac7-4dbf-9572-3f42ef3569f6",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"id\": \"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\",\n  \"name\": \"TST-Fiscal Year 2020\",\n  \"code\": \"FY2020\",\n  \"description\": \"January 1 - December 30\",\n  \"periodStart\": \"2020-01-01T00:00:00Z\",\n  \"periodEnd\": \"2020-12-30T23:59:59Z\",\n  \"series\": \"FY\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/fiscal-years",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance-storage",
+										"fiscal-years"
+									]
+								},
+								"description": "Creates a Fiscal Year record which will be used to create a ledger record"
+							},
+							"response": []
+						},
+						{
 							"name": "Ledger",
 							"event": [
 								{
@@ -1607,7 +1668,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"fiscalYearOneId\": \"684b5dc5-92f6-4db7-b996-b549d88f5e4e\",\r\n\t\"name\": \"Test ledger\"\r\n}"
+									"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\",\r\n    \"fiscalYearOneId\": \"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\"\r\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers",
@@ -20444,55 +20505,55 @@
 	],
 	"variable": [
 		{
-			"id": "80ced7cd-bc22-4007-b670-22e6c007c346",
+			"id": "eb7d1b7c-dfb2-4358-b899-abd183ee03bf",
 			"key": "testTenant",
 			"value": "orders_api_tests1",
 			"type": "string"
 		},
 		{
-			"id": "c7e325be-4bfc-4e8b-9caa-3c16d8b09717",
+			"id": "e8e6aa00-f3dd-4bf2-874c-5a13ec049d8f",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "86fd97f3-afc3-4b8d-84ec-63503e7ca46d",
+			"id": "52e4b13b-8d65-4911-8172-9e51f23555a3",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "d9adfcc6-5f95-4559-9af1-7a853a86bd98",
+			"id": "0d09fee0-0ae8-4848-a17e-1322a4c91f0f",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "d1bc5564-2eb3-467b-93b4-6f2dc0761379",
+			"id": "429f5978-128b-4f54-ad23-221b4420798c",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "a5a9917d-6771-4cc7-8d50-ecbbe065da87",
+			"id": "1ea76acb-db0d-4961-83ce-750a98afbe64",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "5379e422-0c29-44f0-9609-64f591d6a02c",
+			"id": "9fc31a61-7734-4a3c-9833-03a745a978ee",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "8884d3b6-290d-495a-9095-9d080114e744",
+			"id": "215d594a-645c-4d54-8a69-1a5cb666cbcc",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "0bf680ad-5d58-43bd-99e0-a408da1073f9",
+			"id": "eecd0a88-1dc4-4ac3-b0ad-ddadb0a2ecfb",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"


### PR DESCRIPTION
## PURPOSE
https://issues.folio.org/browse/MODORDERS-318
The recent changes to finance module schemas(FiscalYearOneId was added as a required field in ledger schema) are failing the API tests. This PR covers those changes

verified on folio-testing:
![Screen Shot 2019-11-01 at 3 53 34 PM](https://user-images.githubusercontent.com/41596468/68053523-84993980-fcc2-11e9-9366-72a6c26281c3.png)
