### PR TITLE
MODKBEKBJ Add API tests for access type filtering

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9af01b11-4007-4757-9fe5-c457bc818997",
+		"_postman_id": "96c80e1b-afcc-4391-b96e-9450175bb11f",
 		"name": "mod-kb-ebsco-java",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1765,7 +1765,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?filter[selected]=false",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?filter[selected]=false\n",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -2239,7 +2239,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers?q={{custid}}",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers?q={{custid}}\n",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -2489,7 +2489,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?q=abc",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?q=abc\n",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -2790,7 +2790,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=abc",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[name]=abc\n",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -2866,7 +2866,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles/{{managed-titleid}}?include=resources",
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles/{{managed-titleid}}?include=resources\n",
 									"protocol": "{{protocol}}",
 									"host": [
 										"{{url}}"
@@ -3703,6 +3703,16 @@
 										],
 										"type": "text/javascript"
 									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "d1b9c29e-a6c2-41cb-b93d-5ff42ac14477",
+										"exec": [
+											"pm.environment.set(\"access-type-name3\", \"Subscribed\");"
+										],
+										"type": "text/javascript"
+									}
 								}
 							],
 							"request": {
@@ -3727,7 +3737,88 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"type\": \"accessTypes\",\r\n  \"attributes\": {\r\n    \"name\": \"Subscribed\",\r\n    \"description\": \"some description\"\r\n  }\r\n}\r\n",
+									"raw": "{\r\n  \"type\": \"accessTypes\",\r\n  \"attributes\": {\r\n    \"name\": \"{{access-type-name3}}\",\r\n    \"description\": \"some description\"\r\n  }\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/access-types",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"access-types"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create new access type 4",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9a240e65-ab76-434d-b3cb-755db3df2a02",
+										"exec": [
+											"pm.test(\"Status is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"Response must have a json body\", function () {",
+											"    pm.response.to.be.success;",
+											"    pm.response.to.be.withBody;",
+											"    pm.response.to.be.json; ",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"    ",
+											"// Store access type id for future reference in other tests/cleanup",
+											"pm.environment.set(\"access-type-id4\", jsonData.id);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "d1b9c29e-a6c2-41cb-b93d-5ff42ac14477",
+										"exec": [
+											"pm.environment.set(\"access-type-name4\", \"Trial\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/vnd.api+json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"type\": \"accessTypes\",\r\n  \"attributes\": {\r\n    \"name\": \"{{access-type-name4}}\",\r\n    \"description\": \"some description\"\r\n  }\r\n}\r\n",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3883,6 +3974,241 @@
 										"eholdings",
 										"packages",
 										"{{custom-package-id-created-in-post}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update custom package2 with access-type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "b8f6b3ca-ed96-41f1-b648-105564fea3eb",
+										"exec": [
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.json;",
+											"});",
+											"",
+											"let response = pm.response.json();",
+											"",
+											"//Check that status is 200",
+											"pm.test(\"Status is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Validate schema\", function () {",
+											"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_package\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+											"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+											"});",
+											"",
+											"//Test that object has the expected keys",
+											"pm.test('expected keys are present in response object', function() {",
+											"    pm.expect(response.data).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+											"});",
+											"",
+											"//Test that id matches what was provided in query",
+											"pm.test('id matches as provided in query', function(){",
+											"    pm.expect(response.data.id).eq(pm.environment.get('custom-package-created-for-tags-id'));",
+											"});    ",
+											"",
+											"//Test that type is packages",
+											"pm.test('type is packages', function(){",
+											"    pm.expect(response.data.type).eq('packages');",
+											"});",
+											"    ",
+											"//Test that data.attributes has expected attributes",
+											"pm.test('expected data.attributes are present', function() {",
+											"    pm.expect(response.data.attributes).to.be.an('object');",
+											"    pm.expect(response.data.attributes).to.include.all.keys(\"contentType\", \"customCoverage\", \"isCustom\",\"isSelected\",\"name\", \"packageId\", ",
+											"    \"packageType\", \"providerId\", \"providerName\", \"selectedCount\", \"titleCount\", \"visibilityData\", \"allowKbToAddTitles\",\"proxy\");",
+											"});",
+											"",
+											"//Test that contentType matches as provided in request",
+											"//This should be re-visited after https://issues.folio.org/browse/UIEH-490 is fixed.",
+											"pm.test('contentType matches as provided in request', function() {",
+											"    pm.expect(response.data.attributes.contentType).eq('E-Journal');",
+											"});",
+											"",
+											"//Test that isSelected matches as provided in request",
+											"pm.test('isSelected matches as provided in request', function() {",
+											"    pm.expect(response.data.attributes.isSelected).to.be.true;",
+											"});",
+											"",
+											"//Test that visibilityData matches as provided in request",
+											"pm.test('visibilityData matches as provided in request', function() {",
+											"    pm.expect(response.data.attributes.visibilityData.isHidden).to.be.true;",
+											"});",
+											"",
+											"//Test that resources are not included in relationships",
+											"pm.test('relationships meta should not include resources', function() {",
+											"    pm.expect(response.data.relationships.resources.meta.included).to.be.false;",
+											"});",
+											"",
+											"//Test that access type assigned",
+											"pm.test('access type should be assigned', function() {",
+											"    pm.expect(response.data.relationships.accessType.meta.included).to.be.true;",
+											"    pm.expect(response.data.relationships.accessType.data.id).to.be.equal(pm.environment.get(\"access-type-id4\"));",
+											"    pm.expect(response.included[0].id).to.be.equal(pm.environment.get(\"access-type-id4\"));",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/vnd.api+json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"data\": {\n        \"type\": \"packages\",\n        \"attributes\": {\n            \"name\": \"{{custom-package-created-for-tags-name}}\",\n            \"contentType\": \"E-Journal\",\n            \"isCustom\": true,\n            \"isSelected\": true,\n            \"visibilityData\": {\n                \"isHidden\": true\n            },\n            \"allowKbToAddTitles\": false,\n            \"proxy\": {\n                \"id\": \"<n>\",\n                \"inherited\": false\n            },\n            \"accessTypeId\": \"{{access-type-id4}}\"\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-package-created-for-tags-id}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"packages",
+										"{{custom-package-created-for-tags-id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "update custom resource with access type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1bbccb9f-00b3-497f-bc84-db593ca5f27a",
+										"exec": [
+											"pm.test(\"Status is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Response must have a json body\", function () {",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.be.withBody;",
+											"    pm.response.to.be.json; ",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.test(\"Validate schema\", function () {",
+											"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_resource\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+											"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+											"});",
+											"",
+											"//Get the first record",
+											"let firstRecord = jsonData.data;",
+											"    ",
+											"//Test that object has the expected keys",
+											"pm.test('expected keys are present in a record', function() {",
+											"    pm.expect(firstRecord).to.be.an('object');",
+											"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+											"});",
+											"",
+											"// Test that attributes have the expected keys",
+											"let firstAttributes = firstRecord.attributes;",
+											"pm.test('expected attributes are present in a record', function() {",
+											"    pm.expect(firstAttributes).to.be.an('object');",
+											"    pm.expect(firstAttributes).to.include.all.keys(\"isPeerReviewed\",\"isTitleCustom\", \"titleId\", \"contributors\", \"identifiers\", \"name\", \"publicationType\", \"subjects\", \"customEmbargoPeriod\", \"isPackageCustom\", \"isSelected\", \"isTokenNeeded\", \"locationId\",\"managedEmbargoPeriod\", \"packageId\", \"packageName\", \"providerId\", \"providerName\",\"visibilityData\", \"managedCoverages\", \"customCoverages\", \"proxy\", \"userDefinedField1\", \"userDefinedField2\", \"userDefinedField3\", \"userDefinedField4\", \"userDefinedField5\");",
+											"});",
+											"",
+											"pm.test(\"data type is as expected\", function () {",
+											"    pm.expect(firstRecord.type).eq(\"resources\");",
+											"});",
+											"",
+											"pm.test(\"isSelected is as expected\", function () {",
+											"   pm.expect(firstAttributes.isSelected).to.eql(true);",
+											"});",
+											"",
+											"pm.test(\"isHidden is as expected\", function () {",
+											"   pm.expect(firstAttributes.visibilityData.isHidden).to.eql(false);",
+											"});",
+											"",
+											"pm.test(\"proxy is as expected\", function () {",
+											"   pm.expect(firstAttributes.proxy.id).to.eql(\"<n>\");",
+											"});",
+											"",
+											"pm.test(\"relationships is as expected\", function () {",
+											"   pm.expect(firstRecord.relationships.accessType.data.type).to.eq(\"accessTypes\");",
+											"   pm.expect(firstRecord.relationships.accessType.data.id).to.eq(pm.environment.get(\"access-type-id3\"));",
+											"   pm.expect(jsonData.included[0].id).to.be.equal(pm.environment.get(\"access-type-id3\"));",
+											"});",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "4f66110c-22c5-4c48-94f8-b1f133aada9e",
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.globals.set(\"custom-resource-uuid\", uuid.v4());"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.api+json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"data\": {\n        \"type\": \"resources\",\n        \"attributes\": {\n            \"isSelected\": true,\n            \"isTitleCustom\": true,\n            \"accessTypeId\": \"{{access-type-id3}}\",\n            \"userDefinedField1\": \"test 1\",\n            \"userDefinedField2\": \"test 2\",\n            \"userDefinedField3\": \"\",\n            \"userDefinedField4\": \"test 4\",\n            \"userDefinedField5\": \"test 5\"\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/resources/{{custom-resourceid-from-setup}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"resources",
+										"{{custom-resourceid-from-setup}}"
 									]
 								}
 							},
