### PR TITLE
MODORDERS-349 Make title schema changes to all APIs

### DIFF
--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "67579841-7928-4fc3-85f3-39d2d6af8f63",
+		"_postman_id": "cf643145-9e57-4854-9d81-22cad53faeb5",
 		"name": "mod-orders-acq-units",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -6607,7 +6607,7 @@
 											"    pm.response.to.have.status(201);",
 											"    let jsonData = pm.response.json();",
 											"    pm.expect(jsonData.id).to.exist;",
-											"    pm.environment.set(\"orderForDeleteId\", jsonData.id); ",
+											"    pm.environment.set(\"orderForDeleteId\", jsonData.id);",
 											"});",
 											""
 										],
@@ -6625,6 +6625,7 @@
 											"    let order = utils.prepareOrder(res.json());",
 											"     order.workflowStatus = \"Pending\";",
 											"    order.acqUnitIds = [pm.environment.get(\"deleteProtectUnitId\")];",
+											"    order.compositePoLines.forEach(line => line.isPackage = true);",
 											"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(order));",
 											"});"
 										],
@@ -6680,6 +6681,7 @@
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/compositeLines/minimalContent.json\", function (err, res) {",
 											"    var line = utils.preparePoLine(res.json());",
 											"    line.purchaseOrderId = pm.environment.get(\"orderForDeleteId\"); ",
+											"    line.isPackage = true;",
 											"    pm.variables.set(\"minimal_content_line\", JSON.stringify(line));",
 											"});"
 										],
@@ -7487,6 +7489,7 @@
 											"    order.compositePoLines = [];",
 											"    order.workflowStatus = \"Pending\";",
 											"    order.acqUnitIds = [pm.environment.get(\"deleteOpenUnitId\"), pm.environment.get(\"createOpenUnitId\")];",
+											"    order.compositePoLines.forEach(line => line.isPackage = true);",
 											"    pm.variables.set(\"po_listed_print_monograph\", JSON.stringify(order));",
 											"});"
 										],
@@ -7542,6 +7545,7 @@
 											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/mockdata/compositeLines/minimalContent.json\", function (err, res) {",
 											"    var line = utils.preparePoLine(res.json());",
 											"    line.purchaseOrderId = pm.environment.get(\"orderForDeleteId\"); ",
+											"    line.isPackage = true;",
 											"    pm.variables.set(\"minimal_content_line\", JSON.stringify(line));",
 											"});"
 										],
@@ -11452,7 +11456,7 @@
 					"                    \"barcode\": \"11111111111\",",
 					"                    \"comment\": \"Very important note\",",
 					"                    \"caption\": \"Vol. 1\",",
-					"                    \"itemStatus\": \"Received\",",
+					"                    \"itemStatus\": \"In process\",",
 					"                    \"locationId\": \"fcd64ce1-6995-48f0-840e-89ffa2288371\",",
 					"                    \"pieceId\": \"\"",
 					"                }]",
@@ -11476,8 +11480,7 @@
 					"                        \"supplement\": false,",
 					"                        \"accessionNumber\": \"1956.1\",",
 					"                        \"itemDescription\": \"This is the piece item checkin\",",
-					"                        \"electronicBookplate\": \"This item is from API tests\",",
-					"                        \"itemStatus\": \"\"",
+					"                        \"electronicBookplate\": \"This item is from API tests\"",
 					"                    }]",
 					"              }],",
 					"              \"totalRecords\":1",
@@ -11485,12 +11488,13 @@
 					"    }",
 					"};",
 					"",
+					"",
 					"// Global testing object - used in further tests",
 					"pm.globals.set(\"testData\", testData);",
 					"",
 					"postman.setGlobalVariable(\"loadUtils\", function loadUtils() {",
 					"    let utils = {};",
-					"",
+					"    ",
 					"    /**",
 					"     * Builds Postman Request base data",
 					"     */",
@@ -11574,7 +11578,7 @@
 					"        toBeCheckedInTemplate.checkedIn = 1;",
 					"        checkinPiecesTemplate.id = pieceId;",
 					"         if (typeof checkinStatus === \"undefined\") {",
-					"            checkinPiecesTemplate.itemStatus = \"In Process\";",
+					"            checkinPiecesTemplate.itemStatus = \"In process\";",
 					"        } else {",
 					"            checkinPiecesTemplate.itemStatus = checkinStatus;",
 					"        }",
@@ -11594,7 +11598,7 @@
 					"        toBeReceivedTemplate.poLineId = compPoLineId;",
 					"        toBeReceivedTemplate.received = 1;",
 					"         if (typeof receivingStatus === \"undefined\") {",
-					"            receivingItemsTemplate.itemStatus = \"In Process\";",
+					"            receivingItemsTemplate.itemStatus = \"In process\";",
 					"        } else {",
 					"            receivingItemsTemplate.itemStatus = receivingStatus;",
 					"        }",
