### PR TITLE
MODORDERS-350 Update piece schema (receipt date)

### DIFF
--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d6d32a10-cac3-4781-b9fc-2543a96d5917",
+		"_postman_id": "f9851495-974d-47ad-93cc-0aaaf93d90fd",
 		"name": "mod-orders-acq-units",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -566,6 +566,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -651,6 +652,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -784,6 +786,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -1451,6 +1454,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -1705,6 +1709,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -1959,9 +1964,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Positive Tests",
@@ -3555,6 +3562,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -3714,8 +3722,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"notAssignedLineId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"notAssignedLineId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -4209,8 +4216,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"protectedLineId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"protectedLineId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -4283,8 +4289,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"protectedLineId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"protectedLineId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -4493,8 +4498,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"createOpenLineId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"createOpenLineId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -4614,8 +4618,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"notAssignedLineId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"notAssignedLineId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -4670,6 +4673,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -4828,8 +4832,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"lineForUpdateId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"lineForUpdateId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -6586,6 +6589,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -6744,8 +6748,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"lineForDeleteId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"lineForDeleteId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -7607,8 +7610,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"lineForDeleteId\"); ",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"lineForDeleteId\"));",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
 										],
@@ -7877,6 +7879,7 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -8473,6 +8476,7 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						},
 						{
@@ -9864,9 +9868,11 @@
 									"response": []
 								}
 							],
+							"protocolProfileBehavior": {},
 							"_postman_isSubFolder": true
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
@@ -10164,8 +10170,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"lineId_1\");",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"lineId_1\"));",
 											"    piece.receivingStatus = \"Expected\";",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
@@ -10234,8 +10239,7 @@
 											"var piece = {};",
 											"",
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-											"    var piece = utils.preparePoLine(res.json());",
-											"    piece.poLineId = pm.environment.get(\"lineId_2\");",
+											"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"lineId_2\"));",
 											"    piece.receivingStatus = \"Expected\";",
 											"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 											"});"
@@ -10787,6 +10791,7 @@
 							}
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
 			],
@@ -10811,7 +10816,8 @@
 						]
 					}
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Negative Tests",
@@ -11103,8 +11109,7 @@
 									"var piece = {};",
 									"",
 									"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function (err, res) {",
-									"    var piece = utils.preparePoLine(res.json());",
-									"    piece.poLineId = pm.environment.get(\"protectedLineId\"); ",
+									"    var piece = utils.preparePiece(res.json(), pm.environment.get(\"protectedLineId\"));",
 									"    pm.variables.set(\"piece_content\", JSON.stringify(piece));",
 									"});"
 								],