@@ -4363,6 +4689,16 @@
 													"    ",
 													"// Store access type id for future reference in other tests/cleanup",
 													"pm.environment.set(\"access-type-id2\", response.id);"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "998e7518-85f3-4b33-b481-45d36ad30816",
+												"exec": [
+													"pm.environment.set(\"access-type-name2\", \"Subscribed updated\");"
 												],
 												"type": "text/javascript"
 											}
@@ -8171,6 +8507,171 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "with valid providerId and filtered by access type",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "8840c58b-b441-44dc-bf30-c78a2e0e337f",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of packages in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Test that count is equal to number of records returned in response",
+													"        pm.test('count equals number of records in response', function() {",
+													"            pm.expect(len).to.be.above(0);",
+													"        });",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is packages",
+													"        pm.test('type is packages', function(){",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that isSelected is true",
+													"        pm.test('check isSelected', function() {",
+													"            pm.expect(firstRecord.attributes.isSelected).to.be.true;",
+													"        });",
+													"    }",
+													"}",
+													"",
+													"pm.sendRequest({",
+													"    url: pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + \"/eholdings/packages/\" + response.data[0].id,",
+													"    method: 'GET',",
+													"    header: {",
+													"        'X-Okapi-Tenant': pm.environment.get(\"xokapitenant\"),",
+													"        'X-Okapi-Token': pm.environment.get(\"xokapitoken\"),",
+													"        'Content-Type': 'application/json'",
+													"    },",
+													"}, function(err, res) {",
+													"    pm.test(\"Check name of tag\", function () {",
+													"        var response = res.json();",
+													"        pm.expect(response.data.attributes.tags.tagList[0]).to.eq(pm.environment.get(\"tagName\"));",
+													"    });",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/{{provider-with-tags-id}}/packages?filter[access-type]={{access-type-name3}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"{{provider-with-tags-id}}",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "filter[access-type]",
+													"value": "{{access-type-name3}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "with valid providerId and filtered bynon existing access type",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "8840c58b-b441-44dc-bf30-c78a2e0e337f",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?filter[access-type]=Not Existing",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "filter[access-type]",
+													"value": "Not Existing"
+												}
+											]
+										}
+									},
+									"response": []
 								}
 							],
 							"protocolProfileBehavior": {},
