### PR TITLE
MODORDERS-328 - Migrate orders settings from mod-configuration

### DIFF
--- a/mod-orders/mod-orders.postman_collection.json
+++ b/mod-orders/mod-orders.postman_collection.json
@@ -13683,6 +13683,1030 @@
 					],
 					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Configuration",
+					"item": [
+						{
+							"name": "Reason for closure",
+							"item": [
+								{
+									"name": "Create reason for closure",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.reasonForClosure;",
+													"body.source = \"System\";",
+													"pm.variables.set(\"reasonForClosureBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let expectedReasonForClosure = globals.testData.reasonForClosure;",
+													"",
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    ",
+													"    var reasonForClosure = pm.response.json();",
+													"    ",
+													"    pm.test(\"Verify reason for closure\", () => {",
+													"        pm.expect(reasonForClosure.id).to.exist;",
+													"        pm.expect(reasonForClosure.reason).to.eql(expectedReasonForClosure.reason);",
+													"        pm.expect(reasonForClosure.source).to.eql(\"User\");",
+													"        pm.environment.set(\"reasonForClosureId\", reasonForClosure.id);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{reasonForClosureBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get reason for closure by id",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let expectedReasonForClosure = globals.testData.reasonForClosure;",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"",
+													"    var reasonForClosure = pm.response.json();",
+													"",
+													"    pm.test(\"Verify reason for closure\", () => {",
+													"        pm.expect(reasonForClosure.id).to.exist;",
+													"        pm.expect(reasonForClosure.reason).to.eql(expectedReasonForClosure.reason);",
+													"        pm.expect(reasonForClosure.source).to.eql(\"User\");",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure/{{reasonForClosureId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure",
+												"{{reasonForClosureId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update reason for closure",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.reasonForClosure;",
+													"body.reason = \"Updated reason\";",
+													"body.source = \"System\";",
+													"pm.variables.set(\"updatedReason\", body.reason);",
+													"pm.variables.set(\"updatedReasonForClosureBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    utils.sendGetRequest(\"/orders/configuration/reasons-for-closure/\" + pm.environment.get(\"reasonForClosureId\"), (err, res) => {",
+													"        pm.test(\"Reason for closure is updated\", () => {",
+													"            pm.expect(res.code).to.eql(200);",
+													"            var reasonForClosure = res.json();",
+													"            pm.expect(reasonForClosure.reason).to.eql(pm.variables.get(\"updatedReason\"));",
+													"            pm.expect(reasonForClosure.source).to.eql(\"User\");",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedReasonForClosureBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure/{{reasonForClosureId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure",
+												"{{reasonForClosureId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get reason for closure collection",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"    var reasonForClosureCollection = pm.response.json();",
+													"    pm.test(\"Verify reason for closure collection contains reasons for closure\", () => {",
+													"        reasonForClosureCollection.totalRecords > 0;",
+													"        pm.expect(reasonForClosureCollection.reasonsForClosure.length).to.eql(reasonForClosureCollection.totalRecords);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure?limit=1000",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure"
+											],
+											"query": [
+												{
+													"key": "limit",
+													"value": "1000"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete reason for closure",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    utils.sendGetRequest(\"/orders/configuration/reasons-for-closure/\" + pm.environment.get(\"reasonForClosureId\"), (err, res) => {",
+													"        pm.test(\"Reason for closure is deleted\", () => {",
+													"            pm.expect(res.code).to.eql(404);",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure/{{reasonForClosureId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure",
+												"{{reasonForClosureId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Prefix",
+							"item": [
+								{
+									"name": "Create prefix",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.prefix;",
+													"pm.variables.set(\"prefixBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let expectedPrefix = globals.testData.prefix;",
+													"",
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    ",
+													"    var prefix = pm.response.json();",
+													"    ",
+													"    pm.test(\"Verify prefix\", () => {",
+													"        pm.expect(prefix.id).to.exist;",
+													"        pm.expect(prefix.name).to.eql(expectedPrefix.name);",
+													"        pm.expect(prefix.description).to.eql(expectedPrefix.description);",
+													"        pm.environment.set(\"prefixId\", prefix.id);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{prefixBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get prefix by id",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let expectedPrefix = globals.testData.prefix;",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"",
+													"    var prefix = pm.response.json();",
+													"",
+													"    pm.test(\"Verify prefix\", () => {",
+													"        pm.expect(prefix.id).to.exist;",
+													"        pm.expect(prefix.name).to.eql(expectedPrefix.name);",
+													"        pm.expect(prefix.description).to.eql(expectedPrefix.description);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes/{{prefixId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes",
+												"{{prefixId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update prefix",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.prefix;",
+													"body.name = \"Updated name\";",
+													"pm.variables.set(\"updatedName\", body.name);",
+													"pm.variables.set(\"updatedPrefixBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    utils.sendGetRequest(\"/orders/configuration/prefixes/\" + pm.environment.get(\"prefixId\"), (err, res) => {",
+													"        pm.test(\"Prefix is updated\", () => {",
+													"            pm.expect(res.code).to.eql(200);",
+													"            var prefix = res.json();",
+													"            pm.expect(prefix.name).to.eql(pm.variables.get(\"updatedName\"));",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedPrefixBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes/{{prefixId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes",
+												"{{prefixId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get prefix collection",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"    var prefixCollection = pm.response.json();",
+													"    pm.test(\"Verify prefix collection contains prefixes\", () => {",
+													"        prefixCollection.totalRecords > 0;",
+													"        pm.expect(prefixCollection.prefixes.length).to.eql(prefixCollection.totalRecords);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes?limit=1000",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes"
+											],
+											"query": [
+												{
+													"key": "limit",
+													"value": "1000"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete prefix",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    utils.sendGetRequest(\"/orders/configuration/prefixes/\" + pm.environment.get(\"prefixId\"), (err, res) => {",
+													"        pm.test(\"Prefix is deleted\", () => {",
+													"            pm.expect(res.code).to.eql(404);",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes/{{prefixId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes",
+												"{{prefixId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Suffix",
+							"item": [
+								{
+									"name": "Create suffix",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.suffix;",
+													"pm.variables.set(\"suffixBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let expectedSuffix = globals.testData.suffix;",
+													"",
+													"pm.test(\"Status code is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    ",
+													"    var suffix = pm.response.json();",
+													"    ",
+													"    pm.test(\"Verify suffix\", () => {",
+													"        pm.expect(suffix.id).to.exist;",
+													"        pm.expect(suffix.name).to.eql(expectedSuffix.name);",
+													"        pm.expect(suffix.description).to.eql(expectedSuffix.description);",
+													"        pm.environment.set(\"suffixId\", suffix.id);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{suffixBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get suffix by id",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let expectedSuffix = globals.testData.suffix;",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"",
+													"    var suffix = pm.response.json();",
+													"",
+													"    pm.test(\"Verify suffix\", () => {",
+													"        pm.expect(suffix.id).to.exist;",
+													"        pm.expect(suffix.name).to.eql(expectedSuffix.name);",
+													"        pm.expect(suffix.description).to.eql(expectedSuffix.description);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes/{{suffixId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes",
+												"{{suffixId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update suffix",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.suffix;",
+													"body.name = \"Updated name\";",
+													"pm.variables.set(\"updatedName\", body.name);",
+													"pm.variables.set(\"updatedSuffixBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    utils.sendGetRequest(\"/orders/configuration/suffixes/\" + pm.environment.get(\"suffixId\"), (err, res) => {",
+													"        pm.test(\"Suffix is updated\", () => {",
+													"            pm.expect(res.code).to.eql(200);",
+													"            var suffix = res.json();",
+													"            pm.expect(suffix.name).to.eql(pm.variables.get(\"updatedName\"));",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedSuffixBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes/{{suffixId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes",
+												"{{suffixId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get suffix collection",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"    var suffixCollection = pm.response.json();",
+													"    pm.test(\"Verify suffix collection contains suffixes\", () => {",
+													"        suffixCollection.totalRecords > 0;",
+													"        pm.expect(suffixCollection.suffixes.length).to.eql(suffixCollection.totalRecords);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes?limit=1000",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes"
+											],
+											"query": [
+												{
+													"key": "limit",
+													"value": "1000"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete suffix",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    utils.sendGetRequest(\"/orders/configuration/suffixes/\" + pm.environment.get(\"suffixId\"), (err, res) => {",
+													"        pm.test(\"Suffix is deleted\", () => {",
+													"            pm.expect(res.code).to.eql(404);",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes/{{suffixId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes",
+												"{{suffixId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -19370,7 +20394,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/776df59b-d7d8-4ef9-bb11-cf1b53be09ea",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes/776df59b-d7d8-4ef9-bb11-cf1b53be09ea",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -19378,7 +20402,8 @@
 									"port": "{{okapiport}}",
 									"path": [
 										"orders",
-										"order-templates",
+										"configuration",
+										"suffixes",
 										"776df59b-d7d8-4ef9-bb11-cf1b53be09ea"
 									]
 								}
@@ -19597,6 +20622,741 @@
 								}
 							},
 							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Configuration",
+					"item": [
+						{
+							"name": "Reason for closure",
+							"item": [
+								{
+									"name": "Get reason for closure collection - invalid query",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure?query=invalid-query",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "invalid-query"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get reason for closure - not found",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure/776df59b-d7d8-4ef9-bb11-cf1b53be09ea",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09ea"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update reason for closure - id mismatch",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.reasonForClosure;",
+													"body.id = \"776df59b-d7d8-4ef9-bb11-cf1b53be09ea\";",
+													"pm.variables.set(\"updatedReasonForClosureBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedReasonForClosureBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete reason for closure - not found",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/reasons-for-closure/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"reasons-for-closure",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Prefix",
+							"item": [
+								{
+									"name": "Get prefix collection - invalid query",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes?query=invalid-query",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "invalid-query"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get prefix - not found",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/order-templates/776df59b-d7d8-4ef9-bb11-cf1b53be09ea",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"order-templates",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09ea"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update prefix - id mismatch",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.prefix;",
+													"body.id = \"776df59b-d7d8-4ef9-bb11-cf1b53be09ea\";",
+													"pm.variables.set(\"updatedPrefixBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedPrefixBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete prefix - not found",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Suffix",
+							"item": [
+								{
+									"name": "Get suffix collection - invalid query",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/prefixes?query=invalid-query",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"prefixes"
+											],
+											"query": [
+												{
+													"key": "query",
+													"value": "invalid-query"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get suffix - not found",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes/776df59b-d7d8-4ef9-bb11-cf1b53be09ea",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09ea"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update suffix - id mismatch",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													"let body = globals.testData.suffix;",
+													"body.id = \"776df59b-d7d8-4ef9-bb11-cf1b53be09ea\";",
+													"pm.variables.set(\"updatedSuffixBody\", JSON.stringify(body));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.test(\"Status code is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{updatedSuffixBody}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete suffix - not found",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "eb2052a4-e388-4860-80be-ea96976bcf21",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "3bf00f6d-8798-4764-a256-2d360ea02876",
+												"exec": [
+													"pm.test(\"Status code is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/orders/configuration/suffixes/776df59b-d7d8-4ef9-bb11-cf1b53be09eb",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"orders",
+												"configuration",
+												"suffixes",
+												"776df59b-d7d8-4ef9-bb11-cf1b53be09eb"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
 						}
 					],
 					"protocolProfileBehavior": {},
@@ -19942,6 +21702,18 @@
 					"        templateName: \"Amazon orders\",",
 					"        acquisitionMethod: \"Purchase At Vendor System\",",
 					"        approved: true",
+					"    },",
+					"    reasonForClosure: {",
+					"        reason: \"Test closure reason\",",
+					"        source: \"User\"",
+					"    },",
+					"    prefix: {",
+					"        name: \"Test prefix\",",
+					"        description: \"Test prefix description\"",
+					"    },",
+					"    suffix: {",
+					"        name: \"Test suffix\",",
+					"        description: \"Test suffix description\"",
 					"    },",
 					"",
 					"};",
@@ -21261,7 +23033,9 @@
 					"        pm.environment.unset(\"mod-tenant-configs\");",
 					"        pm.environment.unset(\"receivingItemBarcode\");",
 					"        pm.environment.unset(\"temp-orders-configs\");",
-					"        pm.environment.unset(\"uniqueProductId\");",
+					"        pm.environment.unset(\"reasonForClosureId\");",
+					"        pm.environment.unset(\"prefixId\");",
+					"        pm.environment.unset(\"suffixId\");",
 					"        pm.environment.unset(\"xokapitoken\");",
 					"        pm.environment.unset(\"xokapitoken-admin\");",
 					"        pm.environment.unset(\"xokapitoken-testAdmin\");",
@@ -21333,55 +23107,55 @@
 	],
 	"variable": [
 		{
-			"id": "1e712ad4-e09a-48fc-9e58-03950b9b708f",
+			"id": "2f1fdc5d-854a-4355-ae2c-b504565734a2",
 			"key": "testTenant",
 			"value": "orders_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "7322a606-43c5-4127-856d-f40ea260643e",
+			"id": "9374de5c-1465-4b2d-9adb-1fc62c1d4c30",
 			"key": "mod-ordersResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-orders/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "d7994f8c-3861-47c9-b144-f2b78d32953b",
+			"id": "c7c2aab3-0f6e-4490-9959-56f554e2c24d",
 			"key": "poLines-limit",
 			"value": "10",
 			"type": "string"
 		},
 		{
-			"id": "e1387c2b-19f1-4818-a1f3-d14d579d6d30",
+			"id": "8d71aa69-57ff-4fc3-b13f-4b7a157c6275",
 			"key": "inventory-identifierTypeName",
 			"value": "ordersApiTestsIdentifierTypeName",
 			"type": "string"
 		},
 		{
-			"id": "ff86e253-a52e-4414-81cc-f7e9a80de159",
+			"id": "ec52868e-c7a2-4510-b7d8-6ff9176c68cb",
 			"key": "inventory-instanceTypeCode",
 			"value": "ordersApiTestsInstanceTypeCode",
 			"type": "string"
 		},
 		{
-			"id": "c4196115-2170-44ab-b56b-a7e2e0451154",
+			"id": "42a86f95-90e7-4e5f-89c2-873903b2b736",
 			"key": "inventory-instanceStatusCode",
 			"value": "ordersApiTestsInstanceStatusCode",
 			"type": "string"
 		},
 		{
-			"id": "e4cac2ff-d75c-4ed0-bfa8-0ac0c7744857",
+			"id": "711e8d6b-f2b3-47aa-934e-1bf3c9084ff6",
 			"key": "inventory-loanTypeName",
 			"value": "ordersApiTestsLoanTypeName",
 			"type": "string"
 		},
 		{
-			"id": "5aab5ba8-dddf-4497-add1-46971246db5f",
+			"id": "49c425e3-2023-4e56-93b5-da0e19d02182",
 			"key": "tenant.addresses",
 			"value": "{\n  \"address\": \"sample address\",\n  \"name\": \"sample name\"\n}\n",
 			"type": "string"
 		},
 		{
-			"id": "2c153401-ee32-4bfb-b3f3-80bb24e6536a",
+			"id": "668ac76f-08f0-4ed3-93b5-466c5a58a00d",
 			"key": "approvals",
 			"value": "{\"isApprovalRequired\":false}",
 			"type": "string"


### PR DESCRIPTION
API Tests for [MODORDERS-328](https://issues.folio.org/browse/MODORDERS-328).

Positive tests:
CRUD operations for reason for closure, prefix, suffix:

1. Create
2. Get by id
3. Update/Get by Id
4. Get collection
5. Delete/Get by Id

<img width="478" alt="image" src="https://user-images.githubusercontent.com/42964285/76147938-72853880-60b2-11ea-8f69-615e801f1603.png">

Negative tests:

1. Get by invalid query
2. Get - not found
3. Update - id mismatch
4. Delete - not found

<img width="482" alt="image" src="https://user-images.githubusercontent.com/42964285/76147952-8f217080-60b2-11ea-8125-256c82f1bc34.png">
