### PR TITLE
[MODFIN-117] Add API test for error message

### DIFF
--- a/mod-finance/mod-finance.postman_collection.json
+++ b/mod-finance/mod-finance.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cfff7708-10b7-4467-a6b3-aa6954bb0d75",
+		"_postman_id": "134f246b-737f-49a5-b5dc-4f8374354d87",
 		"name": "mod-finance",
 		"description": "Tests for mod-finance",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -3318,6 +3318,847 @@
 				{
 					"name": "Budgets",
 					"item": [
+						{
+							"name": "Budget deletion without transaction",
+							"item": [
+								{
+									"name": "Create fiscal year  - required for budgets",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "8c99d17f-1af5-4b91-97f6-83e472944ca2",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.variables.set(\"allocFyContent\", JSON.stringify(utils.buildFiscalYearMinContent(\"ALLOCFY2019\")));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd0615f0-1de3-42ac-bcfb-f6eb63da0056",
+												"exec": [
+													"pm.test(\"Ledger is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"allocFiscalYearId\", pm.response.json().id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocFyContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/fiscal-years",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"fiscal-years"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create ledger - required for funds",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Ledger is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"allocLedgerId\", pm.response.json().id); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let ledger = utils.buildLedgerMinContent(\"ALLOC-LDGR\", \"Test transaction ledger\");",
+													"ledger.fiscalYearOneId = pm.environment.get(\"allocFiscalYearId\");",
+													"pm.environment.set(\"allocLedgerContent\", JSON.stringify(ledger));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocLedgerContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/ledgers",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"ledgers"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create fund - required for transactions",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let record = {};",
+													"",
+													"pm.test(\"Fund is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"});",
+													"",
+													"pm.test(\"Fund content is valid\", function() {",
+													"    utils.validateCompositeFund(record);",
+													"    pm.environment.set(\"toFundId\", record.fund.id); ",
+													"    pm.expect(record.fund.code).to.eql(\"ALLOC-FND\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.variables.set(\"allocFundContent\", JSON.stringify(utils.buildCompositeFund(utils.buildFundMinContent(\"ALLOC-FND\", pm.environment.get(\"allocLedgerId\")))));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocFundContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"funds"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create budget",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let record = {};",
+													"",
+													"pm.test(\"Budget is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"});",
+													"",
+													"pm.test(\"Budget content is valid\", function() {",
+													"    utils.validateBudget(record);",
+													"    pm.environment.set(\"allocBudgetId\", record.id); ",
+													"    pm.expect(record.name).to.eql(\"ALLOC-BDGT\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.variables.set(\"allocBudgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"ALLOC-BDGT\", pm.environment.get(\"toFundId\"), pm.environment.get(\"allocFiscalYearId\"))));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocBudgetContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"budgets"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get fiscal year by id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Fiscal year is retrieved\", function() {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateFiscalYear(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/fiscal-years/{{allocFiscalYearId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"fiscal-years",
+												"{{allocFiscalYearId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get fund record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Fund is retrieved\", function () {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateCompositeFund(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds/{{toFundId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"funds",
+												"{{toFundId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get budget record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Budget is retrieved\", function () {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateBudget(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{allocBudgetId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"budgets",
+												"{{allocBudgetId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create allocations",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"pm.test(\"Trasaction allocation is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"transactionId\", pm.response.json().id); ",
+													"    record = pm.response.json();",
+													"    pm.expect(record.transactionType).to.eql(\"Allocation\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.environment.set(\"allocationContent\", JSON.stringify(utils.buildTransactionMinContent(25, pm.environment.get(\"allocFiscalYearId\"), pm.environment.get(\"toFundId\"), \"Allocation\")));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocationContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/allocations",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"allocations"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get transaction by id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Transaction allocation is retrieved\", function () {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateTransaction(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/transactions/{{transactionId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"transactions",
+												"{{transactionId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete transaction",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Transaction is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/transactions/{{transactionId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"transactions",
+												"{{transactionId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete budget record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Budget is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{allocBudgetId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"budgets",
+												"{{allocBudgetId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete fund record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Fund is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds/{{toFundId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"funds",
+												"{{toFundId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Ledger",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Ledger is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/ledgers/{{allocLedgerId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"ledgers",
+												"{{allocLedgerId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete fiscal year",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Fiscal year is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/fiscal-years/{{allocFiscalYearId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"fiscal-years",
+												"{{allocFiscalYearId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Budget deletion without transaction",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "1ecae97a-9907-4fdd-b891-2781ca652380",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "8f376013-2826-4929-8179-a3bc74455ea9",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
 						{
 							"name": "Create first budget",
 							"event": [
@@ -6938,7 +7779,123 @@
 									"_postman_isSubFolder": true
 								},
 								{
-									"name": "Create encumbrances",
+									"name": "Create order transaction summaries to release",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "8c99d17f-1af5-4b91-97f6-83e472944ca2",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd0615f0-1de3-42ac-bcfb-f6eb63da0056",
+												"exec": [
+													"pm.test(\"Order transaction summary is created\", () => {",
+													"    pm.environment.set(\"orderTransactionIdToRelease\", pm.response.json().id);",
+													"    pm.response.to.have.status(201);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"id\": \"e5ae4afd-3fa9-494e-a972-f541df9b8771\",\r\n  \"numTransactions\": 1\r\n}\r\n"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/order-transaction-summaries",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"order-transaction-summaries"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create invoice transaction summary to release",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Trasaction allocation is created\", () => {",
+													"    pm.environment.set(\"invoiceTransactionSummaryIdToRelease\", pm.response.json().id);",
+													"    pm.response.to.have.status(201);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"id\": \"187c7e6f-782a-4bd0-a04e-7174d4da2429\",\n  \"numEncumbrances\": 1,\n  \"numPaymentsCredits\": 1\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/invoice-transaction-summaries",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"invoice-transaction-summaries"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create encumbrances to release",
 									"event": [
 										{
 											"listen": "test",
@@ -6948,7 +7905,7 @@
 													"let record = {};",
 													"pm.test(\"Trasaction encumbrance is created\", () => {",
 													"    pm.response.to.have.status(201);",
-													"    pm.environment.set(\"encumbranceId\", pm.response.json().id);",
+													"    pm.environment.set(\"encumbranceIdToRelease\", pm.response.json().id);",
 													"    record = pm.response.json();",
 													"    pm.expect(record.transactionType).to.eql(\"Encumbrance\");",
 													"});"
@@ -6969,7 +7926,11 @@
 													"let transactionEncumbrance = utils.buildTransactionMinContent(25, pm.environment.get(\"encFiscalYearId\"), pm.environment.get(\"toFundId\"), \"Encumbrance\");",
 													"",
 													"transactionEncumbrance.encumbrance = encumbranceMinContent;",
+													"",
+													"transactionEncumbrance.encumbrance.sourcePurchaseOrderId = pm.environment.get(\"orderTransactionIdToRelease\");",
+													"transactionEncumbrance.sourceInvoiceId = pm.environment.get(\"invoiceTransactionSummaryIdToRelease\");",
 													"transactionEncumbrance.fromFundId = pm.environment.get(\"fromFundId\");",
+													"",
 													"",
 													"pm.environment.set(\"encumbranceContent\", JSON.stringify(transactionEncumbrance));"
 												],
@@ -7070,6 +8031,140 @@
 													"key": "fiscalYear",
 													"value": "{{encFiscalYearId}}"
 												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Release encumbrance request",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Encumbrance successfully released\", () => {",
+													"    pm.response.to.have.status(204);",
+													"});",
+													"",
+													"",
+													"utils.sendGetRequest(\"/finance/budgets/\" + pm.environment.get(\"encBudgetId\"), (err, res) => {",
+													"    let budget = res.json();",
+													"    pm.expect(budget.encumbered).to.equal(0);",
+													"    pm.expect(budget.available).to.equal(2500);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/release-encumbrance/{{encumbranceIdToRelease}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"release-encumbrance",
+												"{{encumbranceIdToRelease}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create encumbrances",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"pm.test(\"Trasaction encumbrance is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"encumbranceId\", pm.response.json().id);",
+													"    record = pm.response.json();",
+													"    pm.expect(record.transactionType).to.eql(\"Encumbrance\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"var uuid = require(\"uuid\");",
+													"",
+													"",
+													"let encumbranceMinContent = utils.buildEncumbranceMinContent();",
+													"let transactionEncumbrance = utils.buildTransactionMinContent(25, pm.environment.get(\"encFiscalYearId\"), pm.environment.get(\"toFundId\"), \"Encumbrance\");",
+													"",
+													"transactionEncumbrance.encumbrance = encumbranceMinContent;",
+													"transactionEncumbrance.fromFundId = pm.environment.get(\"fromFundId\");",
+													"",
+													"pm.environment.set(\"encumbranceContent\", JSON.stringify(transactionEncumbrance));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{encumbranceContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/encumbrances",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"encumbrances"
 											]
 										}
 									},
@@ -7333,69 +8428,6 @@
 									"response": []
 								},
 								{
-									"name": "Release encumbrance request",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
-												"exec": [
-													"let utils = eval(globals.loadUtils);",
-													"",
-													"pm.test(\"Encumbrance successfully released\", () => {",
-													"    pm.response.to.have.status(204);",
-													"});",
-													"",
-													"",
-													"utils.sendGetRequest(\"/finance/budgets/\" + pm.environment.get(\"encBudgetId\"), (err, res) => {",
-													"    let budget = res.json();",
-													"    pm.expect(budget.encumbered).to.equal(0);",
-													"    pm.expect(budget.available).to.equal(2481.56);",
-													"});"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
-												"exec": [
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "x-okapi-token",
-												"value": "{{xokapitoken}}"
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/release-encumbrance/{{encumbranceId}}",
-											"protocol": "{{protocol}}",
-											"host": [
-												"{{url}}"
-											],
-											"port": "{{okapiport}}",
-											"path": [
-												"finance",
-												"release-encumbrance",
-												"{{encumbranceId}}"
-											]
-										}
-									},
-									"response": []
-								},
-								{
 									"name": "Delete transaction",
 									"event": [
 										{
@@ -7442,6 +8474,58 @@
 												"finance-storage",
 												"transactions",
 												"{{encumbranceId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete transaction to release",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Encumbrance is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/transactions/{{encumbranceIdToRelease}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"transactions",
+												"{{encumbranceIdToRelease}}"
 											]
 										}
 									},
@@ -9250,6 +10334,64 @@
 											"path": [
 												"finance",
 												"payments"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create invoice transaction summary",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Trasaction allocation is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"invoiceTransactionSummaryId\", pm.response.json().id); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"id\": \"{{$guid}}\",\n  \"numEncumbrances\": 1,\n  \"numPaymentsCredits\": 1\n}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/invoice-transaction-summaries",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"invoice-transaction-summaries"
 											]
 										}
 									},
@@ -11762,6 +12904,904 @@
 					"name": "Budgets",
 					"item": [
 						{
+							"name": "Budget deletion with existing transaction",
+							"item": [
+								{
+									"name": "Create fiscal year  - required for budgets",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "8c99d17f-1af5-4b91-97f6-83e472944ca2",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.variables.set(\"allocFyContent\", JSON.stringify(utils.buildFiscalYearMinContent(\"ALLOCFY2019\")));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd0615f0-1de3-42ac-bcfb-f6eb63da0056",
+												"exec": [
+													"pm.test(\"Ledger is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"allocFiscalYearId\", pm.response.json().id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocFyContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/fiscal-years",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"fiscal-years"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create ledger - required for funds",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Ledger is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"allocLedgerId\", pm.response.json().id); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let ledger = utils.buildLedgerMinContent(\"ALLOC-LDGR\", \"Test transaction ledger\");",
+													"ledger.fiscalYearOneId = pm.environment.get(\"allocFiscalYearId\");",
+													"pm.environment.set(\"allocLedgerContent\", JSON.stringify(ledger));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocLedgerContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/ledgers",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"ledgers"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create fund - required for transactions",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let record = {};",
+													"",
+													"pm.test(\"Fund is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"});",
+													"",
+													"pm.test(\"Fund content is valid\", function() {",
+													"    utils.validateCompositeFund(record);",
+													"    pm.environment.set(\"toFundId\", record.fund.id); ",
+													"    pm.expect(record.fund.code).to.eql(\"ALLOC-FND\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.variables.set(\"allocFundContent\", JSON.stringify(utils.buildCompositeFund(utils.buildFundMinContent(\"ALLOC-FND\", pm.environment.get(\"allocLedgerId\")))));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocFundContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"funds"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create budget",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"let record = {};",
+													"",
+													"pm.test(\"Budget is created\", function () {",
+													"    pm.response.to.have.status(201);",
+													"    record = pm.response.json();",
+													"});",
+													"",
+													"pm.test(\"Budget content is valid\", function() {",
+													"    utils.validateBudget(record);",
+													"    pm.environment.set(\"allocBudgetId\", record.id); ",
+													"    pm.expect(record.name).to.eql(\"ALLOC-BDGT\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.variables.set(\"allocBudgetContent\", JSON.stringify(utils.buildBudgetMinContent(\"ALLOC-BDGT\", pm.environment.get(\"toFundId\"), pm.environment.get(\"allocFiscalYearId\"))));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocBudgetContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"budgets"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get fiscal year by id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Fiscal year is retrieved\", function() {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateFiscalYear(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/fiscal-years/{{allocFiscalYearId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"fiscal-years",
+												"{{allocFiscalYearId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get fund record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Fund is retrieved\", function () {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateCompositeFund(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds/{{toFundId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"funds",
+												"{{toFundId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get budget record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Budget is retrieved\", function () {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateBudget(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{allocBudgetId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"budgets",
+												"{{allocBudgetId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create allocations",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let record = {};",
+													"pm.test(\"Trasaction allocation is created\", () => {",
+													"    pm.response.to.have.status(201);",
+													"    pm.environment.set(\"transactionId\", pm.response.json().id); ",
+													"    record = pm.response.json();",
+													"    pm.expect(record.transactionType).to.eql(\"Allocation\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"pm.environment.set(\"allocationContent\", JSON.stringify(utils.buildTransactionMinContent(25, pm.environment.get(\"allocFiscalYearId\"), pm.environment.get(\"toFundId\"), \"Allocation\")));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{allocationContent}}"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/allocations",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"allocations"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get transaction by id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"let utils = eval(globals.loadUtils);",
+													"",
+													"pm.test(\"Transaction allocation is retrieved\", function () {",
+													"    pm.response.to.be.ok;",
+													"    utils.validateTransaction(pm.response.json());",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/transactions/{{transactionId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"transactions",
+												"{{transactionId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete budget record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Budget deletion is failed\", function () {",
+													"    pm.response.to.have.status(400).and.to.be.json;",
+													"    pm.expect(pm.response.json().errors).to.have.lengthOf(1);",
+													"    pm.expect(pm.response.json().errors[0].code).to.contain(\"transactionIsPresentBudgetDeleteError\");",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{allocBudgetId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"budgets",
+												"{{allocBudgetId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete transaction",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Transaction is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance-storage/transactions/{{transactionId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance-storage",
+												"transactions",
+												"{{transactionId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete budget record after transaction",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Budget is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/budgets/{{allocBudgetId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"budgets",
+												"{{allocBudgetId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete fund record",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Fund is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/funds/{{toFundId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"funds",
+												"{{toFundId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Ledger",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Ledger is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/ledgers/{{allocLedgerId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"ledgers",
+												"{{allocLedgerId}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete fiscal year",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+												"exec": [
+													"pm.test(\"Fiscal year is deleted\", () => pm.response.to.have.status(204));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-token",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/fiscal-years/{{allocFiscalYearId}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"finance",
+												"fiscal-years",
+												"{{allocFiscalYearId}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Delete budget with existing transaction",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "3c2a4aeb-fe87-497c-911a-8ba5937cdaed",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "0aeef2d9-e673-4685-931a-eae01611e9c5",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
 							"name": "Create first budget for negative tests",
 							"event": [
 								{
@@ -12321,6 +14361,122 @@
 							"response": []
 						},
 						{
+							"name": "Create order transaction summaries",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "8c99d17f-1af5-4b91-97f6-83e472944ca2",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd0615f0-1de3-42ac-bcfb-f6eb63da0056",
+										"exec": [
+											"pm.test(\"Order transaction summary is created\", () => {",
+											"    pm.environment.set(\"orderTransactionIdBudget\", pm.response.json().id);",
+											"    pm.response.to.have.status(201);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"id\": \"e5ae4afd-3fa9-494e-a972-f541df9b8772\",\r\n  \"numTransactions\": 1\r\n}\r\n"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/order-transaction-summaries",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"order-transaction-summaries"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create invoice transaction summary",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Trasaction allocation is created\", () => {",
+											"    pm.environment.set(\"invoiceTransactionSummaryId\", pm.response.json().id);",
+											"    pm.response.to.have.status(201);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"id\": \"187c7e6f-782a-4bd0-a04e-7174d4da2415\",\n  \"numEncumbrances\": 1,\n  \"numPaymentsCredits\": 1\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/finance/invoice-transaction-summaries",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"finance",
+										"invoice-transaction-summaries"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Create encumbrances",
 							"event": [
 								{
@@ -12350,6 +14506,7 @@
 											"let transactionEncumbrance = utils.buildTransactionMinContent(25, pm.environment.get(\"fiscalYearId\"), pm.environment.get(\"fundId\"), \"Encumbrance\");",
 											"",
 											"transactionEncumbrance.encumbrance = encumbranceMinContent;",
+											"transactionEncumbrance.encumbrance.sourcePurchaseOrderId = pm.environment.get(\"orderTransactionIdBudget\");",
 											"transactionEncumbrance.fromFundId = pm.environment.get(\"fundId\");",
 											"pm.environment.set(\"encumbranceContent\", JSON.stringify(transactionEncumbrance));",
 											""
@@ -14985,13 +17142,13 @@
 	],
 	"variable": [
 		{
-			"id": "22eb36c6-e53e-4342-ba66-071e162df35b",
+			"id": "e3b302bf-6339-4992-a16d-26e18304bbbf",
 			"key": "mod-financeResourcesURL",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-finance/master/src/test/resources",
 			"type": "string"
 		},
 		{
-			"id": "ad5d08e2-ad4a-448f-af44-394f071c896e",
+			"id": "4f02dcb6-bdb7-4ef6-a97c-cdb253160f8d",
 			"key": "testTenant",
 			"value": "finance_api_tests",
 			"type": "string"


### PR DESCRIPTION
# Approach
https://issues.folio.org/browse/MODFIN-117
need to update API test with case to test meaningful error message upon failed budget deletion

Verified on testing env.
![image](https://user-images.githubusercontent.com/14274525/78110093-1be5f280-7403-11ea-907a-cac947d09ad8.png)

![image](https://user-images.githubusercontent.com/14274525/78110291-58195300-7403-11ea-8805-36ca9dd07f0e.png)
![image](https://user-images.githubusercontent.com/14274525/78110317-65ced880-7403-11ea-8f28-0f9a600423aa.png)