@@ -9910,6 +10411,260 @@
 												{
 													"key": "filter[tags]",
 													"value": "{{non-existing-tag}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "valid filter[access-type] param",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "8840c58b-b441-44dc-bf30-c78a2e0e337f",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of packages in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Test that count is equal to number of records returned in response",
+													"        pm.test('count equals number of records in response', function() {",
+													"            pm.expect(len).to.be.above(0);",
+													"        });",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is packages",
+													"        pm.test('type is packages', function(){",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that isSelected is true",
+													"        pm.test('check isSelected', function() {",
+													"            pm.expect(firstRecord.attributes.isSelected).to.be.true;",
+													"        });",
+													"    }",
+													"}",
+													"",
+													"pm.sendRequest({",
+													"    url: pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + \"/eholdings/packages/\" + response.data[0].id,",
+													"    method: 'GET',",
+													"    header: {",
+													"        'X-Okapi-Tenant': pm.environment.get(\"xokapitenant\"),",
+													"        'X-Okapi-Token': pm.environment.get(\"xokapitoken\"),",
+													"        'Content-Type': 'application/json'",
+													"    },",
+													"}, function(err, res) {",
+													"    pm.test(\"Check name of tag\", function () {",
+													"        var response = res.json();",
+													"        pm.expect(response.data.attributes.tags.tagList[0]).to.eq(pm.environment.get(\"tagName\"));",
+													"    });",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?filter[access-type]={{access-type-name3}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "filter[access-type]",
+													"value": "{{access-type-name3}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "valid filter[access-type] multiple param",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "8840c58b-b441-44dc-bf30-c78a2e0e337f",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check if we get a collection of packages in response",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Test that count is equal to number of records returned in response",
+													"        pm.test('count equals number of records in response', function() {",
+													"            pm.expect(len).to.be.above(0);",
+													"        });",
+													"        //Get the first record",
+													"        let firstRecord = response.data[0];",
+													"        ",
+													"        //Test that type is packages",
+													"        pm.test('type is packages', function(){",
+													"            pm.expect(firstRecord.type).eq('packages');",
+													"        });",
+													"        ",
+													"        //Test that isSelected is true",
+													"        pm.test('check isSelected', function() {",
+													"            pm.expect(firstRecord.attributes.isSelected).to.be.true;",
+													"        });",
+													"    }",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages?filter[access-type]={{access-type-name4}}&filter[tags]={{tagName}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "filter[access-type]",
+													"value": "{{access-type-name4}}"
+												},
+												{
+													"key": "filter[tags]",
+													"value": "{{tagName}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "valid filter[access-type] with non existing access type",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "8840c58b-b441-44dc-bf30-c78a2e0e337f",
+												"exec": [
+													"pm.test(\"success test\", function() {",
+													"    pm.response.to.be.json;",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_packageCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/providers/{{provider-with-tags-id}}/packages?filter[access-type]=Not Existing",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"providers",
+												"{{provider-with-tags-id}}",
+												"packages"
+											],
+											"query": [
+												{
+													"key": "filter[access-type]",
+													"value": "Not Existing"
 												}
 											]
 										}
@@ -11844,7 +12599,6 @@
 													"            pm.expect(firstRecord.type).to.eq('resources');",
 													"            pm.expect(firstRecord.attributes.userDefinedField1).eq(\"test 1\");",
 													"            pm.expect(firstRecord.attributes.userDefinedField2).eq(\"test 2\");",
-													"            pm.expect(firstRecord.attributes.userDefinedField3).eq(\"test 3\");",
 													"            pm.expect(firstRecord.attributes.userDefinedField4).eq(\"test 4\");",
 													"            pm.expect(firstRecord.attributes.userDefinedField5).eq(\"test 5\");",
 													"        });",
@@ -15206,6 +15960,101 @@
 					],
 					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
+				},
+				{
+					"name": "GET resources included to package",
+					"item": [
+						{
+							"name": "valid filter[access-type] param",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "8840c58b-b441-44dc-bf30-c78a2e0e337f",
+										"exec": [
+											"pm.test(\"success test\", function() {",
+											"    pm.response.to.be.json;",
+											"});",
+											"",
+											"let response = pm.response.json();",
+											"",
+											"//Check that status is 200",
+											"pm.test(\"Status is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"//Validate response against json api schema",
+											"pm.test(\"Validate schema\", function () {",
+											"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_resourceCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+											"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+											"});",
+											"",
+											"//Check if we get a collection of packages in response",
+											"if(response.data) {",
+											"    let len = response.data.length;",
+											"    if(len > 0){",
+											"        //Test that count is equal to number of records returned in response",
+											"        pm.test('count equals number of records in response', function() {",
+											"            pm.expect(len).to.be.above(0);",
+											"        });",
+											"        //Get the first record",
+											"        let firstRecord = response.data[0];",
+											"        ",
+											"        //Test that type is packages",
+											"        pm.test('type is resources', function(){",
+											"            pm.expect(firstRecord.type).eq('resources');",
+											"        });",
+											"        ",
+											"        //Test that isSelected is true",
+											"        pm.test('check isSelected', function() {",
+											"            pm.expect(firstRecord.attributes.isSelected).to.be.true;",
+											"        });",
+											"    }",
+											"}",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/packages/{{custom-packageid-from-setup}}/resources?filter[access-type]={{access-type-name2}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"packages",
+										"{{custom-packageid-from-setup}}",
+										"resources"
+									],
+									"query": [
+										{
+											"key": "filter[access-type]",
+											"value": "{{access-type-name2}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
 				}
 			],
 			"event": [
@@ -16827,7 +17676,7 @@
 									"response": []
 								},
 								{
-									"name": "/resources GET specific resource (custom title)",
+									"name": "GET resource",
 									"event": [
 										{
 											"listen": "test",
@@ -17728,7 +18577,7 @@
 													"// Errors array should return a more relevant response",
 													"pm.test(\"Errors array contains 1 entries\", function () {",
 													"    pm.expect(jsonData.errors.length).to.eql(1);",
-													"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid\");",
+													"    pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid - 1\");",
 													"});",
 													"",
 													"",
@@ -20602,7 +21451,7 @@
 													"",
 													"pm.test(\"Errors array contains 1 entry\", function () {",
 													"   pm.expect(jsonData.errors.length).to.eql(1);",
-													"  pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid\");",
+													"  pm.expect(jsonData.errors[0].title).to.equal(\"Resource id is invalid - 1\");",
 													"});",
 													"",
 													"",
@@ -22673,6 +23522,101 @@
 												{
 													"key": "sort",
 													"value": "name"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "/titles filter[access-type]",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "8840c58b-b441-44dc-bf30-c78a2e0e337f",
+												"exec": [
+													"",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.ok;",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"var jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(jsonData, JSON.parse(pm.environment.get(\"schema_titleCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"",
+													"//verify headers",
+													"pm.test(\"'Content-Type'header is present and has 'application/vnd.api+json' value\", function () {",
+													"    pm.response.to.have.header(\"Content-Type\");",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"pm.test(\"'Transfer-Encoding' header is present and has 'chunked' value\", function () {",
+													"    pm.response.to.have.header(\"Transfer-Encoding\");",
+													"    pm.expect(pm.response.headers.get(\"Transfer-Encoding\")).to.be.equal(\"chunked\");",
+													"});",
+													"",
+													"pm.test(\"'X-Okapi-Trace' header is present\", function () {",
+													"    pm.response.to.have.header(\"X-Okapi-Trace\");",
+													"});",
+													"",
+													"//Get the first record",
+													"let firstRecord = jsonData.data[0];",
+													"    ",
+													"//Test that object has the expected keys",
+													"pm.test('expected keys are present in a record', function() {",
+													"    pm.expect(firstRecord).to.be.an('object');",
+													"    pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\",\"relationships\");",
+													"});",
+													"",
+													"// Test that attributes have the expected keys",
+													"let firstAttributes = firstRecord.attributes;",
+													"pm.test('expected attributes are present in a record', function() {",
+													"    pm.expect(firstAttributes).to.be.an('object');",
+													"    pm.expect(firstAttributes).to.include.all.keys(\"name\", \"publicationType\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/titles?filter[access-type]={{access-type-name2}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"titles"
+											],
+											"query": [
+												{
+													"key": "filter[access-type]",
+													"value": "{{access-type-name2}}"
 												}
 											]
 										}
@@ -33892,6 +34836,60 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "DELETE fourth access type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+										"exec": [
+											"//Check that status is 204",
+											"pm.test(\"Status is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.response.to.be.success;",
+											"});",
+											"",
+											"pm.test(\"Response without error json body\", function () {",
+											"    pm.response.to.be.success;",
+											"    pm.response.to.not.have.body;",
+											"    pm.response.to.not.have.jsonBody('error');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/access-types/{{access-type-id4}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"access-types",
+										"{{access-type-id4}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"protocolProfileBehavior": {},
@@ -33925,31 +34923,31 @@
 	],
 	"variable": [
 		{
-			"id": "61b26b78-b9bf-4d12-bb2b-8a8fd7c0c72c",
+			"id": "905e7584-62ad-473a-aac1-b0a455395b69",
 			"key": "custid",
 			"value": "apidvgvmt",
 			"type": "string"
 		},
 		{
-			"id": "9c475bac-81f3-4da4-9a46-2ffbeaea33c5",
+			"id": "a89a44b7-aaab-4b31-a59a-4d9bbbe04112",
 			"key": "packageId",
 			"value": "583-4345",
 			"type": "string"
 		},
 		{
-			"id": "38f8dee4-76db-4e05-9d10-59abce0be80c",
+			"id": "6638e53f-b69a-4033-9f8f-ba5667e86cf3",
 			"key": "rmapi_api_key",
 			"value": "",
 			"type": "string"
 		},
 		{
-			"id": "98e9408b-589c-4922-abc6-14e93484a4ec",
+			"id": "292ac531-b36e-4dee-9073-4a8ea836ca21",
 			"key": "rmapi_url",
 			"value": "https://sandbox.ebsco.io",
 			"type": "string"
 		},
 		{
-			"id": "2d8bf2c2-5a67-41b2-ae2b-f56dd4bf091e",
+			"id": "8549c616-bc84-4ba4-bf6a-28fac06670de",
 			"key": "default_rmapi_url",
 			"value": "https://sandbox.ebsco.io",
 			"type": "string"


### PR DESCRIPTION
## Purpose
add tests to cover:
* https://issues.folio.org/browse/MODKBEKBJ-355
* https://issues.folio.org/browse/MODKBEKBJ-356
* https://issues.folio.org/browse/MODKBEKBJ-375
* https://issues.folio.org/browse/MODKBEKBJ-376

## Approach
Add tests for following endpoint:
 * GET/eholdings/packages
 * GET/eholdings/packages/{id}/resources
 * GET/eholdings/provider/{id}/packages
 * GET/eholdings/titles