### PR TITLE
MODFIN-78 Fund API updates: GET by id/GET by query

### DIFF
--- a/mod-finance/mod-finance.postman_collection.json
+++ b/mod-finance/mod-finance.postman_collection.json
@@ -4616,6 +4616,78 @@
 							"response": []
 						},
 						{
+							"name": "Get fund with groups - current fiscal year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let record = {};",
+											"",
+											"pm.test(\"Fund is retrieved\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    record = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Fund content is valid\", function() {",
+											"    utils.validateCompositeFund(record);",
+											"    pm.environment.set(\"currentFyFundId\", record.fund.id);",
+											"    pm.expect(record.groupIds).to.have.lengthOf(1);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{fundContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds/{{currentFyFundId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"funds",
+										"{{currentFyFundId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Get group fund fiscal year by query - current FY",
 							"event": [
 								{
@@ -4757,6 +4829,78 @@
 									"path": [
 										"finance",
 										"funds"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get fund with groups - next fiscal year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let record = {};",
+											"",
+											"pm.test(\"Fund is retrieved\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    record = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"Fund content is valid\", function() {",
+											"    utils.validateCompositeFund(record);",
+											"    pm.environment.set(\"currentFyFundId\", record.fund.id);",
+											"    pm.expect(record.groupIds).to.have.lengthOf(1);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{fundContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds/{{nextFyFundId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"funds",
+										"{{nextFyFundId}}"
 									]
 								}
 							},
@@ -7342,6 +7486,18 @@
 					"        pm.environment.unset(\"gffyFundTypeId\");",
 					"        pm.environment.unset(\"gffyFundId\");",
 					"        pm.environment.unset(\"groupFundFiscalYearId\");",
+					"        pm.environment.unset(\"groupId\");",
+					"        pm.environment.unset(\"testCurrentFiscalYearOneId\");",
+					"        pm.environment.unset(\"testNextFiscalYearOneId\");",
+					"        pm.environment.unset(\"currentFiscalYearId\");",
+					"        pm.environment.unset(\"nextFiscalYearId\");",
+					"        pm.environment.unset(\"currentFyLedgerId\");",
+					"        pm.environment.unset(\"nextFyLedgerId\");",
+					"        pm.environment.unset(\"currentFyFundId\");",
+					"        pm.environment.unset(\"nextFyFundId\");",
+					"        pm.environment.unset(\"testNegativeFiscalYearOneId\");",
+					"        pm.environment.unset(\"afterNextFiscalYearId\");",
+					"        pm.environment.unset(\"negativeyLedgerId\");",
 					"    };",
 					"",
 					"",
@@ -7395,13 +7551,13 @@
 	],
 	"variable": [
 		{
-			"id": "65ed2ddd-fa3c-44b2-8ca1-b27054a6d4d7",
+			"id": "b40b38e2-12bd-456d-96f6-ae5b57fa5a86",
 			"key": "mod-financeResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-finance/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "874352a9-a54f-429f-b2f7-61491d9d4442",
+			"id": "ae825fac-3d49-46e3-8ae7-40a1d3e13b13",
 			"key": "testTenant",
 			"value": "finance_api_tests",
 			"type": "string"


### PR DESCRIPTION
## Purpose
[MODFIN-78(https://issues.folio.org/browse/MODFIN-78)

## Approach
- added tests to verify GET /finance/funds/{id} assigned to current or next fiscal year

## Verification
![image](https://user-images.githubusercontent.com/41672277/68667044-2425ba00-0556-11ea-9e96-235b3de61a18.png)