@@ -11821,19 +11825,19 @@
 	],
 	"variable": [
 		{
-			"id": "b068928b-3d48-4831-89eb-ae024a7f88ca",
+			"id": "32d04c42-03c0-4dab-8218-d439c022e97d",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "c59a4775-5d72-4302-8e31-f02c9f8cbbf4",
+			"id": "b3973484-ad75-401f-95d3-96e9a916a36a",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "cb331741-3462-4128-b478-b1cc3f3c2ba4",
+			"id": "33b1a108-5796-495a-b0aa-119d56d25a2b",
 			"key": "testTenant",
 			"value": "orders_acq_units_test",
 			"type": "string"

--- a/mod-orders/mod-orders-acq-units.postman_collection.json
+++ b/mod-orders/mod-orders-acq-units.postman_collection.json
@@ -11621,7 +11621,7 @@
 					"\t            \"listUnitPrice\": 1,",
 					"\t            \"quantityPhysical\":1",
 					"\t        },",
-					"\t        \"title\": \"Kayak Fishing in the Northern Gulf Coast\"",
+					"\t        \"titleOrPackage\": \"Kayak Fishing in the Northern Gulf Coast\"",
 					"        };",
 					"    };",
 					"",

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1668,7 +1668,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\",\r\n    \"fiscalYearOneId\": \"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\"\r\n}"
+									"raw": "{\r\n\t\"id\": \"5e4fbdab-f1b1-4be8-9c33-d3c41ec9a695\",\r\n\t\"code\": \"TST-LDG\",\r\n\t\"ledgerStatus\": \"Active\",\r\n\t\"name\": \"Test ledger\",\r\n    \"fiscalYearOneId\": \"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\",\r\n    \"restrictEncumbrance\": false\r\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/ledgers",
@@ -1792,17 +1792,17 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"budgetStatus\": \"Active\",\r\n  \"fundId\": \"{{fundId}}\",\r\n  \"name\": \"Budget for orders API Tests\",\r\n  \"fiscalYearId\":\"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\"\r\n}"
+									"raw": "{\r\n  \"budgetStatus\": \"Active\",\r\n  \"fundId\": \"{{fundId}}\",\r\n  \"name\": \"Budget for orders API Tests\",\r\n  \"fiscalYearId\":\"ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2\",\r\n  \"allocated\": 9999999\r\n}"
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/budgets",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
 									],
 									"port": "{{okapiport}}",
 									"path": [
-										"finance-storage",
+										"finance",
 										"budgets"
 									]
 								},
@@ -11992,7 +11992,7 @@
 											"utils.sendGetRequest(\"/orders/order-lines/\" + checkinPoLineId, (err, res) => {",
 											"    let line = res.json();",
 											"    utils.validateReceiptStatus(line, \"Awaiting Receipt\");",
-											"     utils.validateInventoryItemsReceived(line, 1, \"On Order\");",
+											"     utils.validateInventoryItemsReceived(line, 1, \"On order\");",
 											"    utils.validateReceivingHistoryNumberOfPiecesByStatus(line, 1, \"Expected\");",
 											"});"
 										],
@@ -12008,7 +12008,7 @@
 											"let compPoLine = pm.globals.get(\"checkin_physical_poLine\");",
 											"",
 											"utils.sendGetRequest(\"/orders-storage/pieces?limit=1&query=poLineId==\"+compPoLine.id +\" and format == Physical and receivingStatus == Received\", (err,res) => {",
-											"    utils.prepareCheckinBody(compPoLine,res.json().pieces[0].id,\"On Order\");",
+											"    utils.prepareCheckinBody(compPoLine,res.json().pieces[0].id,\"On order\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -19423,7 +19423,7 @@
 					"                    \"callNumber\": \"BF2050 .M335 1999\",",
 					"                    \"comment\": \"Very important note\",",
 					"                    \"caption\": \"Vol. 1\",",
-					"                    \"itemStatus\": \"Received\",",
+					"                    \"itemStatus\": \"In process\",",
 					"                    \"locationId\": pm.variables.get(\"locationId2\"),",
 					"                    \"pieceId\": \"\"",
 					"                }]",
@@ -19460,8 +19460,7 @@
 					"                            \"locationId\": \"\",",
 					"                            \"accessionNumber\": \"1956.1\",",
 					"                            \"itemDescription\": \"This is the piece item checkin\",",
-					"                            \"electronicBookplate\": \"This item is from API tests\",",
-					"                            \"itemStatus\": \"\"",
+					"                            \"electronicBookplate\": \"This item is from API tests\"",
 					"                        }]",
 					"                }],",
 					"            \"totalRecords\":1",
@@ -19473,7 +19472,7 @@
 					"            \"permanentLoanTypeId\": pm.variables.get(\"loanTypeId\"),",
 					"            \"materialTypeId\": pm.variables.get(\"materialTypeId\"),",
 					"            \"status\": {",
-					"                \"name\": \"On Order\"",
+					"                \"name\": \"On order\"",
 					"            },",
 					"            \"purchaseOrderLineIdentifier\":\"\"",
 					"        }",
@@ -19899,7 +19898,7 @@
 					"     */",
 					"    utils.validateInventoryItemsReceived = function(poLine, expectedQuantity, itemStatus) {",
 					"        let expectedCount = typeof expectedQuantity === \"undefined\" ? utils.calculateExpectedItemsQuantity(poLine) : expectedQuantity;",
-					"        let status = typeof itemStatus === \"undefined\" ? \"Received\" : itemStatus;",
+					"        let status = typeof itemStatus === \"undefined\" ? \"In process\" : itemStatus;",
 					"        utils.sendGetRequest(\"/item-storage/items?limit=100&query=status.name==\" + status + \" and purchaseOrderLineIdentifier==\" + poLine.id, (err, res) => {",
 					"            pm.test(expectedCount + \" Item Records marked as received for PO Line with number=\" + poLine.poLineNumber, function() {",
 					"                let body = res.json();",
@@ -20008,7 +20007,7 @@
 					"     */",
 					"    utils.prepareReceivingRequestForOrder = function(orderId, quantityToReceive, itemStatus) {",
 					"        if (typeof itemStatus === \"undefined\") {",
