### PR TITLE
MODKBEKBJ-353 Add API tests

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -12514,7 +12514,7 @@
 															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
 															"});",
 															"",
-															"//Test that object has the expected keys ",
+															"//Test that object has the expected keys",
 															"pm.test('expected keys are present in response object', function() {",
 															"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
 															"});",
@@ -12717,7 +12717,7 @@
 												],
 												"body": {
 													"mode": "raw",
-													"raw": "{\n  \"data\": {\n    \"id\": \"{{custom-package-id-created-in-post}}\",\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n      \"contentType\": \"Print\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isCustom\": true,\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"allowKbToAddTitles\": false,\n      \"proxy\": {\n        \"id\": \"<n>\",\n        \"inherited\": false\n      },\n      \"accessTypeId\": \"{{access-type-id2}}\"\n    }\n  }\n}"
+													"raw": "{\n    \"data\": {\n        \"id\": \"{{custom-package-id-created-in-post}}\",\n        \"type\": \"packages\",\n        \"attributes\": {\n            \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n            \"contentType\": \"Print\",\n            \"customCoverage\": {\n                \"beginCoverage\": \"2003-01-01\",\n                \"endCoverage\": \"2003-12-01\"\n            },\n            \"isCustom\": true,\n            \"isSelected\": true,\n            \"visibilityData\": {\n                \"isHidden\": true\n            },\n            \"allowKbToAddTitles\": false,\n            \"proxy\": {\n                \"id\": \"<n>\",\n                \"inherited\": false\n            },\n            \"accessTypeId\": \"{{access-type-id2}}\"\n        }\n    }\n}"
 												},
 												"url": {
 													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
@@ -13519,6 +13519,121 @@
 											"response": []
 										},
 										{
+											"name": "update managed package access type",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6b350358-c50d-431a-8891-635afafb9d77",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 200",
+															"pm.test(\"Status is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Test that object has the expected keys",
+															"pm.test('expected keys are present in response object', function() {",
+															"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+															"});",
+															"",
+															"//Test that id matches what was provided in query",
+															"pm.test('id matches as provided in query', function(){",
+															"    pm.expect(response.data.id).eq(pm.variables.get('packageId'));",
+															"});    ",
+															"",
+															"//Test that type is packages",
+															"pm.test('type is packages', function(){",
+															"    pm.expect(response.data.type).eq('packages');",
+															"});",
+															"    ",
+															"//Test that data.attributes has expected attributes",
+															"pm.test('expected data.attributes are present', function() {",
+															"    pm.expect(response.data.attributes).to.be.an('object');",
+															"    pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\",\"isSelected\",\"name\", \"packageId\", ",
+															"    \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\",\"proxy\");",
+															"});",
+															"",
+															"",
+															"//Test that isSelected matches as provided in request",
+															"pm.test('isSelected matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.isSelected).to.be.true;",
+															"});",
+															"",
+															"//Test that visibilityData matches as provided in request",
+															"pm.test('visibilityData matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.visibilityData.isHidden).to.be.true;",
+															"});",
+															"",
+															"//Test that allowKbToAddTitles matches as provided in request",
+															"pm.test('allowKbToAddTitles matches as provided in request', function() {",
+															"    pm.expect(response.data.attributes.allowKbToAddTitles).to.be.true;",
+															"});",
+															"",
+															"//Test that resources are not included in relationships",
+															"pm.test('relationships meta should not include resources', function() {",
+															"    pm.expect(response.data.relationships.resources.meta.included).to.be.false;",
+															"});",
+															"",
+															"//Test that access type assigned",
+															"pm.test('access type should be assigned', function() {",
+															"    pm.expect(response.data.relationships.accessType.meta.included).to.be.true;",
+															"    pm.expect(response.data.relationships.accessType.data.id).to.be.equal(pm.environment.get(\"access-type-id2\"));",
+															"    pm.expect(response.included[0].id).to.be.equal(pm.environment.get(\"access-type-id2\"));",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"id\": \"{{packageId}}\",\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"contentType\": \"E-Book\",\n      \"accessTypeId\": \"{{access-type-id2}}\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-12\",\n        \"endCoverage\": \"2018-09-13\"\n      },\n      \"isCustom\": false,\n      \"isSelected\": true,\n      \"name\": \"ABC-CLIO eBook Collection\",\n      \"visibilityData\": {\n        \"isHidden\": true,\n        \"reason\": \"\"\n      },\n      \"allowKbToAddTitles\": true,\n      \"proxy\": {\n        \"id\": \"<n>\",\n        \"inherited\": false\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
 											"name": "update managed package with isFullPackage=false",
 											"event": [
 												{
@@ -13678,6 +13793,78 @@
 								{
 									"name": "Negative",
 									"item": [
+										{
+											"name": "invalid access type",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6b350358-c50d-431a-8891-635afafb9d77",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].message).to.contains('must match');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"id\": \"{{packageId}}\",\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"contentType\": \"E-Book\",\n      \"accessTypeId\": \"invalid-id\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-12\",\n        \"endCoverage\": \"2018-09-13\"\n      },\n      \"isCustom\": false,\n      \"isSelected\": true,\n      \"name\": \"ABC-CLIO eBook Collection\",\n      \"visibilityData\": {\n        \"isHidden\": true,\n        \"reason\": \"\"\n      },\n      \"allowKbToAddTitles\": true,\n      \"proxy\": {\n        \"id\": \"<n>\",\n        \"inherited\": false\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
 										{
 											"name": "invalid dates for coverage",
 											"event": [
@@ -13984,6 +14171,162 @@
 												"body": {
 													"mode": "raw",
 													"raw": "{\n  \"data\": {\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"isCustom\": false,\n      \"isSelected\": true,\n      \"visibilityData\": {\n        \"isHidden\": true\n      },\n      \"allowKbToAddTitles\": true,\n      \"customCoverage\": {\n        \"beginCoverage\": 13-08-2018,\n        \"endCoverage\": 13-09-2018\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "missing access type",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6b350358-c50d-431a-8891-635afafb9d77",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 400",
+															"pm.test(\"Status is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.contains('Access type not found by id');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"id\": \"{{packageId}}\",\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"contentType\": \"E-Book\",\n      \"accessTypeId\": \"9b2f5369-04b0-4a54-b1e5-89713ab19188\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-12\",\n        \"endCoverage\": \"2018-09-13\"\n      },\n      \"isCustom\": false,\n      \"isSelected\": true,\n      \"name\": \"ABC-CLIO eBook Collection\",\n      \"visibilityData\": {\n        \"isHidden\": true,\n        \"reason\": \"\"\n      },\n      \"allowKbToAddTitles\": true,\n      \"proxy\": {\n        \"id\": \"<n>\",\n        \"inherited\": false\n      }\n    }\n  }\n}"
+												},
+												"url": {
+													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+													"protocol": "{{protocol}}",
+													"host": [
+														"{{url}}"
+													],
+													"port": "{{okapiport}}",
+													"path": [
+														"eholdings",
+														"packages",
+														"{{packageId}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "not selected",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"id": "6b350358-c50d-431a-8891-635afafb9d77",
+														"exec": [
+															"pm.test(\"success test\", function() {",
+															"    pm.response.to.be.json;",
+															"});",
+															"",
+															"let response = pm.response.json();",
+															"",
+															"//Check that status is 422",
+															"pm.test(\"Status is 422\", function () {",
+															"    pm.response.to.have.status(422);",
+															"});",
+															"",
+															"//Validate response against json api schema",
+															"pm.test(\"Validate schema\", function () {",
+															"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+															"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+															"});",
+															"",
+															"//Ensure that errors array is not empty",
+															"if(response.errors) {",
+															"    pm.test('Ensure that errors array is not empty', function() {",
+															"        pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+															"    });",
+															"",
+															"    //Test that we get expected error message",
+															"    pm.test('Ensure that we get expected error message', function() {",
+															"        pm.expect(response.errors[0].title).to.contains('Package is not updatable');",
+															"    }); ",
+															"}",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "x-okapi-tenant",
+														"value": "{{xokapitenant}}"
+													},
+													{
+														"key": "x-okapi-token",
+														"value": "{{xokapitoken}}"
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/vnd.api+json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": " {\n  \"data\": {\n    \"id\": \"{{packageId}}\",\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"contentType\": \"E-Book\",\n      \"accessTypeId\": \"{{access-type-id2}}\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-12\",\n        \"endCoverage\": \"2018-09-13\"\n      },\n      \"isCustom\": false,\n      \"isSelected\": false,\n      \"name\": \"ABC-CLIO eBook Collection\",\n      \"visibilityData\": {\n        \"isHidden\": true,\n        \"reason\": \"\"\n      },\n      \"allowKbToAddTitles\": true,\n      \"proxy\": {\n        \"id\": \"<n>\",\n        \"inherited\": false\n      }\n    }\n  }\n}"
 												},
 												"url": {
 													"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
@@ -14338,7 +14681,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post-valid2}}",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -14347,7 +14690,7 @@
 											"path": [
 												"eholdings",
 												"packages",
-												"{{custom-package-id-created-in-post}}"
+												"{{custom-package-id-created-in-post-valid2}}"
 											]
 										}
 									},
@@ -30990,6 +31333,148 @@
 					"name": "tear-down packages",
 					"item": [
 						{
+							"name": "Unassign access mapping from cusom package",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "6b350358-c50d-431a-8891-635afafb9d77",
+										"exec": [
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.json;",
+											"});",
+											"",
+											"let response = pm.response.json();",
+											"",
+											"//Check that status is 200",
+											"pm.test(\"Status is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Validate schema\", function () {",
+											"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+											"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+											"});",
+											"",
+											"//Test that access type unassigned",
+											"pm.test('access type should be unassigned', function() {",
+											"    pm.expect(response.data.relationships).not.to.have.property('accessType');",
+											"    pm.expect(response.included.length).to.be.equal(0);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.api+json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": " {\n  \"data\": {\n    \"id\": \"{{custom-package-id-created-in-post}}\",\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"contentType\": \"E-Journal\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2003-01-01\",\n        \"endCoverage\": \"2003-12-01\"\n      },\n      \"isCustom\": true,\n      \"isSelected\": true,\n      \"name\": \"custom-packages-{{custom-package-one-uuid}}\",\n      \"visibilityData\": {\n        \"isHidden\": false,\n        \"reason\": \"\"\n      },\n      \"allowKbToAddTitles\": false,\n      \"proxy\": {\n        \"id\": \"<n>\",\n        \"inherited\": false\n      }\n    }\n  }\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"packages",
+										"{{custom-package-id-created-in-post}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unassign access mapping from managed package",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "6b350358-c50d-431a-8891-635afafb9d77",
+										"exec": [
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.json;",
+											"});",
+											"",
+											"let response = pm.response.json();",
+											"",
+											"//Check that status is 200",
+											"pm.test(\"Status is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Validate schema\", function () {",
+											"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+											"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+											"});",
+											"",
+											"//Test that access type unassigned",
+											"pm.test('access type should be unassigned', function() {",
+											"    pm.expect(response.data.relationships).not.to.have.property('accessType');",
+											"    pm.expect(response.included.length).to.be.equal(0);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.api+json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": " {\n  \"data\": {\n    \"id\": \"{{packageId}}\",\n    \"type\": \"packages\",\n    \"attributes\": {\n      \"contentType\": \"E-Book\",\n      \"customCoverage\": {\n        \"beginCoverage\": \"2018-08-12\",\n        \"endCoverage\": \"2018-09-13\"\n      },\n      \"isCustom\": false,\n      \"isSelected\": true,\n      \"name\": \"ABC-CLIO eBook Collection\",\n      \"visibilityData\": {\n        \"isHidden\": true,\n        \"reason\": \"\"\n      },\n      \"allowKbToAddTitles\": true,\n      \"proxy\": {\n        \"id\": \"<n>\",\n        \"inherited\": false\n      }\n    }\n  }\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{packageId}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"packages",
+										"{{packageId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Delete custom package created in post 1",
 							"event": [
 								{
@@ -31091,7 +31576,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post-valid2}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-id-created-in-post}}",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -31100,7 +31585,7 @@
 									"path": [
 										"eholdings",
 										"packages",
-										"{{custom-package-id-created-in-post-valid2}}"
+										"{{custom-package-id-created-in-post}}"
 									]
 								},
 								"description": "Delete custom package created in post."
@@ -32047,31 +32532,31 @@
 	],
 	"variable": [
 		{
-			"id": "be165c82-1ea8-49b6-86f4-884d39eaaa08",
+			"id": "d81a96c3-c763-420f-a309-9a494340e5ff",
 			"key": "custid",
 			"value": "apidvgvmt",
 			"type": "string"
 		},
 		{
-			"id": "be0981e9-f8af-4cbd-ae24-8709157e9e24",
+			"id": "06d96c27-1da5-4c9a-85ae-64082abc55aa",
 			"key": "packageId",
 			"value": "583-4345",
 			"type": "string"
 		},
 		{
-			"id": "ee7a9e92-040b-45b5-bb7a-759669b29500",
+			"id": "d23ef6ad-3088-4573-899c-8fdd3a5df27c",
 			"key": "rmapi_api_key",
 			"value": "",
 			"type": "string"
 		},
 		{
-			"id": "631924cb-c903-49fa-b308-7f0fef79fa5a",
+			"id": "f8ba9b90-a0d8-4c1d-afa1-71105964ccfd",
 			"key": "rmapi_url",
 			"value": "https://sandbox.ebsco.io",
 			"type": "string"
 		},
 		{
-			"id": "970faa5e-26ea-4edb-a4dd-d21dd72dd3bf",
+			"id": "66a075dc-baec-4bd3-9c04-ac9519a54e30",
 			"key": "default_rmapi_url",
 			"value": "https://sandbox.ebsco.io",
 			"type": "string"


### PR DESCRIPTION
## Purpose
add tests to cover https://issues.folio.org/browse/MODKBEKBJ-353

## Approach
* add tests for following endpoint:
     PUT /eholdings/packages/{id}
* add tear-down requests to unassign access types from packages