@@ -11165,7 +11170,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Cleanup",
@@ -11317,9 +11323,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		}
 	],
 	"event": [
@@ -11644,6 +11652,16 @@
 					"",
 					"        return poLine;",
 					"    };",
+					"    ",
+					"    /**",
+					"     * Updates sub-objects of the PO Line removing ids and adding missing data.",
+					"     */",
+					"    utils.preparePiece = function(piece, poLineId) {",
+					"       piece.receiptDate = new Date();",
+					"       piece.poLineId = poLineId;",
+					"",
+					"        return piece;",
+					"    };",
 					"",
 					"    /**",
 					"     * Build unit assignment",
@@ -11806,22 +11824,23 @@
 	],
 	"variable": [
 		{
-			"id": "c64c7919-ce69-4de7-892c-086ddc335b07",
+			"id": "8ceabe74-5fbf-4870-bb47-155b16460e9e",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "ac5d54ad-6122-427f-9674-65c5302d6491",
+			"id": "94c536d9-40c9-46b6-a88e-09ffbc39f172",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "9ca30dc2-3f32-408c-a786-3eeba0dca475",
+			"id": "7524ca6d-600d-4b71-b5a0-37b9608ec6e5",
 			"key": "testTenant",
 			"value": "orders_acq_units_test",
 			"type": "string"
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f9851495-974d-47ad-93cc-0aaaf93d90fd",
+		"_postman_id": "67579841-7928-4fc3-85f3-39d2d6af8f63",
 		"name": "mod-orders-acq-units",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -11474,7 +11474,6 @@
 					"                        \"caption\": \"Vol. 1\",",
 					"                        \"createItem\": true,",
 					"                        \"supplement\": false,",
-					"                        \"locationId\": \"\",",
 					"                        \"accessionNumber\": \"1956.1\",",
 					"                        \"itemDescription\": \"This is the piece item checkin\",",
 					"                        \"electronicBookplate\": \"This item is from API tests\",",
@@ -11574,7 +11573,6 @@
 					"        toBeCheckedInTemplate.poLineId = compPoLineId;",
 					"        toBeCheckedInTemplate.checkedIn = 1;",
 					"        checkinPiecesTemplate.id = pieceId;",
-					"        checkinPiecesTemplate.locationId = pm.environment.get(\"newLocationId\");",
 					"         if (typeof checkinStatus === \"undefined\") {",
 					"            checkinPiecesTemplate.itemStatus = \"In Process\";",
 					"        } else {",
@@ -11595,7 +11593,6 @@
 					"        let receivingItemsTemplate = toBeReceivedTemplate.receivedItems.pop();",
 					"        toBeReceivedTemplate.poLineId = compPoLineId;",
 					"        toBeReceivedTemplate.received = 1;",
-					"        receivingItemsTemplate.locationId = pm.environment.get(\"newLocationId\");",
 					"         if (typeof receivingStatus === \"undefined\") {",
 					"            receivingItemsTemplate.itemStatus = \"In Process\";",
 					"        } else {",
@@ -11824,21 +11821,21 @@
 	],
 	"variable": [
 		{
-			"id": "8ceabe74-5fbf-4870-bb47-155b16460e9e",
+			"id": "0e37ec05-6b26-454d-a07d-70bdf06cc4c8",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "94c536d9-40c9-46b6-a88e-09ffbc39f172",
+			"id": "5dc51eab-0b00-4bee-a579-1dfc74e1c079",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "7524ca6d-600d-4b71-b5a0-37b9608ec6e5",
+			"id": "029cfff8-2c29-46d7-9eed-14e3dd42929c",
 			"key": "testTenant",
-			"value": "orders_acq_units_test",
+			"value": "orders_acq_units_test1",
 			"type": "string"
 		}
 	],

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -11821,21 +11821,21 @@
 	],
 	"variable": [
 		{
-			"id": "0e37ec05-6b26-454d-a07d-70bdf06cc4c8",
+			"id": "b068928b-3d48-4831-89eb-ae024a7f88ca",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "5dc51eab-0b00-4bee-a579-1dfc74e1c079",
+			"id": "c59a4775-5d72-4302-8e31-f02c9f8cbbf4",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "029cfff8-2c29-46d7-9eed-14e3dd42929c",
+			"id": "cb331741-3462-4128-b478-b1cc3f3c2ba4",
 			"key": "testTenant",
-			"value": "orders_acq_units_test1",
+			"value": "orders_acq_units_test",
 			"type": "string"
 		}
 	],

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "5694342e-609a-47ec-b8e7-4a821ad39955",
+		"_postman_id": "3ef83e44-160f-4b90-b71c-0d47574591a0",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -15177,7 +15177,7 @@
 													"    order.compositePoLines[0].eresource.createInventory = \"Instance, Holding, Item\";",
 													"    order.compositePoLines[0].physical.createInventory = \"Instance, Holding, Item\";",
 													"    order.compositePoLines[0].title = \"Test title\";",
-													"    order.compositePoLines[0].details.productIds[0].productType = \"Vendor Title Number\";",
+													"    order.compositePoLines[0].details.productIds[0].productIdType = \"Vendor Title Number\";",
 													"    ",
 													"    pm.variables.set(\"orderBody\", JSON.stringify(utils.prepareOrder(order)));",
 													"});"
@@ -15266,7 +15266,7 @@
 													"    order.compositePoLines[0].eresource.createInventory = \"Instance, Holding, Item\";",
 													"    order.compositePoLines[0].physical.createInventory = \"Instance, Holding, Item\";",
 													"    order.compositePoLines[0].title = \"Test title\";",
-													"    order.compositePoLines[0].details.productIds[0].productType = \"Vendor Title Number\";",
+													"    order.compositePoLines[0].details.productIds[0].productIdType = \"Vendor Title Number\";",
 													"    ",
 													"    pm.variables.set(\"orderBody\", JSON.stringify(utils.prepareOrder(order)));",
 													"});"