-					"            itemStatus = \"Received\";",
+					"            itemStatus = \"In process\";",
 					"        }",
 					"        let pieceStatus = (itemStatus === \"On order\") ? \"Received\" : \"Expected\";",
 					"        utils.sendGetRequest(\"/orders/composite-orders/\" + orderId, (err, res) => {",
@@ -20048,7 +20047,7 @@
 					"     */",
 					"    utils.prepareReceivingRequestForPoLineOfFormat = function(orderId, orderFormat, quantityToReceive, itemStatus) {",
 					"        if (typeof itemStatus === \"undefined\") {",
-					"            itemStatus = \"Received\";",
+					"            itemStatus = \"In process\";",
 					"        }",
 					"        let pieceStatus = (itemStatus === \"On order\") ? \"Received\" : \"Expected\";",
 					"        utils.sendGetRequest(\"/orders/composite-orders/\" + orderId, (err, res) => {",
@@ -20078,7 +20077,7 @@
 					"     */",
 					"    utils.prepareReceivingRequest = function(receivingHistory, itemStatus) {",
 					"        if (typeof itemStatus === \"undefined\") {",
-					"            itemStatus = \"Received\";",
+					"            itemStatus = \"In process\";",
 					"        }",
 					"        let isRevertCase = itemStatus === \"On order\";",
 					"",
@@ -20539,7 +20538,7 @@
 					"        checkinPiecesTemplate.id = pieceId;",
 					"        checkinPiecesTemplate.locationId = pm.environment.get(\"locationId1\");",
 					"        if (typeof checkinStatus === \"undefined\") {",
-					"            checkinPiecesTemplate.itemStatus = \"In Process\";",
+					"            checkinPiecesTemplate.itemStatus = \"In process\";",
 					"        } else {",
 					"            checkinPiecesTemplate.itemStatus = checkinStatus;",
 					"        }",
@@ -20864,55 +20863,55 @@
 	],
 	"variable": [
 		{
-			"id": "2e9db8bb-ee78-4a7d-b797-8f9bfcf1f756",
+			"id": "1e712ad4-e09a-48fc-9e58-03950b9b708f",
 			"key": "testTenant",
 			"value": "orders_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "26c06db6-a512-4656-b70d-595eba4f49ed",
+			"id": "7322a606-43c5-4127-856d-f40ea260643e",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "c3e627eb-62d7-49ed-830b-39ccedf76565",
+			"id": "d7994f8c-3861-47c9-b144-f2b78d32953b",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "f564d202-1bac-4be3-9673-6b14b35963fd",
+			"id": "e1387c2b-19f1-4818-a1f3-d14d579d6d30",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "802f58fb-bfe8-4bed-8235-7b10a8df1ce2",
+			"id": "ff86e253-a52e-4414-81cc-f7e9a80de159",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "8f6356ad-e395-4306-9564-1e49b9d80e31",
+			"id": "c4196115-2170-44ab-b56b-a7e2e0451154",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "d13f6e7c-d5f1-4428-9f16-8ada253226f0",
+			"id": "e4cac2ff-d75c-4ed0-bfa8-0ac0c7744857",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "5d245849-93b4-4202-95eb-6fbc6a8af492",
+			"id": "5aab5ba8-dddf-4497-add1-46971246db5f",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "48a47ec0-4648-4d4c-993c-d183c1154284",
+			"id": "2c153401-ee32-4bfb-b3f3-80bb24e6536a",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"

--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0d39991c-1715-467e-9002-9eddebe469d3",
+		"_postman_id": "fbbbf923-13af-4a9b-bd37-29c716f3bbfa",
 		"name": "mod-orders",
 		"description": "Tests for mod-orders",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -3188,6 +3188,7 @@
 													"",
 													"utils.verifyOrderCalculatedInfo(jsonData);",
 													"",
+													"",
 													"pm.test(\"Each order has these optional fields\", function() {",
 													"    pm.expect(jsonData.id).to.exist;",
 													"    pm.globals.set(\"completeOrderId\", jsonData.id); ",
@@ -3388,7 +3389,9 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));",
+													"",
+													"utils.deleteTitlesByLineId(pm.variables.get(\"poLineId\"));"
 												],
 												"type": "text/javascript"
 											}
@@ -3805,7 +3808,10 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
-													"pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));"
+													"pm.variables.set(\"poLineId\", utils.getLastPoLineId(true));",
+													"",
+													"",
+													"utils.deleteTitlesByLineId(pm.variables.get(\"poLineId\"));"
 												],
 												"type": "text/javascript"
 											}
@@ -3818,6 +3824,7 @@
 													"pm.test(\"Status code is 204\", function () {",
 													"    pm.response.to.have.status(204);",
 													"});",
+													"",
 													""
 												],
 												"type": "text/javascript"
@@ -4384,6 +4391,9 @@
 													"let utils = eval(globals.loadUtils);",
 													"pm.variables.set(\"poLineId\", utils.getLastPoLineId());",
 													"",
+													"let completePolineIds = pm.globals.get(\"completePolineIds\") ? JSON.parse(pm.globals.get(\"completePolineIds\")) : [];",
+													"utils.deleteTitlesByLineId(completePolineIds[completePolineIds.length - 2]);",
+													"",
 													"pm.variables.set(\"listUnitPriceUpdate\", 537.96);",
 													"pm.variables.set(\"discountUpdate\", 19.84);",
 													"pm.variables.set(\"discountTypeUpdate\", \"percentage\");",
