### PR TITLE
MODFIN-73 - Implement the GET /finance/group-fiscal-year-summaries API

### DIFF
--- a/mod-finance/mod-finance.postman_collection.json
+++ b/mod-finance/mod-finance.postman_collection.json
@@ -1063,6 +1063,68 @@
 					"name": "Groups",
 					"item": [
 						{
+							"name": "Create group - for Group Fund Fiscal Year",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Group is created\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    pm.environment.set(\"groupId\", pm.response.json().id); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"let group = utils.buildGroupMinContent(\"GROUP_GFFY\");",
+											"group.name = \"Test group for GFFY\";",
+											"",
+											"pm.environment.set(\"groupContent\", JSON.stringify(group));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{groupContent}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/groups",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"groups"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Create group - for CRUD test",
 							"event": [
 								{
@@ -3802,318 +3864,6 @@
 					"name": "Group Fund Fiscal Years",
 					"item": [
 						{
-							"name": "Prepare data for testing",
-							"item": [
-								{
-									"name": "Create Group",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let record = {};",
-													"",
-													"pm.test(\"Group is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    record = pm.response.json();",
-													"    pm.environment.set(\"gffyGroupId\", record.id);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken-testAdmin}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"code\": \"HIST-Test\",\n    \"description\": \"Test\",\n    \"name\": \"History-Test\",\n    \"status\": \"Active\"\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/groups",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"finance-storage",
-												"groups"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Create Fiscal Year",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let record = {};",
-													"",
-													"pm.test(\"Fiscal year is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    record = pm.response.json();",
-													"    pm.environment.set(\"gffyFiscalYearId\", record.id);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken-testAdmin}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"code\": \"TS2020\",\n    \"name\": \"Test fiscal year\",\n    \"periodStart\": \"2019-01-01\",\n    \"periodEnd\": \"2020-01-01\"\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/fiscal-years",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"finance-storage",
-												"fiscal-years"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Create Ledger",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let record = {};",
-													"",
-													"pm.test(\"Ledger is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    record = pm.response.json();",
-													"    pm.environment.set(\"gffyLedgerId\", record.id);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken-testAdmin}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"code\": \"LDGR-TEST\",\n    \"ledgerStatus\": \"Active\",\n    \"fiscalYearOneId\": \"{{gffyFiscalYearId}}\",\n    \"name\": \"Test ledger for GFFY\"\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"finance-storage",
-												"ledgers"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Create Fund Type",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let record = {};",
-													"",
-													"pm.test(\"Fund type is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    record = pm.response.json();",
-													"    pm.environment.set(\"gffyFundTypeId\", record.id);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken-testAdmin}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"name\": \"Test fund type\"\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/fund-types",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"finance-storage",
-												"fund-types"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Create Fund",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let record = {};",
-													"",
-													"pm.test(\"Fund is created\", function () {",
-													"    pm.response.to.have.status(201);",
-													"    record = pm.response.json();",
-													"    pm.environment.set(\"gffyFundId\", record.id);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken-testAdmin}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"code\": \"TST-FND-GFFY\",\n    \"fundStatus\": \"Active\",\n    \"ledgerId\": \"{{gffyLedgerId}}\",\n    \"fundTypeId\": \"{{gffyFundTypeId}}\",\n    \"name\": \"Test fund for GFFY\"\n}"
-										},
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/funds",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"finance-storage",
-												"funds"
-											]
-										}
-									},
-									"response": []
-								}
-							],
-							"protocolProfileBehavior": {},
-							"_postman_isSubFolder": true
-						},
-						{
 							"name": "Create group fund fiscal year",
 							"event": [
 								{
@@ -4127,7 +3877,7 @@
 											"pm.test(\"Group fund fiscal year is created\", function () {",
 											"    pm.response.to.have.status(201);",
 											"    record = pm.response.json();",
-											"    pm.environment.set(\"groupFundFiscalYearId\", record.id);",
+											"    pm.environment.set(\"groupFundFiscalYearForCrudId\", record.id);",
 											"});"
 										],
 										"type": "text/javascript"
@@ -4138,7 +3888,9 @@
 									"script": {
 										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
 										"exec": [
-											""
+											"let utils = eval(globals.loadUtils);",
+											"pm.variables.set(\"groupFundFiscalYearContent\", ",
+											"JSON.stringify(utils.buildGroupFundFiscalYearMinContent(pm.environment.get(\"groupId\"), pm.environment.get(\"fundId\"), pm.environment.get(\"fiscalYearId\"))));"
 										],
 										"type": "text/javascript"
 									}
@@ -4160,7 +3912,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"groupId\": \"{{gffyGroupId}}\",\r\n  \"fiscalYearId\": \"{{gffyFiscalYearId}}\",\r\n  \"fundId\": \"{{gffyFundId}}\"\r\n}",
+									"raw": "{{groupFundFiscalYearContent}}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4226,7 +3978,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years?query=id={{groupFundFiscalYearId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years?query=id={{groupFundFiscalYearForCrudId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -4239,7 +3991,7 @@
 									"query": [
 										{
 											"key": "query",
-											"value": "id={{groupFundFiscalYearId}}"
+											"value": "id={{groupFundFiscalYearForCrudId}}"
 										}
 									]
 								}
@@ -4283,7 +4035,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years/{{groupFundFiscalYearId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years/{{groupFundFiscalYearForCrudId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -4292,7 +4044,7 @@
 									"path": [
 										"finance",
 										"group-fund-fiscal-years",
-										"{{groupFundFiscalYearId}}"
+										"{{groupFundFiscalYearForCrudId}}"
 									]
 								}
 							},
@@ -4342,7 +4094,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years?query=id=={{groupFundFiscalYearId}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years?query=id=={{groupFundFiscalYearForCrudId}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -4355,7 +4107,7 @@
 									"query": [
 										{
 											"key": "query",
-											"value": "id=={{groupFundFiscalYearId}}"
+											"value": "id=={{groupFundFiscalYearForCrudId}}"
 										}
 									]
 								}
@@ -8281,6 +8033,182 @@
 					],
 					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Group FiscalYear Summary",
+					"item": [
+						{
+							"name": "Prepare data for testing",
+							"item": [
+								{
+									"name": "Create group fund fiscal year",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let record = {};",
+													"",
+													"pm.test(\"Group fund fiscal year is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.variables.set(\"groupFundFiscalYearContent\", ",
+													"JSON.stringify(utils.buildGroupFundFiscalYearMinContent(pm.environment.get(\"groupId\"), pm.environment.get(\"fundId\"), pm.environment.get(\"fiscalYearId\"))));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{groupFundFiscalYearContent}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"group-fund-fiscal-years"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Get group fiscal year summary",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Group fiscal year summary is retrieved\", function() {",
+											"    pm.response.to.be.ok;",
+											"    let summaries = pm.response.json().groupFiscalYearSummaries;",
+											"    pm.expect(summaries.length).to.equal(1);",
+											"    utils.validateGroupFiscalYearSummaries(summaries[0]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"// let utils = eval(globals.loadUtils);",
+											"",
+											"// let fiscalYear = utils.buildFiscalYearMinContent(\"DD1259\");",
+											"// let group = utils.buildGroupMinContent();",
+											"",
+											"// // Create fiscal year",
+											"// pm.test(\"Fiscal year is created\", function() {",
+											"//     utils.sendPostRequest('/finance/fiscal-years', fiscalYear, (err, res) => {",
+											"//         pm.expect(res).to.have.status(201);",
+											"//         pm.variables.set(\"fiscalYearId\", res.json().id);",
+											"//             // Create group",
+											"//             pm.test(\"Group is created\", function() {",
+											"//                 utils.sendPostRequest('/finance/groups', group, (err, res) => {",
+											"//                 pm.expect(res).to.have.status(201);",
+											"//                 pm.variables.set(\"groupId\", res.json().id);",
+											"//                 pm.variables.set(\"fiscalYearId\", res.json().id);",
+											"//                 // Create fund",
+											"//                 pm.test(\"Fund is created\", function() {",
+											"//                     utils.sendPostRequest('/finance/funds', group, (err, res) => {",
+											"//                     pm.expect(res).to.have.status(201);",
+											"//                     pm.variables.set(\"fundIdId\", res.json().id);",
+											"//                     });",
+											"//                 });",
+											"//             });",
+											"//         });",
+											"//     });",
+											"// });",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fiscal-year-summaries?query=groupFundFY.groupId={{groupId}} or groupId={{groupId}} and fiscalYearId=={{fiscalYearId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fiscal-year-summaries"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "groupFundFY.groupId={{groupId}} or groupId={{groupId}} and fiscalYearId=={{fiscalYearId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -10250,7 +10178,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"id\": \"a8bf1036-502c-42e4-8783-00a60beeae24\",\r\n  \"groupId\": \"{{gffyGroupId}}\",\r\n  \"fiscalYearId\": \"{{gffyFiscalYearId}}\",\r\n  \"fundId\": \"{{gffyFundId}}\"\r\n}"
+									"raw": "{\r\n  \"id\": \"a8bf1036-502c-42e4-8783-00a60beeae24\",\r\n  \"groupId\": \"{{groupId}}\",\r\n  \"fiscalYearId\": \"{{fiscalYearId}}\",\r\n  \"fundId\": \"{{fundId}}\"\r\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years",
@@ -10309,7 +10237,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"id\": \"a8bf1036-502c-42e4-8783-00a60beeae24\",\r\n  \"groupId\": \"{{gffyGroupId}}\",\r\n  \"fiscalYearId\": \"{{gffyFiscalYearId}}\",\r\n  \"fundId\": \"{{gffyFundId}}\"\r\n}"
+									"raw": "{\r\n  \"id\": \"a8bf1036-502c-42e4-8783-00a60beeae24\",\r\n  \"groupId\": \"{{groupId}}\",\r\n  \"fiscalYearId\": \"{{fiscalYearId}}\",\r\n  \"fundId\": \"{{fundId}}\"\r\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fund-fiscal-years",
@@ -10327,14 +10255,14 @@
 							"response": []
 						},
 						{
-							"name": "Update group fund fiscal year - name already exists",
+							"name": "Delete group fund fiscal year - not found",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
 										"exec": [
-											"pm.test(\"Fund type is not updated\", function () {",
+											"pm.test(\"Group fund fiscal year is not deleted\", function () {",
 											"    pm.response.to.have.status(404).and.to.be.json;",
 											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
 											"    pm.expect(pm.response.json().errors[0].message).to.contain(\"Not found\");",
@@ -11237,6 +11165,105 @@
 					],
 					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Group fiscal year summary",
+					"item": [
+						{
+							"name": "Get group fiscal year summary - fiscal year not found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Group fiscal year summary is empty\", function() {",
+											"    pm.response.to.be.ok;",
+											"    let summaries = pm.response.json().groupFiscalYearSummaries;",
+											"    pm.expect(summaries.length).to.equal(0);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											"// let utils = eval(globals.loadUtils);",
+											"",
+											"// let fiscalYear = utils.buildFiscalYearMinContent(\"DD1259\");",
+											"// let group = utils.buildGroupMinContent();",
+											"",
+											"// // Create fiscal year",
+											"// pm.test(\"Fiscal year is created\", function() {",
+											"//     utils.sendPostRequest('/finance/fiscal-years', fiscalYear, (err, res) => {",
+											"//         pm.expect(res).to.have.status(201);",
+											"//         pm.variables.set(\"fiscalYearId\", res.json().id);",
+											"//             // Create group",
+											"//             pm.test(\"Group is created\", function() {",
+											"//                 utils.sendPostRequest('/finance/groups', group, (err, res) => {",
+											"//                 pm.expect(res).to.have.status(201);",
+											"//                 pm.variables.set(\"groupId\", res.json().id);",
+											"//                 pm.variables.set(\"fiscalYearId\", res.json().id);",
+											"//                 // Create fund",
+											"//                 pm.test(\"Fund is created\", function() {",
+											"//                     utils.sendPostRequest('/finance/funds', group, (err, res) => {",
+											"//                     pm.expect(res).to.have.status(201);",
+											"//                     pm.variables.set(\"fundIdId\", res.json().id);",
+											"//                     });",
+											"//                 });",
+											"//             });",
+											"//         });",
+											"//     });",
+											"// });",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/group-fiscal-year-summaries?query=groupFundFY.groupId={{groupId}} or groupId={{groupId}} and fiscalYearId=={{$guid}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"group-fiscal-year-summaries"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "groupFundFY.groupId={{groupId}} or groupId={{groupId}} and fiscalYearId=={{$guid}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
 				}
 			],
 			"protocolProfileBehavior": {}
@@ -11639,6 +11666,17 @@
 					"            \"periodEnd\": \"2025-12-30T23:59:59Z\",",
 					"        };",
 					"    };",
+					"    ",
+					"    /**",
+					"     * Build group fund fiscal year record with minimal required fields.",
+					"     */",
+					"    utils.buildGroupFundFiscalYearMinContent = function(groupId, fundId, fiscalYearId) {",
+					"        return {",
+					"            \"groupId\": groupId,",
+					"            \"fiscalYearId\": fiscalYearId,",
+					"            \"fundId\": fundId",
+					"        };",
+					"    };",
 					"",
 					"    /**",
 					"     * Build Fund record with minimal required fields.",
@@ -11797,6 +11835,19 @@
 					"        pm.expect(jsonData.series).to.exist;",
 					"",
 					"        utils._validateAgainstSchema(jsonData, JSON.parse(pm.environment.get(utils.schemaPrefix + \"fiscal_year.json\")));",
+					"    };",
+					"    ",
+					"    /**",
+					"    * Validates the content of the group fiscal year summary record",
+					"    */",
+					"    utils.validateGroupFiscalYearSummaries = function(jsonData) {",
+					"        pm.expect(jsonData.groupId).to.exist;",
+					"        pm.expect(jsonData.fiscalYearId).to.exist;",
+					"        pm.expect(jsonData.allocated).to.exist;",
+					"        pm.expect(jsonData.available).to.exist;",
+					"        pm.expect(jsonData.unavailable).to.exist;",
+					"",
+					"        utils._validateAgainstSchema(jsonData, JSON.parse(pm.environment.get(utils.schemaPrefix + \"group_fiscal_year_summary.json\")));",
 					"    };",
 					"",
 					"    /**",


### PR DESCRIPTION
- API tests for Group Fiscal Year Summary

- Refactoring of Group Fund Fiscal Year tests

Positive test:
1) Retrieve summary


Negative test:
1) Retrieve summary for non-existed fiscal year

Verified on localhost:
<img width="1298" alt="Снимок экрана 2019-11-30 в 15 37 12" src="https://user-images.githubusercontent.com/42964285/69900678-84569180-1387-11ea-8934-affe96eea653.png">
<img width="1275" alt="Снимок экрана 2019-11-30 в 15 37 58" src="https://user-images.githubusercontent.com/42964285/69900685-8f112680-1387-11ea-85a6-a1a59aa20de5.png">