@@ -18381,6 +18381,79 @@
 								"description": "Create a piece with empty body"
 							},
 							"response": []
+						},
+						{
+							"name": "Create piece with missing receiptDate 422",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"poLineId\", utils.getLastPoLineId());",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/pieces/pieceRecord.json\", function(err, res) {",
+											"    let piece = res.json();",
+											"    delete piece.receiptDate;",
+											"    piece.poLineId = pm.variables.get(\"poLineId\");",
+											"    pm.globals.set(\"pieceRecord\", JSON.stringify(piece));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"pm.test(\"Status code is 422\", function () {",
+											"    pm.response.to.have.status(422);",
+											"});",
+											"",
+											"pm.test(\"Expected errors verification\", function () {",
+											"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+											"    pm.expect(pm.response.json().errors[0].code).to.equal(\"missingReceiptDate\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{pieceRecord}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/pieces",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"pieces"
+									]
+								},
+								"description": "Create a piece with empty body"
+							},
+							"response": []
 						}
 					],
 					"protocolProfileBehavior": {},
@@ -19332,6 +19405,7 @@
 					"        pm.expect(history.pieceFormat, \"Piece format expected\").to.exist;",
 					"        pm.expect(history.poLineReceiptStatus, \"Receipt status expected\").to.exist;",
 					"        pm.expect(history.purchaseOrderId, \"Purchase order id expected\").to.exist;",
+					"        ",
 					"    };",
 					"",
 					"    utils.validatePiece = function(piece) {",
@@ -20333,6 +20407,7 @@
 					"        } else {",
 					"            pieceTemplate.itemId = itemId;",
 					"        }",
+					"        pieceTemplate.receiptDate = new Date();",
 					"        pm.variables.set(\"checkinPoLineId\", compPoLine.id);",
 					"        utils.postRequest(\"/orders/pieces\", pieceTemplate, (err, res) => {",
 					"            pm.test(\"creating piece for check-in \", function() {",
@@ -20661,55 +20736,55 @@
 	],
 	"variable": [
 		{
-			"id": "87c40512-f95e-40f6-bd48-79fcd6ed4608",
+			"id": "908ce5b0-2886-4f2f-8cd3-f005be7e7090",
 			"key": "testTenant",
 			"value": "orders_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "da4d5d2c-1514-4f80-9cae-e4eb27bb7035",
+			"id": "4cd4ebcd-3018-42ae-a678-eb5fc212b967",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "c0de6b91-5ace-4a08-badf-76491a20ff38",
+			"id": "d619a10e-e98b-47b2-ae60-82654b797a95",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "efd75848-11ab-4c44-9585-8cb072b8896e",
+			"id": "83b0643a-3cfb-424a-83b8-cbfb1332c9eb",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "c6838e54-6b58-4e52-b9f1-8ea5704cad03",
+			"id": "cc0c3c4c-ea91-4348-876c-7d92a2dbaea8",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "3fa6422e-5cb4-4dca-a827-bb86cc900688",
+			"id": "ac10a119-ac6f-40c2-a411-a01276cec572",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "e9f14ce6-7f76-4992-848e-795fd8437ae5",
+			"id": "bea3efe4-c2b6-4a37-bba1-1840835a5c17",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "29a49a38-b7b5-4b3a-a120-88505e5dd60c",
+			"id": "17b767d4-c047-428e-ae20-41645b9857e7",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "f0875b71-5056-470a-be7e-551358ac4274",
+			"id": "83bc5775-9694-477c-820c-31cd458a3e43",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"


### PR DESCRIPTION
[MODORDERS-350](https://issues.folio.org/browse/MODORDERS-350)
## Approach
- adding receiptDate for POST Pieces  for mod-orders and mod-orders.acq-units collections
- adding negative case when for piece creation when receiptDate is missing

## Verification
Verified on folio-testing:
![image](https://user-images.githubusercontent.com/41672277/72260729-89645d00-3624-11ea-85b6-6f65a0c97007.png)
![image](https://user-images.githubusercontent.com/41672277/72260737-8ec1a780-3624-11ea-8b4d-4352fe36e972.png)