@@ -4461,7 +4471,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": \"268758test2\",\n  \"reEncumber\": false,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poLineId}}\",\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"{{currencyUpdate}}\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityElectronic\": 0,\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": \"API\",\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": \"268758test2\",\n  \"reEncumber\": false,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"id\": \"{{poLineId}}\",\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"{{currencyUpdate}}\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityElectronic\": 0,\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": \"API\",\n      \"titleOrPackage\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
@@ -4488,11 +4498,15 @@
 											"script": {
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
 													"pm.variables.set(\"listUnitPriceUpdate\", 10.0);",
 													"pm.variables.set(\"additionalCostUpdate\", 5.0);",
 													"pm.variables.set(\"discountUpdate\", 15.01);",
 													"pm.variables.set(\"discountTypeUpdate\", \"amount\");",
 													"pm.variables.set(\"quantityPhysicalUpdate\", 21);",
+													"",
+													"utils.deleteTitlesByLineId(pm.variables.get(\"poLineId\"));",
 													"",
 													"// Expected PO Line's total based on values above",
 													"pm.variables.set(\"expectedPoLineEstimatedPrice\", 199.99);"
@@ -4548,7 +4562,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": {{completeOrderPoNumber}},\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"additionalCost\": {{additionalCostUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"USD\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": \"API\",\n      \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
+											"raw": "{\n  \"approved\": true,\n  \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n  \"notes\": [\n    \"ABCDEFGHIJKLMNO\",\n    \"ABCDEFGHIJKLMNOPQRST\",\n    \"ABCDEFGHIJKLMNOPQRSTUV\"\n  ],\n  \"orderType\": \"One-Time\",\n  \"poNumber\": {{completeOrderPoNumber}},\n  \"reEncumber\": false,\n  \"totalEstimatedPrice\": 100.99,\n  \"vendor\": \"d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1\",\n  \"workflowStatus\": \"Pending\",\n  \"compositePoLines\": [\n    {\n      \"acquisitionMethod\": \"Purchase At Vendor System\",\n      \"alerts\": [\n        {\n          \"alert\": \"Receipt overdue\"\n        }\n      ],\n      \"cancellationRestriction\": false,\n      \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n      \"claims\": [\n        {\n          \"claimed\": false,\n          \"sent\": \"2018-10-09T00:00:00.000Z\",\n          \"grace\": 30\n        }\n      ],\n      \"collection\": false,\n      \"contributors\": [\n        {\n          \"contributor\": \"Ed Mashburn\",\n          \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n        }\n      ],\n      \"cost\": {\n        \"listUnitPrice\": {{listUnitPriceUpdate}},\n        \"additionalCost\": {{additionalCostUpdate}},\n        \"discount\": {{discountUpdate}},\n        \"discountType\": \"{{discountTypeUpdate}}\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}},\n        \"currency\": \"USD\"\n      },\n      \"description\": \"ABCDEFGH\",\n      \"details\": {\n        \"receivingNote\": \"ABCDEFGHIJKL\",\n        \"productIds\": [\n          {\n            \"productId\": \"9780764354113\",\n            \"productIdType\": \"{{identifierTypeId}}\"\n          }\n        ],\n        \"subscriptionFrom\": \"2018-10-09T00:00:00.000Z\",\n        \"subscriptionInterval\": 824,\n        \"subscriptionTo\": \"2020-10-09T00:00:00.000Z\"\n      },\n      \"donor\": \"ABCDEFGHIJKLM\",\n      \"fundDistribution\": [\n        {\n          \"code\": \"HIST\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 80.0,\n          \"encumbrance\": \"eb506834-6c70-4239-8d1a-6414a5b08ac3\"\n        },\n        {\n          \"code\": \"GENRL\",\n          \"fundId\": \"fb7b70f1-b898-4924-a991-0e4b6312bb5f\",\n          \"distributionType\": \"percentage\",\n          \"value\": 20.0,\n          \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\"\n        }\n      ],\n      \"locations\": [{\n        \"locationId\": \"eb2d063a-5b4c-4cab-8db1-5fc5c5941df6\",\n        \"quantityPhysical\": {{quantityPhysicalUpdate}}\n      }],\n      \"orderFormat\": \"Physical Resource\",\n      \"paymentStatus\": \"Awaiting Payment\",\n      \"physical\": {\n        \"volumes\": [\"1\"],\n        \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n        \"receiptDue\": \"2018-10-10T00:00:00.000Z\",\n        \"materialType\": \"{{materialTypeId}}\"\n      },\n      \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n      \"poLineNumber\": \"268758-03\",\n      \"publicationDate\": \"2017\",\n      \"publisher\": \"Schiffer Publishing\",\n      \"receiptDate\": \"2018-10-09T00:00:00.000Z\",\n      \"receiptStatus\": \"Awaiting Receipt\", \n      \"reportingCodes\": [\n        {\n          \"code\": \"CODE1\",\n          \"description\": \"ABCDEF\"\n        },\n        {\n          \"code\": \"CODE2\",\n          \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n        },\n        {\n          \"code\": \"CODE3\",\n          \"description\": \"ABCDE\"\n        }\n      ],\n      \"requester\": \"Leo Bulero\",\n      \"rush\": true,\n      \"selector\": \"ABCD\",\n      \"source\": \"API\",\n      \"titleOrPackage\": \"Kayak Fishing in the Northern Gulf Coast\",\n      \"vendorDetail\": {\n        \"instructions\": \"ABCDEFG\",\n        \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n        \"refNumber\": \"123456-78\",\n        \"refNumberType\": \"Supplier's unique order line reference number\",\n        \"vendorAccount\": \"8910-10\"\n      }\n    }\n  ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders/{{completeOrderId}}",
@@ -6487,8 +6501,8 @@
 											"    // Set new product ids to be sure that new instances will be created",
 											"    order.compositePoLines[0].details.productIds.pop();",
 											"    ",
-											"    order.compositePoLines[0].title = \"Hey! Just API testing checkin\"",
-											"    order.compositePoLines[1].title = \"Hey! Just API testing checkin with no items\"",
+											"    order.compositePoLines[0].titleOrPackage = \"Hey! Just API testing checkin\"",
+											"    order.compositePoLines[1].titleOrPackage = \"Hey! Just API testing checkin with no items\"",
 											"    ",
 											"    //set create Inventory so that no item interaction is necessary",
 											"    order.compositePoLines[1].eresource.createInventory = \"Instance, Holding\";",
@@ -6554,6 +6568,89 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{{poForTestingCheckin}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"orders",
+										"composite-orders"
+									]
+								},
+								"description": "Create a purchase order in Open status based on `po_listed_print_monograph.json` from mod-orders. This also should trigger interraction with Inventory (based on [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66), [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67), [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) and [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117)).\nThe order has two lines: \n- the first line is of `P/E Mix` format, 3 locations, 3 physical + 1 electronic (create inventory is `true`) items in total.\n- the second line is of `Electronic Resources` format, 2 location, 3 items, create inventory is `true`, checkinItems is `true`."
+							},
+							"response": []
+						},
+						{
+							"name": "Create Open order. POLines with isPackage = true",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/po_listed_print_monograph.json\", (err, res) => {",
+											"    let order  = res.json();",
+											"    order.workflowStatus = \"Open\";",
+											"    order = utils.deletePoNumber(order);",
+											"    let line = order.compositePoLines[0];",
+											"    line.isPackage = true;",
+											"    // Set checkingItems flag",
+											"    order.compositePoLines = [line];",
+											"    ",
+											"    pm.variables.set(\"poListedPrintMonographForPartialCheckIn\", JSON.stringify(utils.prepareOrder(order)));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"var jsonData = {};",
+											" ",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    jsonData = pm.response.json();",
+											"});",
+											"",
+											"pm.test(\"po_lines and corresponding Inventory not entities exist\", function () {",
+											"    utils.validatePoLines(jsonData, 1);",
+											"});",
+											"",
+											"utils.validateWorkflowStatus(jsonData);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{poListedPrintMonographForPartialCheckIn}}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -9889,7 +9986,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"vendor\": \"{{activeVendorId}}\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"{{identifierTypeId}}\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n        \t\t\t\"fundId\": \"{{fundId}}\",\n        \t\t\t\"distributionType\": \"percentage\",\n        \t\t\t\"value\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n        \t\t\t\"fundId\": \"{{fundId}}\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n        \t\t\t\"distributionType\": \"percentage\",\n        \t\t\t\"value\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"{{locationId1}}\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"{{locationId2}}\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialTypeId}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": \"API\",\n            \"title\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
+											"raw": "{\n    \"id\": \"{{randomUUId}}\",\n    \"approved\": true,\n    \"assignedTo\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\",\n    \"notes\": [\n        \"ABCDEFGHIJKLMNO\",\n        \"ABCDEFGHIJKLMNOPQRST\",\n        \"ABCDEFGHIJKLMNOPQRSTUV\"\n    ],\n    \"poNumber\": \"PIECE100674545\",\n    \"orderType\": \"One-Time\",\n    \"reEncumber\": false,\n    \"totalEstimatedPrice\": 152.63,\n    \"totalItems\": 6,\n    \"workflowStatus\": \"Pending\",\n    \"vendor\": \"{{activeVendorId}}\",\n    \"compositePoLines\": [\n        {\n            \"id\": \"4186d931-3965-4794-bfbf-a398944127c2\",\n            \"acquisitionMethod\": \"Purchase At Vendor System\",\n            \"alerts\": [\n                {\n                    \"id\": \"a8129c90-208d-4a0d-aba1-71faa188fe84\",\n                    \"alert\": \"Receipt overdue\"\n                }\n            ],\n            \"cancellationRestriction\": false,\n            \"cancellationRestrictionNote\": \"ABCDEFGHIJKLMNOPQRSTUVW\",\n            \"claims\": [\n                {\n                    \"claimed\": false,\n                    \"sent\": \"2018-10-09T00:00:00.000+0000\",\n                    \"grace\": 30\n                }\n            ],\n            \"collection\": false,\n            \"contributors\": [\n                {\n                    \"contributor\": \"Ed Mashburn\",\n                    \"contributorNameTypeId\": \"{{contributorNameTypeId}}\"\n                }\n            ],\n            \"cost\": {\n                \"listUnitPrice\": 24.99,\n                \"currency\": \"USD\",\n                \"additionalCost\": 10,\n                \"discount\": 5,\n                \"discountType\": \"percentage\",\n                \"quantityPhysical\": 3,\n                \"quantityElectronic\": 0,\n                \"poLineEstimatedPrice\": 81.22\n            },\n            \"description\": \"ABCDEFGH\",\n            \"details\": {\n                \"receivingNote\": \"ABCDEFGHIJKL\",\n                \"productIds\": [\n                    {\n                        \"productId\": \"9780764354113\",\n                        \"productIdType\": \"{{identifierTypeId}}\"\n                    }\n                ],\n                \"subscriptionFrom\": \"2018-10-09T00:00:00.000+0000\",\n                \"subscriptionInterval\": 824,\n                \"subscriptionTo\": \"2020-10-09T00:00:00.000+0000\"\n            },\n            \"donor\": \"ABCDEFGHIJKLM\",\n            \"fundDistribution\": [\n                {\n                    \"code\": \"HIST\",\n        \t\t\t\"fundId\": \"{{fundId}}\",\n        \t\t\t\"distributionType\": \"percentage\",\n        \t\t\t\"value\": 80\n                },\n                {\n                    \"code\": \"GENRL\",\n        \t\t\t\"fundId\": \"{{fundId}}\",\n                    \"encumbrance\": \"0466cb77-0344-43c6-85eb-0a64aa2934e5\",\n        \t\t\t\"distributionType\": \"percentage\",\n        \t\t\t\"value\": 20\n                }\n            ],\n            \"locations\": [\n                {\n                    \"locationId\": \"{{locationId1}}\",\n                    \"quantity\": 1,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 1\n                },\n                {\n                    \"locationId\": \"{{locationId2}}\",\n                    \"quantity\": 2,\n                    \"quantityElectronic\": 0,\n                    \"quantityPhysical\": 2\n                }\n            ],\n            \"orderFormat\": \"Physical Resource\",\n            \"paymentStatus\": \"Awaiting Payment\",\n            \"physical\": {\n                \"materialSupplier\": \"73d14bc5-d131-48c6-b380-f8e62f63c8b6\",\n                \"receiptDue\": \"2018-10-10T00:00:00.000+0000\",\n                \"volumes\": [\n                    \"vol.1\"\n                ],\n                \"materialType\": \"{{materialTypeId}}\"\n            },\n            \"poLineDescription\": \"ABCDEFGHIJKLMNOPQRSTUVWXY\",\n            \"publicationDate\": \"2017\",\n            \"publisher\": \"Schiffer Publishing\",\n            \"purchaseOrderId\": \"8b854f27-06cf-41ed-a7cb-d00d5d8fe5e4\",\n            \"receiptStatus\": \"Pending\",\n            \"reportingCodes\": [\n                {\n                    \"id\": \"9f49a9b0-5868-45ac-a2ec-c5a405311f4a\",\n                    \"code\": \"CODE1\",\n                    \"description\": \"ABCDEF\"\n                },\n                {\n                    \"id\": \"4bf527d2-0a01-41ec-bb56-eb660f970248\",\n                    \"code\": \"CODE2\",\n                    \"description\": \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n                },\n                {\n                    \"id\": \"8fd796e5-6b8d-4f60-9302-4071e9e844da\",\n                    \"code\": \"CODE3\",\n                    \"description\": \"ABCDE\"\n                }\n            ],\n            \"requester\": \"Leo Bulero\",\n            \"rush\": true,\n            \"selector\": \"ABCD\",\n            \"source\": \"API\",\n            \"titleOrPackage\": \"Kayak Fishing in the Northern Gulf Coast\",\n            \"vendorDetail\": {\n                \"instructions\": \"ABCDEFG\",\n                \"noteFromVendor\": \"ABCDEFGHIKJKLMNOP\",\n                \"refNumber\": \"123456-78\",\n                \"refNumberType\": \"Supplier's unique order line reference number\",\n                \"vendorAccount\": \"8910-10\"\n            },\n            \"metadata\": {\n                \"createdDate\": \"2010-10-08T03:53:00.000+0000\",\n                \"createdByUserId\": \"ab18897b-0e40-4f31-896b-9c9adc979a88\"\n            }\n        }\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/composite-orders",
@@ -15166,6 +15263,7 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
+													"const uuidv4 = require('uuid');",
 													"",
 													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/print_monograph_for_create_inventory_test.json\", (err, res) => {",
 													"    let order  = res.json();",
@@ -15176,8 +15274,8 @@
 													"    order.compositePoLines[0].id = JSON.parse(globals.poLineForNegativeTests).id;",
 													"    order.compositePoLines[0].eresource.createInventory = \"Instance, Holding, Item\";",
 													"    order.compositePoLines[0].physical.createInventory = \"Instance, Holding, Item\";",
-													"    order.compositePoLines[0].title = \"Test title\";",
-													"    order.compositePoLines[0].details.productIds[0].productIdType = \"Vendor Title Number\";",
+													"    order.compositePoLines[0].titleOrPackage = \"Test title\";",
+													"    order.compositePoLines[0].details.productIds[0].productIdType = uuid.v4();",
 													"    ",
 													"    pm.variables.set(\"orderBody\", JSON.stringify(utils.prepareOrder(order)));",
 													"});"
@@ -15255,9 +15353,10 @@
 												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
 												"exec": [
 													"let utils = eval(globals.loadUtils);",
+													"const uuidv4 = require('uuid');",
 													"",
 													"pm.sendRequest(pm.variables.get(\"mod-ordersResourcesURL\") + \"/print_monograph_for_create_inventory_test.json\", (err, res) => {",
-													"    let order  = res.json();",
+													"    let order  = utils.prepareOrder(res.json());",
 													"    order.workflowStatus = \"Open\";",
 													"    order.poNumber = \"loanType2\";",
 													"    ",
@@ -15265,10 +15364,10 @@
 													"    order.compositePoLines[0].id = JSON.parse(globals.poLineForNegativeTests).id;",
 													"    order.compositePoLines[0].eresource.createInventory = \"Instance, Holding, Item\";",
 													"    order.compositePoLines[0].physical.createInventory = \"Instance, Holding, Item\";",
-													"    order.compositePoLines[0].title = \"Test title\";",
-													"    order.compositePoLines[0].details.productIds[0].productIdType = \"Vendor Title Number\";",
+													"    order.compositePoLines[0].titleOrPackage = \"Test title\";",
+													"    order.compositePoLines[0].details.productIds[0].productIdType = uuid.v4();",
 													"    ",
-													"    pm.variables.set(\"orderBody\", JSON.stringify(utils.prepareOrder(order)));",
+													"    pm.variables.set(\"orderBody\", JSON.stringify(order));",
 													"});"
 												],
 												"type": "text/javascript"
@@ -15437,7 +15536,7 @@
 													"    json = res.json();",
 													"    json.compositePoLines[0].acquisitionMethod = \"Exchange\";",
 													"    json.compositePoLines[0].rush = true;",
-													"    json.compositePoLines[0].title = \"Changing Title\";",
+													"    json.compositePoLines[0].titleOrPackage = \"Changing Title\";",
 													"    pm.variables.set(\"po_with_protected_fields\", JSON.stringify(json));",
 													"});",
 													""
@@ -16402,7 +16501,7 @@
 													"let line = utils.buildPoLineWithMinContent(globals.negativeTestsPendingOrderId);",
 													"delete line.source;",
 													"delete line.cost;",
-													"delete line.title;",
+													"delete line.titleOrPackage;",
 													"delete line.orderFormat;",
 													"delete line.acquisitionMethod;",
 													"pm.variables.set(\"line_body\", JSON.stringify(line));"
@@ -19401,7 +19500,6 @@
 					"        pm.expect(history.id, \"Piece id expected\").to.exist;",
 					"        pm.expect(history.dateOrdered, \"Order date expected\").to.exist;",
 					"        pm.expect(history.checkin, \"Checkin expected\").to.exist;",
-					"        pm.expect(history.instanceId, \"Instance id expected\").to.exist;",
 					"        pm.expect(history.poLineId, \"PO Line id expected\").to.exist;",
 					"        pm.expect(history.poLineNumber, \"PO Line number expected\").to.exist;",
 					"        pm.expect(history.pieceFormat, \"Piece format expected\").to.exist;",
@@ -19558,7 +19656,7 @@
 					"                \"listUnitPrice\": 1,",
 					"                \"quantityPhysical\":1",
 					"            },",
-					"            \"title\": \"Kayak Fishing in the Northern Gulf Coast\"",
+					"            \"titleOrPackage\": \"Kayak Fishing in the Northern Gulf Coast\"",
 					"        };",
 					"    };",
 					"",
@@ -19589,7 +19687,6 @@
 					"                    utils.validatePoLinesInventoryLinks(poLine);",
 					"                } else {",
 					"                    utils.verifyNoInventoryItemsExist(poLine);",
-					"                    pm.expect(poLine.instanceId).to.not.exist;",
 					"                }",
 					"                // Validate that expected piece quantity created of expected format",
 					"                utils.validatePieceRecords(poLine, checkInventory);",
@@ -19608,29 +19705,33 @@
 					"    utils.validatePoLinesInventoryLinks = function(poLine) {",
 					"        // Instance should created only",
 					"        if (!utils.inventoryUpdateNotRequired(poLine)) {",
-					"            pm.expect(poLine.instanceId, \"Instance id is expected\").to.exist;",
-					"            utils.sendGetRequest(\"/instance-storage/instances/\" + poLine.instanceId, (err, res) => {",
-					"                pm.test(\"Instance Record exist for PO Line with number=\" + poLine.poLineNumber, () => {",
-					"                    let instance = res.json();",
-					"                    pm.expect(instance).to.exist;",
-					"",
-					"                    //Check if holdings record is created",
-					"                    utils.validateHoldingsRecord(poLine);",
-					"                    // Now check items",
-					"                    utils.validateInventoryItems(poLine);",
-					"",
-					"                    // Now validate expected instance's content",
-					"                    utils.validateInstanceContent(instance, poLine);",
+					"            utils.sendGetRequest(\"/orders/titles?query=poLineId==\" + poLine.id, (err, res) => {",
+					"                let title = res.json().titles[0];",
+					"                utils.sendGetRequest(\"/instance-storage/instances/\" + title.instanceId, (err1, res1) =>{",
+					"                    pm.test(\"Instance Record exist for PO Line with number=\" + poLine.poLineNumber, () => {",
+					"                        let instance = res1.json();",
+					"                        pm.expect(instance).to.exist;",
+					"    ",
+					"                        //Check if holdings record is created",
+					"                        utils.validateHoldingsRecord(poLine);",
+					"                        // Now check items",
+					"                        utils.validateInventoryItems(poLine);",
+					"    ",
+					"                        // Now validate expected instance's content",
+					"                        utils.validateInstanceContent(instance, poLine);",
+					"                    });",
+					"                    pm.expect(title.instanceId, \"Instance id is expected\").to.exist;",
 					"                });",
 					"            });",
+					"            ",
+					"            ",
 					"        } else {",
 					"            utils.verifyNoInventoryItemsExist(poLine);",
-					"            pm.expect(poLine.instanceId).to.not.exist;",
 					"        }",
 					"    };",
 					"",
 					"    utils.validateInstanceContent = function(instance, poLine) {",
-					"        pm.expect(instance.title, \"Instance's title is not the same as PO Line's\").to.equal(poLine.title);",
+					"        pm.expect(instance.title, \"Instance's title is not the same as PO Line's\").to.equal(poLine.titleOrPackage);",
 					"",
 					"        let ordersConfigs = pm.environment.has(\"current-orders-configs\") ? pm.environment.get(\"current-orders-configs\") : [];",
 					"",
@@ -19855,6 +19956,10 @@
 					"    };",
 					"",
 					"    utils.inventoryUpdateNotRequired = function(compPOL) {",
+					"        if(compPOL.isPackage === true) {",
+					"            return true;",
+					"        }",
+					"        ",
 					"        // in case of \"Other\" order format check Physical createInventory value only",
 					"        if (compPOL.orderFormat === \"Other\") {",
 					"            return compPOL.physical == null || compPOL.physical.createInventory === \"None\";",
@@ -20091,7 +20196,7 @@
 					"     * The logic is based on MODORDERS-100, MODORDERS-194",
 					"     */",
 					"    utils.calculateExpectedPiecesQuantity = function(poLine, pieceFormat) {",
-					"        if (poLine.receiptStatus === \"Receipt Not Required\" || poLine.checkinItems) {",
+					"        if (poLine.receiptStatus === \"Receipt Not Required\" || poLine.checkinItems || poLine.isPackage) {",
 					"            return 0;",
 					"        }",
 					"        switch (poLine.orderFormat) {",
@@ -20237,7 +20342,7 @@
 					"        pm.expect(poLine.selector, \"selector expected\").to.exist;",
 					"        pm.expect(poLine.source, \"source expected\").to.exist;",
 					"        pm.expect(poLine.tags, \"tags expected\").to.exist;",
-					"        pm.expect(poLine.title, \"title expected\").to.exist;",
+					"        pm.expect(poLine.titleOrPackage, \"title expected\").to.exist;",
 					"        pm.expect(poLine.vendorDetail, \"vendorDetail expected\").to.exist;",
 					"    };",
 					"",
@@ -20271,7 +20376,7 @@
 					"        pm.expect(poLine.requester, \"requester not expected\").to.not.exist;",
 					"        pm.expect(poLine.selector, \"selector not expected\").to.not.exist;",
 					"        pm.expect(poLine.tags, \"tags should be empty\").to.not.exist;",
-					"        pm.expect(poLine.title, \"title expected\").to.exist;",
+					"        pm.expect(poLine.titleOrPackage, \"title expected\").to.exist;",
 					"        pm.expect(poLine.vendorDetail, \"vendorDetail not expected\").to.not.exist;",
 					"    };",
 					"",
@@ -20556,6 +20661,26 @@
 					"            });",
 					"    };",
 					"    /* END - Functions to work with mod-configuration */",
+					"    ",
+					"    /**",
+					"     * Delete titles by poLine id",
+					"     *",
+					"     */",
+					"    utils.deleteTitlesByLineId = function(poLineId) {",
+					"        utils.sendGetRequest(\"/orders/titles?query=poLineId==\" + poLineId, (err, res) => {",
+					"            let titles = res.json().titles;",
+					"            titles.forEach(title => {",
+					"                const timerId = setTimeout(() => {}, 60000);",
+					"                utils.processDeleteRequest(\"/orders/titles/\" + title.id)",
+					"                .then(result => clearTimeout(timerId))",
+					"                .catch(err => {",
+					"                    console.log(\"Error happened on Items deletion:\", err);",
+					"                    clearTimeout(timerId);",
+					"                });",
+					"            });",
+					"            ",
+					"        });",
+					"    };",
 					"",
 					"    /**",
 					"     * Sends GET request and uses passed handler to handle result",
@@ -20739,55 +20864,55 @@
 	],
 	"variable": [
 		{
-			"id": "8f4db74f-dca6-4273-8bf4-c1d692c7c069",
+			"id": "2e9db8bb-ee78-4a7d-b797-8f9bfcf1f756",
 			"key": "testTenant",
 			"value": "orders_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "f7d1b8ec-8efd-4b18-87f5-a0c34759ffa8",
+			"id": "26c06db6-a512-4656-b70d-595eba4f49ed",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "fa09edcf-6d7b-4401-ab34-79de1ad9bf7a",
+			"id": "c3e627eb-62d7-49ed-830b-39ccedf76565",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "a45c9a0b-cb3e-4f83-bf4a-e909d84fe774",
+			"id": "f564d202-1bac-4be3-9673-6b14b35963fd",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "e4213544-c034-40a7-9329-92a87ca60c2e",
+			"id": "802f58fb-bfe8-4bed-8235-7b10a8df1ce2",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "6fee3a35-58b9-4953-a437-f05002f7aa79",
+			"id": "8f6356ad-e395-4306-9564-1e49b9d80e31",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "6d9cc39a-b362-4fea-ba4a-b6a1add3ac8b",
+			"id": "d13f6e7c-d5f1-4428-9f16-8ada253226f0",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "6eb34276-0dca-4092-ad62-84933f728e71",
+			"id": "5d245849-93b4-4202-95eb-6fbc6a8af492",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "88b46f0e-70e9-4f36-b0aa-3602031b2d27",
+			"id": "48a47ec0-4648-4d4c-993c-d183c1154284",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"


### PR DESCRIPTION
[MODORDERS-349](https://issues.folio.org/browse/MODORDERS-349)
## Approach
- updated test according to poLine schema changes
- fixed the ledger, budget records to be able create an encumbrance upon opening an order
- fixed test after breaking changes in inventory-storage related to item status

## Verification
folio-testing:
![image](https://user-images.githubusercontent.com/41672277/73068790-293fa780-3ebd-11ea-88b0-a38582ed7bd7.png)
![image](https://user-images.githubusercontent.com/41672277/73068801-2e9cf200-3ebd-11ea-8026-c0105f553f31.png)
