### PR TITLE
MODQM-4 - Api Tests for PUT records-editor/marc-records/id

### DIFF
--- a/mod-quick-marc/mod-quick-marc.postman_collection.json
+++ b/mod-quick-marc/mod-quick-marc.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b3994aed-31bf-47ca-9431-2abc5c41223e",
+		"_postman_id": "d9c5fe0a-1d11-445d-a7b3-95372c0ea2d4",
 		"name": "mod-quick-marc",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1268,6 +1268,75 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Edit record",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"utils.sendGetRequest(\"/records-editor/records?instanceId=\" + pm.variables.get(\"instanceId\"), (err, res) => {",
+									"    let quickMarcJson = res.json();",
+									"    quickMarcJson.fields[quickMarcJson.fields.findIndex(field => field.tag === \"008\")].content.Date1 = \"2020\";",
+									"    quickMarcJson.fields[quickMarcJson.fields.findIndex(field => field.tag === \"008\")].content.Date2 = \"2021\";",
+									"    quickMarcJson.fields[quickMarcJson.fields.findIndex(field => field.tag === \"035\")].content = \"12345678\";",
+									"    pm.environment.set(\"quickMarcJsonId\", quickMarcJson.externalDtoId)",
+									"    pm.environment.set(\"modifiedQuickMarcJsonBody\", JSON.stringify(quickMarcJson));",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{modifiedQuickMarcJsonBody}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/records-editor/records/{{quickMarcJsonId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"records-editor",
+								"records",
+								"{{quickMarcJsonId}}"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"event": [
@@ -1413,6 +1482,206 @@
 									"key": "instanceId",
 									"value": "000-111"
 								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Edit record wrong fixed field length",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+								"exec": [
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"utils.sendGetRequest(\"/records-editor/records?instanceId=\" + pm.variables.get(\"instanceId\"), (err, res) => {",
+									"    let quickMarcJson = res.json();",
+									"    quickMarcJson.fields[quickMarcJson.fields.findIndex(field => field.tag === \"008\")].content.Date1 = \"20201\";",
+									"    quickMarcJson.fields[quickMarcJson.fields.findIndex(field => field.tag === \"008\")].content.Date2 = \"20211\";",
+									"    pm.environment.set(\"quickMarcJsonId\", quickMarcJson.externalDtoId)",
+									"    pm.environment.set(\"modifiedQuickMarcJsonBody\", JSON.stringify(quickMarcJson));",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{modifiedQuickMarcJsonBody}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/records-editor/records/{{quickMarcJsonId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"records-editor",
+								"records",
+								"{{quickMarcJsonId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Edit record Id mismatch",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+								"exec": [
+									"let error = {};",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    error = pm.response.json();",
+									"});",
+									"",
+									"pm.test(\"Record content is valid\", function() {",
+									"    pm.expect(error.code).to.eql(\"HTTP_BAD_REQUEST\");",
+									"    pm.expect(error.message).to.eql(\"request id and entity id are not equal\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"utils.sendGetRequest(\"/records-editor/records?instanceId=\" + pm.variables.get(\"instanceId\"), (err, res) => {",
+									"    let quickMarcJson = res.json();",
+									"    pm.environment.set(\"quickMarcJsonId\", quickMarcJson.parsedRecordId)",
+									"    pm.environment.set(\"modifiedQuickMarcJsonBody\", JSON.stringify(quickMarcJson));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{{modifiedQuickMarcJsonBody}}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/records-editor/records/{{quickMarcJsonId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"records-editor",
+								"records",
+								"{{quickMarcJsonId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Edit record bad UUID",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+								"exec": [
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							},
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/records-editor/records/1234-5678",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"records-editor",
+								"records",
+								"1234-5678"
 							]
 						}
 					},
@@ -1760,19 +2029,19 @@
 	],
 	"variable": [
 		{
-			"id": "200e1098-8bbd-4109-99ad-c4008638410c",
+			"id": "d07a443b-7e2b-4cea-bb11-3b9f6af609b4",
 			"key": "marcRecordsResourceUrl",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-source-record-storage/master/mod-source-record-storage-server/src/main/resources/sampledata/sampleMarcRecords.json",
 			"type": "string"
 		},
 		{
-			"id": "6231bd37-69a7-42c9-a19d-8b8290bdec30",
+			"id": "838b3829-61e1-44da-b49b-b3efa13ed567",
 			"key": "testTenant",
 			"value": "quick_marc_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "60dc1a6d-a15b-40da-b503-188db7029f86",
+			"id": "28e70be8-1f25-4090-9f1a-2d0fe30ea03d",
 			"key": "moduleName",
 			"value": "mod-quick-marc",
 			"type": "string"

--- a/mod-quick-marc/mod-quick-marc.postman_collection.json
+++ b/mod-quick-marc/mod-quick-marc.postman_collection.json
@@ -1048,15 +1048,13 @@
 											"pm.test(\"Record created\", function () {",
 											"    pm.response.to.have.status(201);",
 											"    let recordId = pm.response.json().id;",
-											"    console.log(\"Created record id: \" + recordId);",
 											"    let instanceId = pm.response.json().externalIdsHolder.instanceId;",
-											"    console.log(\"Created instance id: \" + instanceId);",
 											"    pm.expect(recordId, \"The record id is missing but required for API test\").to.not.be.empty;",
 											"    let metadata = pm.response.json().metadata;",
 											"    pm.expect(metadata, \"The metadata is empty but required for API test\").to.not.be.empty;",
 											"    // Remember created record id",
-											"    pm.environment.set(\"recordId\", recordId);",
-											"    pm.environment.set(\"instanceId\", instanceId);",
+											"    pm.variables.set(\"recordId\", recordId);",
+											"    pm.variables.set(\"instanceId\", instanceId);",
 											"});",
 											""
 										],
@@ -1068,9 +1066,15 @@
 									"script": {
 										"id": "cacc131d-5556-41ea-aaf8-92e6907f7a80",
 										"exec": [
-											"let parsedRecord = pm.globals.get(\"testData\").srsData.parsedRecord;",
+											"let utils = eval(globals.loadUtils);",
 											"",
-											"pm.variables.set(\"parsedRecordContent\",  JSON.stringify(parsedRecord));"
+											"pm.sendRequest(pm.variables.get(\"marcRecordsResourceUrl\"), (err, res) => {",
+											"    let parsedRecords  = res.json();",
+											"    let parsedRecord = parsedRecords[0];",
+											"    console.log(parsedRecord);",
+											"    ",
+											"    pm.variables.set(\"parsedRecordContent\", JSON.stringify(parsedRecord));",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -1333,7 +1337,7 @@
 						"header": [
 							{
 								"key": "x-okapi-token",
-								"value": "{{xokapitoken-admin}}"
+								"value": "{{xokapitoken}}"
 							}
 						],
 						"url": {
@@ -1390,7 +1394,7 @@
 						"header": [
 							{
 								"key": "x-okapi-token",
-								"value": "{{xokapitoken-admin}}"
+								"value": "{{xokapitoken}}"
 							}
 						],
 						"url": {
@@ -1634,10 +1638,7 @@
 					"        \"id\": pm.variables.get(\"testTenant\"),",
 					"        \"name\": \"Test quickMARC tenant\",",
 					"        \"description\": \"Tenant for test purpose\"",
-					"    },",
-					"    srsData: {",
-					"\t\tparsedRecord: {\"leader\":\"01741nam a2200373 cb4500\",\"fields\":[{\"001\":\"101073931X\"},{\"003\":\"DE-601\"},{\"005\":\"20180416162657.0\"},{\"008\":\"180111s2018    sz            000 0 eng d\"},{\"020\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"3319643991\"},{\"9\":\"3-319-64399-1\"}]}},{\"020\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"9783319643991\"},{\"9\":\"978-3-319-64399-1\"}]}},{\"020\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"9783319644004 (electronic)\"},{\"9\":\"978-3-319-64400-4\"}]}},{\"035\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"(OCoLC)ocn992783736\"}]}},{\"035\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"(OCoLC)992783736\"}]}},{\"035\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"(DE-599)GBV101073931X\"}]}},{\"040\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"b\":\"ger\"},{\"c\":\"GBVCP\"},{\"e\":\"rda\"}]}},{\"041\":{\"ind1\":\"0\",\"ind2\":\" \",\"subfields\":[{\"a\":\"eng\"}]}},{\"245\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"Futures, biometrics and neuroscience research\"},{\"c\":\"Luiz Moutinho, Mladen Sokele, editors\"}]}},{\"264\":{\"ind1\":\"3\",\"ind2\":\"1\",\"subfields\":[{\"a\":\"Cham\"},{\"b\":\"Palgrave Macmillan\"},{\"c\":\"[2018]\"}]}},{\"300\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"xxix, 224 Seiten\"},{\"b\":\"Illustrationen\"}]}},{\"336\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Text\"},{\"b\":\"txt\"},{\"2\":\"rdacontent\"}]}},{\"337\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"ohne Hilfsmittel zu benutzen\"},{\"b\":\"n\"},{\"2\":\"rdamedia\"}]}},{\"338\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Band\"},{\"b\":\"nc\"},{\"2\":\"rdacarrier\"}]}},{\"490\":{\"ind1\":\"0\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Innovative research methodologies in management\"},{\"v\":\" / Luiz Moutinho, Mladen Sokele ; Volume 2\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Enthält 9 Beiträge\"}]}},{\"650\":{\"ind1\":\" \",\"ind2\":\"7\",\"subfields\":[{\"8\":\"1.1 x\"},{\"a\":\"Betriebswirtschaftslehre\"},{\"0\":\"(DE-601)091351391\"},{\"0\":\"(DE-STW)12041-5\"},{\"2\":\"stw\"}]}},{\"650\":{\"ind1\":\" \",\"ind2\":\"7\",\"subfields\":[{\"8\":\"1.2 x\"},{\"a\":\"Management\"},{\"0\":\"(DE-601)091376173\"},{\"0\":\"(DE-STW)12085-6\"},{\"2\":\"stw\"}]}},{\"650\":{\"ind1\":\" \",\"ind2\":\"7\",\"subfields\":[{\"8\":\"1.3 x\"},{\"a\":\"Wissenschaftliche Methode\"},{\"0\":\"(DE-601)091401445\"},{\"0\":\"(DE-STW)16727-0\"},{\"2\":\"stw\"}]}},{\"700\":{\"ind1\":\"1\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Moutinho, Luiz\"},{\"e\":\"HerausgeberIn\"},{\"4\":\"edt\"},{\"0\":\"(DE-601)509450954\"},{\"0\":\"(DE-588)131450204\"}]}},{\"700\":{\"ind1\":\"1\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Sokele, Mladen\"},{\"e\":\"HerausgeberIn\"},{\"4\":\"edt\"}]}},{\"830\":{\"ind1\":\" \",\"ind2\":\"0\",\"subfields\":[{\"a\":\"Innovative research methodologies in management\"},{\"b\":\" / Luiz Moutinho, Mladen Sokele\"},{\"v\":\"Volume 2\"},{\"9\":\"2.2018\"},{\"w\":\"(DE-601)1011380293\"}]}},{\"856\":{\"ind1\":\"4\",\"ind2\":\"2\",\"subfields\":[{\"y\":\"Inhaltsverzeichnis\"},{\"u\":\"http://www.gbv.de/dms/zbw/101073931X.pdf\"},{\"m\":\"V:DE-601;B:DE-206\"},{\"q\":\"application/pdf\"},{\"3\":\"Inhaltsverzeichnis\"}]}},{\"900\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"GBV\"},{\"b\":\"ZBW Kiel <206>\"},{\"d\":\"!H:! A18-1775\"},{\"x\":\"L\"},{\"z\":\"LC\"},{\"s\":\"206/1\"}]}},{\"954\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"0\":\"ZBW Kiel <206>\"},{\"a\":\"26\"},{\"b\":\"1740761685\"},{\"c\":\"01\"},{\"f\":\"H:\"},{\"d\":\"A18-1775\"},{\"e\":\"u\"},{\"x\":\"206/1\"}]}}]}",
-					"\t}",
+					"    }",
 					"});",
 					"",
 					"postman.setGlobalVariable(\"loadUtils\", function loadUtils() {",
@@ -1649,16 +1650,6 @@
 					"     */",
 					"    utils.buildOkapiUrl = function(path) {",
 					"        return pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + path;",
-					"    };",
-					"",
-					"    /**",
-					"     * Sends delete request based on specified path.",
-					"     * The Promise is returned as a result of the operation holding the http code of the response once completed.",
-					"     */",
-					"    utils.processDeleteRequest = function(path) {",
-					"        return new Promise((resolve) => {",
-					"            utils.sendDeleteRequest(path, (err, response) => resolve(response.code));",
-					"        });",
 					"    };",
 					"",
 					"    utils.getModuleId = function(moduleName, bodyHandler) {",
@@ -1710,7 +1701,10 @@
 					"",
 					"        pm.environment.unset(\"instanceId\");",
 					"        pm.environment.unset(\"enabledModules\");",
+					"        pm.environment.unset(\"recordId\");",
+					"        pm.environment.unset(\"fromDate\");",
 					"        pm.environment.unset(\"xokapitoken\");",
+					"        pm.environment.unset(\"xokapitoken-admin\");",
 					"        pm.environment.unset(\"xokapitoken-testAdmin\");",
 					"",
 					"        // Unset schema variables",
@@ -1766,19 +1760,19 @@
 	],
 	"variable": [
 		{
-			"id": "f23712a2-a255-4c7d-b6d1-7797f003b759",
-			"key": "snapshotResourceUrl",
-			"value": "https://raw.githubusercontent.com/folio-org/data-import-raml-storage/09ba418a3f3e07594cf2175ea34d5682c26eea4c/examples/mod-source-record-storage/snapshot.sample",
+			"id": "200e1098-8bbd-4109-99ad-c4008638410c",
+			"key": "marcRecordsResourceUrl",
+			"value": "https://raw.githubusercontent.com/folio-org/mod-source-record-storage/master/mod-source-record-storage-server/src/main/resources/sampledata/sampleMarcRecords.json",
 			"type": "string"
 		},
 		{
-			"id": "63ea8a95-0c69-4ec7-a06a-269ee7bb5a64",
+			"id": "6231bd37-69a7-42c9-a19d-8b8290bdec30",
 			"key": "testTenant",
 			"value": "quick_marc_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "3319edd4-8c06-4ec1-89ee-60bcc63c4af7",
+			"id": "60dc1a6d-a15b-40da-b503-188db7029f86",
 			"key": "moduleName",
 			"value": "mod-quick-marc",
 			"type": "string"

--- a/mod-quick-marc/mod-quick-marc.postman_collection.json
+++ b/mod-quick-marc/mod-quick-marc.postman_collection.json
@@ -1,0 +1,1788 @@
+{
+	"info": {
+		"_postman_id": "b3994aed-31bf-47ca-9431-2abc5c41223e",
+		"name": "mod-quick-marc",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Setup",
+			"item": [
+				{
+					"name": "Create tenant and enable modules",
+					"item": [
+						{
+							"name": "Login by existing admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.environment.set(\"xokapitoken-admin\", postman.getResponseHeader(\"x-okapi-token\"));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{  \r\n   \"username\":\"{{username}}\",\r\n   \"password\":\"{{password}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"login"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create new tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"tenantData\", JSON.stringify(globals.testData.tenant));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
+										"exec": [
+											"// In case the tenant was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"Tenant created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-admin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{tenantData}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Enable modules for new tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.getModuleId(\"mod-quick-marc\", bodyHandler);",
+											"utils.getModuleId(\"mod-login\", bodyHandler);",
+											"utils.getModuleId(\"mod-permissions\", bodyHandler);",
+											"",
+											"var modulesToEnable = [];",
+											"",
+											"function bodyHandler(moduleId) {",
+											"\tmodulesToEnable.push({",
+											"\t\t\"id\" : moduleId,",
+											"\t\t\"action\": \"enable\"",
+											"\t});",
+											"    pm.variables.set(\"modulesToEnable\", JSON.stringify(modulesToEnable));",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"postman.setNextRequest(null);",
+											"pm.test(\"Enabled required modules\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"enabledModules\", pm.response.json());",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToEnable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create admin user",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "76c0a072-8ef6-4371-b926-f56d6a3218a0",
+										"exec": [
+											"pm.variables.set(\"userData\", JSON.stringify(globals.testData.users.admin.user));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d98143bb-5fc0-4394-ac89-bff8d0df33fe",
+										"exec": [
+											"// In case the user was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"User created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userData}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create credentials for admin user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "5542417e-4b64-431c-8b07-7f5b5e9179ff",
+										"exec": [
+											"pm.test(globals.testData.users.admin.user.username + \" user's credentials created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "de3203a8-0abe-4599-aee0-b34306d051de",
+										"exec": [
+											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.admin.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"credentials"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add all permissions to admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1f1202b1-b74a-46cc-8fcd-e5d9b76d53b7",
+										"exec": [
+											"pm.test(globals.testData.users.admin.user.username + \" user's permissions created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "dded3598-c238-487d-b06c-721c60509cf4",
+										"exec": [
+											"eval(globals.loadUtils).sendGetRequest('/perms/permissions?length=1000&query=(subPermissions=\"\" NOT subPermissions ==/respectAccents []) and (cql.allRecords=1 NOT childOf <>/respectAccents [])', (err, res) => {",
+											"        let userPermissions = globals.testData.users.admin.permissions;",
+											"        userPermissions.permissions = res.json().permissions.map(perm => perm.permissionName);",
+											"        pm.variables.set(\"userPermissions\", JSON.stringify(userPermissions));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userPermissions}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"perms",
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Enable mod-authtoken for new tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"utils.getModuleId(\"mod-authtoken\", bodyHandler);",
+											"",
+											"var modulesToEnable = [];",
+											"",
+											"function bodyHandler(moduleId) {",
+											"\tmodulesToEnable.push({",
+											"\t\t\"id\" : moduleId,",
+											"\t\t\"action\": \"enable\"",
+											"\t});",
+											"    pm.variables.set(\"modulesToEnable\", JSON.stringify(modulesToEnable));",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"postman.setNextRequest(null);",
+											"pm.test(\"mod-authtoken is enabled\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"    pm.environment.set(\"enabledModules\", pm.response.json());",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-admin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToEnable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Login by new admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"// In case the new user cannot be logged in no sense to run further tests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});",
+											"",
+											"pm.environment.set(\"xokapitoken-testAdmin\", postman.getResponseHeader(\"x-okapi-token\"));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a59f5097-d5cb-4e46-8bf6-3bddff268e65",
+										"exec": [
+											"pm.variables.set(\"newUserCreds\", JSON.stringify(globals.testData.users.admin.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{newUserCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"login"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Create regular user",
+					"item": [
+						{
+							"name": "Create user",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "76c0a072-8ef6-4371-b926-f56d6a3218a0",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"userData\", JSON.stringify(globals.testData.users.regular.user));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "d98143bb-5fc0-4394-ac89-bff8d0df33fe",
+										"exec": [
+											"// In case the user was not created no sense to run further requests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"User created - Expected Created (201)\", () => {",
+											"    pm.response.to.have.status(201);",
+											"",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userData}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create credentials",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "5542417e-4b64-431c-8b07-7f5b5e9179ff",
+										"exec": [
+											"pm.test(globals.testData.users.regular.user.username + \" user's credentials created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "de3203a8-0abe-4599-aee0-b34306d051de",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"userCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-testAdmin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/credentials",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"credentials"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Define permissions",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1f1202b1-b74a-46cc-8fcd-e5d9b76d53b7",
+										"exec": [
+											"pm.test(globals.testData.users.regular.user.username + \" user's permissions created\", () => pm.response.to.have.status(201));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "dded3598-c238-487d-b06c-721c60509cf4",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.variables.set(\"userPermissions\", JSON.stringify(globals.testData.users.regular.permissions));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{userPermissions}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/perms/users",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"perms",
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Login by new user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+										"exec": [
+											"// In case the new user cannot be logged in no sense to run further tests",
+											"postman.setNextRequest(null);",
+											"",
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    // All is okay so running further requests",
+											"    postman.setNextRequest();",
+											"});",
+											"",
+											"pm.environment.set(\"xokapitoken\", postman.getResponseHeader(\"x-okapi-token\"));"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a59f5097-d5cb-4e46-8bf6-3bddff268e65",
+										"exec": [
+											"pm.variables.set(\"newUserCreds\", JSON.stringify(globals.testData.users.regular.credentials));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{newUserCreds}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/authn/login",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"authn",
+										"login"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Load schemas for validation",
+					"item": [
+						{
+							"name": "Get schemas and setup env variables",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "f930ca9d-df31-4572-90c8-63f5243ae30e",
+										"exec": [
+											"let utils = eval(globals.loadUtils);\r",
+											"\r",
+											"pm.test(\"Module has schemas to load\", function () {\r",
+											"    pm.response.to.be.ok;\r",
+											"    pm.response.to.have.jsonBody();\r",
+											"\r",
+											"    let schemas = pm.response.json();\r",
+											"    pm.expect(schemas).to.not.be.empty;\r",
+											"    traverse(pm.response.json());\r",
+											"});\r",
+											"\r",
+											"function traverse(schemas) {\r",
+											"    const timerId = setTimeout(() => { }, 60000);\r",
+											"\r",
+											"    var promises = schemas.map(path => fetchSchema(path));\r",
+											"    Promise.all(promises)\r",
+											"        .then(result => {\r",
+											"            let failedSchemas = schemas.filter(path => !result.includes(path));\r",
+											"            pm.test(\"All json schemas are loaded\", () => pm.expect(failedSchemas, failedSchemas.join()).to.be.empty);\r",
+											"            clearTimeout(timerId);\r",
+											"        })\r",
+											"        .catch((err, path) => {\r",
+											"            clearTimeout(timerId);\r",
+											"            pm.test(\"One or more schema could not be loaded: \" + err, () => pm.expect.fail());\r",
+											"            console.log(\"Failure to load \" + path, err);\r",
+											"        });\r",
+											"}\r",
+											"\r",
+											"function fetchSchema(path) {\r",
+											"    let getRequest = buildGetSchemaRequest(path);\r",
+											"    return new Promise((resolve, reject) => {\r",
+											"        pm.sendRequest(getRequest, (err, response) => {\r",
+											"\r",
+											"            if (!err) {\r",
+											"                if (response.code === 200) {\r",
+											"                    let content = replaceResponseRefWithName(response.text());\r",
+											"                    let name = extractName(path);\r",
+											"                    setEnvironmentVariable(name, content);\r",
+											"                    resolve(path);\r",
+											"                } else {\r",
+											"                    resolve();\r",
+											"                }\r",
+											"            } else {\r",
+											"                reject(err);\r",
+											"            }\r",
+											"        });\r",
+											"    });\r",
+											"}\r",
+											"\r",
+											"function setEnvironmentVariable(name, data) {\r",
+											"    pm.environment.set(utils.schemaPrefix + name, data);\r",
+											"}\r",
+											"\r",
+											"function extractName(url) {\r",
+											"    return url.substring(url.lastIndexOf(\"/\") + 1);\r",
+											"}\r",
+											"\r",
+											"function replaceResponseRefWithName(text) {\r",
+											"    return text.replace(/\"\\$ref\":\"([^\"]+\\/)(?=.*(\\.json|\\.schema))/g, \"\\\"$ref\\\":\\\"\" + utils.schemaPrefix);\r",
+											"}\r",
+											"\r",
+											"function buildGetSchemaRequest(path) {\r",
+											"    let getRequest = utils.buildPmRequest(\"/_/jsonSchemas?path=\" + path, \"GET\");\r",
+											"    getRequest.header['X-Okapi-Module-Id'] = pm.variables.get(\"modQuickMarcId\");\r",
+											"    return getRequest;\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "789cccc8-2479-48c7-ac26-5e35328874bd",
+										"exec": [
+											"let utils = eval(globals.loadUtils);\r",
+											"const moduleName = 'mod-quick-marc';\r",
+											"\r",
+											"pm.sendRequest(utils.buildOkapiUrl('/_/proxy/tenants/' + pm.variables.get(\"testTenant\") + '/modules?provides=jsonSchemas'), (err, response) => {\r",
+											"    pm.test(\"jsonSchemas provided by \" + moduleName, function () {\r",
+											"        pm.expect(err).to.equal(null);\r",
+											"        pm.expect(response.text()).to.include(moduleName);\r",
+											"\r",
+											"        let moduleId = response.json().map(element => element.id).filter(modId => modId.includes(moduleName))[0];\r",
+											"        console.log(\"Module id: \" + moduleId);\r",
+											"    \tpm.variables.set(\"modQuickMarcId\", moduleId);\r",
+											"    });\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Module-Id",
+										"type": "text",
+										"value": "{{modQuickMarcId}}"
+									},
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/jsonSchemas",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"jsonSchemas"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "9b589a48-d3fa-4985-85c4-8b7dcda638a9",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "b882afd4-d85f-4006-9746-08bea97bbdf5",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Prepare SRS record",
+					"item": [
+						{
+							"name": "Create snapshot",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "f7bced58-ce19-4644-b63a-5c8ea3316a5f",
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.variables.set('srsSnapshotId', uuid.v4());",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "ef732e35-2c07-4863-9e4c-0046ed1bd21c",
+										"exec": [
+											"pm.test(\"Snapshot creation status\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    pm.response.to.have.jsonBody(\"jobExecutionId\", pm.variables.get('srsSnapshotId'));",
+											"",
+											"    // Set the fromDate param value as current time",
+											"    storeFromDate();",
+											"});",
+											"",
+											"function storeFromDate() {",
+											"    // Set the fromDate param value as current time",
+											"    let moment = require('moment');",
+											"    let metadata = pm.response.json().metadata;",
+											"    // Get time from metadata to work with server time",
+											"    let currentDateTime = metadata ? moment(metadata.createdDate) : moment();",
+											"    pm.environment.set(\"fromDate\", currentDateTime.utc().subtract(1, 'seconds').format(\"YYYY-MM-DDTHH:mm:ss[Z]\"));",
+											"    console.log(\"From date: \" + pm.environment.get(\"fromDate\"));",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "X-Okapi-Token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"jobExecutionId\": \"{{srsSnapshotId}}\",\n  \"status\": \"PARSING_IN_PROGRESS\"\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/source-storage/snapshots",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"source-storage",
+										"snapshots"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "976c44b6-9efa-4f76-8818-aa488c6ceb15",
+										"exec": [
+											"pm.test(\"Record created\", function () {",
+											"    pm.response.to.have.status(201);",
+											"    let recordId = pm.response.json().id;",
+											"    console.log(\"Created record id: \" + recordId);",
+											"    let instanceId = pm.response.json().externalIdsHolder.instanceId;",
+											"    console.log(\"Created instance id: \" + instanceId);",
+											"    pm.expect(recordId, \"The record id is missing but required for API test\").to.not.be.empty;",
+											"    let metadata = pm.response.json().metadata;",
+											"    pm.expect(metadata, \"The metadata is empty but required for API test\").to.not.be.empty;",
+											"    // Remember created record id",
+											"    pm.environment.set(\"recordId\", recordId);",
+											"    pm.environment.set(\"instanceId\", instanceId);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "cacc131d-5556-41ea-aaf8-92e6907f7a80",
+										"exec": [
+											"let parsedRecord = pm.globals.get(\"testData\").srsData.parsedRecord;",
+											"",
+											"pm.variables.set(\"parsedRecordContent\",  JSON.stringify(parsedRecord));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "content-type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"snapshotId\": \"{{srsSnapshotId}}\",\r\n  \"matchedId\": \"{{$guid}}\",\r\n  \"recordType\": \"MARC\",\r\n  \"rawRecord\": {\r\n    \"content\": \"marc data goes here\"\r\n  },\r\n  \"externalIdsHolder\": {\r\n     \"instanceId\": \"24db5e55-478e-4da1-85b5-3e4ab41987eb\"\r\n  },\r\n  \"parsedRecord\": {\r\n    \"content\": {{parsedRecordContent}}\r\n  }\r\n}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/source-storage/records",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"source-storage",
+										"records"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Check created record",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d339cbd4-3b65-4fc6-b18e-166cfd412abc",
+										"exec": [
+											"pm.test(\"Records result status\", function () {",
+											"    pm.response.to.be.ok;",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Okapi-Tenant",
+										"type": "text",
+										"value": "{{testTenant}}"
+									},
+									{
+										"key": "X-Okapi-Token",
+										"type": "text",
+										"value": "{{xokapitoken-testAdmin}}"
+									}
+								],
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/source-storage/sourceRecords?query=recordType=MARC and metadata.createdDate>{{fromDate}}&limit=1",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"source-storage",
+										"sourceRecords"
+									],
+									"query": [
+										{
+											"key": "query",
+											"value": "recordType=MARC and metadata.createdDate>{{fromDate}}"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "3b3b7dd0-10c5-4ba9-8483-4749656dad81",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "7b3f3a80-f9bc-4f21-9c94-6c629034170a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Positive Tests",
+			"item": [
+				{
+					"name": "Get record by instanceId",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"let record = {};",
+									"",
+									"pm.test(\"Record found\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    record = pm.response.json();",
+									"});",
+									"",
+									"pm.test(\"Record content is valid\", function() {",
+									"    utils.validateQuickMarcJson(record);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/records-editor/records?instanceId={{instanceId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"records-editor",
+								"records"
+							],
+							"query": [
+								{
+									"key": "instanceId",
+									"value": "{{instanceId}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "eabc0e99-5321-4b94-8073-c1009945649c",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "42e30b13-2d65-40cc-871d-b736930858cb",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Negative Tests",
+			"item": [
+				{
+					"name": "Get record not found",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"let error = {};",
+									"",
+									"pm.test(\"Record not found\", function () {",
+									"    pm.response.to.have.status(404);",
+									"    error = pm.response.json();",
+									"});",
+									"",
+									"pm.test(\"Record content is valid\", function() {",
+									"    pm.expect(error.code).to.eql(\"HTTP_NOT_FOUND\");",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken-admin}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/records-editor/records?instanceId=445c41b1-5f0f-4bea-856b-b6459f97949c",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"records-editor",
+								"records"
+							],
+							"query": [
+								{
+									"key": "instanceId",
+									"value": "445c41b1-5f0f-4bea-856b-b6459f97949c"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get record bad instanceId",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fd474d88-68c0-4f40-ac6f-59e07108f064",
+								"exec": [
+									"let utils = eval(globals.loadUtils);",
+									"",
+									"pm.test(\"Record instanceId is incorrect\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5972827b-f9a4-47f7-98ab-7eacd59aa566",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-okapi-token",
+								"value": "{{xokapitoken-admin}}"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{url}}:{{okapiport}}/records-editor/records?instanceId=000-111",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{url}}"
+							],
+							"port": "{{okapiport}}",
+							"path": [
+								"records-editor",
+								"records"
+							],
+							"query": [
+								{
+									"key": "instanceId",
+									"value": "000-111"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Cleanup",
+			"item": [
+				{
+					"name": "Cleanup test tenant",
+					"item": [
+						{
+							"name": "Purge and disable all module for created tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "c0e4e7c3-311a-4fd3-8b45-3bab9a58256f",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"pm.sendRequest(utils.buildOkapiUrl(\"/_/proxy/tenants/\" + pm.variables.get(\"testTenant\") + \"/modules\"), (err, res) => {",
+											"    pm.test(\"Preparing request to disable modules\", () => {",
+											"        pm.expect(err).to.equal(null);",
+											"        pm.expect(res.code).to.equal(200);",
+											"        let modulesToDisable = res.json();",
+											"        modulesToDisable.forEach(entry => entry.action = \"disable\");",
+											"",
+											"        console.log(modulesToDisable);",
+											"        pm.variables.set(\"modulesToDisable\", JSON.stringify(modulesToDisable));",
+											"    });",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "a7a55baa-f34f-4e7b-bb2f-0f6a6d4ca951",
+										"exec": [
+											"let utils = eval(globals.loadUtils);",
+											"",
+											"pm.test(\"Disable all modules for test tenant\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.withBody;",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Okapi-Token",
+										"value": "{{xokapitoken-admin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{{modulesToDisable}}"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}/install?purge=true",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}",
+										"install"
+									],
+									"query": [
+										{
+											"key": "purge",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete test tenant",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "458e788d-f4f1-4a2e-bf7f-dce99511f09a",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "9b46996e-04ac-475d-8d3a-fe8947e8db87",
+										"exec": [
+											"pm.test(\"Tenant deleted - Expected Created (204)\", () => {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											"",
+											"// Remove all created variables",
+											"eval(globals.loadUtils).unsetTestVariables();"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-token",
+										"value": "{{xokapitoken-admin}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/_/proxy/tenants/{{testTenant}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"_",
+										"proxy",
+										"tenants",
+										"{{testTenant}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "e07ce59d-212b-4673-9fd7-346a4ca947e2",
+				"type": "text/javascript",
+				"exec": [
+					"// Global testing object - used in further tests",
+					"pm.globals.set(\"testData\", {",
+					"    // User templates with hardcoded id",
+					"    users: {",
+					"        admin: {",
+					"            user: {",
+					"                \"id\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"username\": \"mod-quick-marc-admin-user\",",
+					"                \"active\": true,",
+					"                \"personal\": {",
+					"                    \"firstName\": \"Tenant\",",
+					"                    \"lastName\": \"Admin\"",
+					"                }",
+					"            },",
+					"            credentials: {",
+					"                \"id\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"username\": \"mod-quick-marc-admin-user\",",
+					"                \"password\": \"mod-quick-marc-admin-password\"",
+					"            },",
+					"            permissions: {",
+					"                \"id\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"userId\": \"00000000-1111-5555-9999-999999999999\",",
+					"                \"permissions\": [ ]",
+					"            }",
+					"        },",
+					"        regular: {",
+					"            user: {",
+					"                \"id\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"username\": \"mod-quick-marc-user\",",
+					"                \"active\": true,",
+					"                \"personal\": {",
+					"                    \"firstName\": \"mod-quick-marc\",",
+					"                    \"lastName\": \"API Tests\"",
+					"                }",
+					"            },",
+					"            credentials: {",
+					"                \"id\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"username\": \"mod-quick-marc-user\",",
+					"                \"password\": \"mod-quick-marc-user-password\"",
+					"            },",
+					"            permissions: {",
+					"                \"id\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"userId\": \"00000001-1111-5555-9999-999999999999\",",
+					"                \"permissions\": [",
+					"                    \"records-editor.all\"",
+					"                ]",
+					"            }",
+					"        }",
+					"    },",
+					"    tenant: {",
+					"        \"id\": pm.variables.get(\"testTenant\"),",
+					"        \"name\": \"Test quickMARC tenant\",",
+					"        \"description\": \"Tenant for test purpose\"",
+					"    },",
+					"    srsData: {",
+					"\t\tparsedRecord: {\"leader\":\"01741nam a2200373 cb4500\",\"fields\":[{\"001\":\"101073931X\"},{\"003\":\"DE-601\"},{\"005\":\"20180416162657.0\"},{\"008\":\"180111s2018    sz            000 0 eng d\"},{\"020\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"3319643991\"},{\"9\":\"3-319-64399-1\"}]}},{\"020\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"9783319643991\"},{\"9\":\"978-3-319-64399-1\"}]}},{\"020\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"9783319644004 (electronic)\"},{\"9\":\"978-3-319-64400-4\"}]}},{\"035\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"(OCoLC)ocn992783736\"}]}},{\"035\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"(OCoLC)992783736\"}]}},{\"035\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"(DE-599)GBV101073931X\"}]}},{\"040\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"b\":\"ger\"},{\"c\":\"GBVCP\"},{\"e\":\"rda\"}]}},{\"041\":{\"ind1\":\"0\",\"ind2\":\" \",\"subfields\":[{\"a\":\"eng\"}]}},{\"245\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"Futures, biometrics and neuroscience research\"},{\"c\":\"Luiz Moutinho, Mladen Sokele, editors\"}]}},{\"264\":{\"ind1\":\"3\",\"ind2\":\"1\",\"subfields\":[{\"a\":\"Cham\"},{\"b\":\"Palgrave Macmillan\"},{\"c\":\"[2018]\"}]}},{\"300\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"xxix, 224 Seiten\"},{\"b\":\"Illustrationen\"}]}},{\"336\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Text\"},{\"b\":\"txt\"},{\"2\":\"rdacontent\"}]}},{\"337\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"ohne Hilfsmittel zu benutzen\"},{\"b\":\"n\"},{\"2\":\"rdamedia\"}]}},{\"338\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Band\"},{\"b\":\"nc\"},{\"2\":\"rdacarrier\"}]}},{\"490\":{\"ind1\":\"0\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Innovative research methodologies in management\"},{\"v\":\" / Luiz Moutinho, Mladen Sokele ; Volume 2\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Enthält 9 Beiträge\"}]}},{\"650\":{\"ind1\":\" \",\"ind2\":\"7\",\"subfields\":[{\"8\":\"1.1 x\"},{\"a\":\"Betriebswirtschaftslehre\"},{\"0\":\"(DE-601)091351391\"},{\"0\":\"(DE-STW)12041-5\"},{\"2\":\"stw\"}]}},{\"650\":{\"ind1\":\" \",\"ind2\":\"7\",\"subfields\":[{\"8\":\"1.2 x\"},{\"a\":\"Management\"},{\"0\":\"(DE-601)091376173\"},{\"0\":\"(DE-STW)12085-6\"},{\"2\":\"stw\"}]}},{\"650\":{\"ind1\":\" \",\"ind2\":\"7\",\"subfields\":[{\"8\":\"1.3 x\"},{\"a\":\"Wissenschaftliche Methode\"},{\"0\":\"(DE-601)091401445\"},{\"0\":\"(DE-STW)16727-0\"},{\"2\":\"stw\"}]}},{\"700\":{\"ind1\":\"1\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Moutinho, Luiz\"},{\"e\":\"HerausgeberIn\"},{\"4\":\"edt\"},{\"0\":\"(DE-601)509450954\"},{\"0\":\"(DE-588)131450204\"}]}},{\"700\":{\"ind1\":\"1\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Sokele, Mladen\"},{\"e\":\"HerausgeberIn\"},{\"4\":\"edt\"}]}},{\"830\":{\"ind1\":\" \",\"ind2\":\"0\",\"subfields\":[{\"a\":\"Innovative research methodologies in management\"},{\"b\":\" / Luiz Moutinho, Mladen Sokele\"},{\"v\":\"Volume 2\"},{\"9\":\"2.2018\"},{\"w\":\"(DE-601)1011380293\"}]}},{\"856\":{\"ind1\":\"4\",\"ind2\":\"2\",\"subfields\":[{\"y\":\"Inhaltsverzeichnis\"},{\"u\":\"http://www.gbv.de/dms/zbw/101073931X.pdf\"},{\"m\":\"V:DE-601;B:DE-206\"},{\"q\":\"application/pdf\"},{\"3\":\"Inhaltsverzeichnis\"}]}},{\"900\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"GBV\"},{\"b\":\"ZBW Kiel <206>\"},{\"d\":\"!H:! A18-1775\"},{\"x\":\"L\"},{\"z\":\"LC\"},{\"s\":\"206/1\"}]}},{\"954\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"0\":\"ZBW Kiel <206>\"},{\"a\":\"26\"},{\"b\":\"1740761685\"},{\"c\":\"01\"},{\"f\":\"H:\"},{\"d\":\"A18-1775\"},{\"e\":\"u\"},{\"x\":\"206/1\"}]}}]}",
+					"\t}",
+					"});",
+					"",
+					"postman.setGlobalVariable(\"loadUtils\", function loadUtils() {",
+					"    let utils = {};",
+					"    utils.schemaPrefix = \"schemas_\";",
+					"",
+					"    /**",
+					"     * Creates OKAPI URL endpoint based on provided path",
+					"     */",
+					"    utils.buildOkapiUrl = function(path) {",
+					"        return pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + path;",
+					"    };",
+					"",
+					"    /**",
+					"     * Sends delete request based on specified path.",
+					"     * The Promise is returned as a result of the operation holding the http code of the response once completed.",
+					"     */",
+					"    utils.processDeleteRequest = function(path) {",
+					"        return new Promise((resolve) => {",
+					"            utils.sendDeleteRequest(path, (err, response) => resolve(response.code));",
+					"        });",
+					"    };",
+					"",
+					"    utils.getModuleId = function(moduleName, bodyHandler) {",
+					"        pm.sendRequest({",
+					"            url: utils.buildOkapiUrl(\"/_/proxy/modules?latest=1&filter=\" + moduleName),",
+					"            method: \"GET\",",
+					"            header: {",
+					"                \"X-Okapi-Tenant\": pm.environment.get(\"xokapitenant\"),",
+					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken-admin\")",
+					"            }",
+					"        }, (err, res) => {",
+					"            pm.test(moduleName + \" module is available\", () => {",
+					"                pm.expect(err).to.equal(null);",
+					"                pm.expect(res).to.be.ok;",
+					"                let modulesArr = res.json();",
+					"                pm.expect(modulesArr).to.have.lengthOf.at.least(1);",
+					"                bodyHandler(modulesArr[modulesArr.length - 1].id);",
+					"            });",
+					"        });",
+					"    };",
+					"",
+					"    /**",
+					"     * Sends GET request and uses passed handler to handle result",
+					"     */",
+					"    utils.sendGetRequest = function(path, handler) {",
+					"        pm.sendRequest(utils.buildPmRequest(path, \"GET\"), handler);",
+					"    };",
+					"",
+					"    /**",
+					"     * Sends GET request and uses passed handler to handle result",
+					"     */",
+					"    utils.buildPmRequest = function(path, method) {",
+					"        return {",
+					"            url: utils.buildOkapiUrl(path),",
+					"            method: method,",
+					"            header: {",
+					"                \"X-Okapi-Tenant\": pm.variables.get(\"testTenant\"),",
+					"                \"X-Okapi-Token\": pm.environment.get(\"xokapitoken\")",
+					"            }",
+					"        };",
+					"    };",
+					"",
+					"    /**",
+					"     * Clean up variables",
+					"     */",
+					"    utils.unsetTestVariables = function() {",
+					"        pm.globals.unset(\"loadUtils\");",
+					"        pm.globals.unset(\"testData\");",
+					"",
+					"        pm.environment.unset(\"instanceId\");",
+					"        pm.environment.unset(\"enabledModules\");",
+					"        pm.environment.unset(\"xokapitoken\");",
+					"        pm.environment.unset(\"xokapitoken-testAdmin\");",
+					"",
+					"        // Unset schema variables",
+					"        pm.environment.values",
+					"            .filter(variable => variable.key.startsWith(utils.schemaPrefix))",
+					"            .forEach(schemaVar => pm.environment.unset(schemaVar.key));",
+					"    };",
+					"",
+					"    /**",
+					"     * Internal function to validate object against specified schema",
+					"     */",
+					"    utils.validateQuickMarcJson = function(jsonData) {",
+					"        utils._validateAgainstSchema(jsonData, JSON.parse(pm.environment.get(utils.schemaPrefix + \"quick_marc_json.json\")));",
+					"    };",
+					"",
+					"    /**",
+					"     * Internal function to load schema defenitions to tv4",
+					"     */",
+					"    utils._addSchemas = function() {",
+					"        //Create and add schemas for validation",
+					"        pm.environment.values",
+					"            .filter(variable => variable.key.startsWith(utils.schemaPrefix))",
+					"            .forEach(schemaVar => tv4.addSchema(schemaVar.key, JSON.parse(schemaVar.value)));",
+					"    };",
+					"    ",
+					"        /**",
+					"     * Internal function to validate object against specified schema",
+					"     */",
+					"    utils._validateAgainstSchema = function(jsonData, schema) {",
+					"        utils._addSchemas();",
+					"        var result = tv4.validateMultiple(jsonData, schema);",
+					"        pm.expect(result.valid).to.equal(true, \"Schema validation error: \" + JSON.stringify(result.errors));",
+					"        //make sure no schemas are missing",
+					"        pm.expect(result.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(result.missing));",
+					"    };",
+					"",
+					"    return utils;",
+					"",
+					"} + '; loadUtils();');"
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "55006f90-5989-4448-9d61-ff39c3e3191b",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "f23712a2-a255-4c7d-b6d1-7797f003b759",
+			"key": "snapshotResourceUrl",
+			"value": "https://raw.githubusercontent.com/folio-org/data-import-raml-storage/09ba418a3f3e07594cf2175ea34d5682c26eea4c/examples/mod-source-record-storage/snapshot.sample",
+			"type": "string"
+		},
+		{
+			"id": "63ea8a95-0c69-4ec7-a06a-269ee7bb5a64",
+			"key": "testTenant",
+			"value": "quick_marc_api_tests",
+			"type": "string"
+		},
+		{
+			"id": "3319edd4-8c06-4ec1-89ee-60bcc63c4af7",
+			"key": "moduleName",
+			"value": "mod-quick-marc",
+			"type": "string"
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/mod-quick-marc/mod-quick-marc.postman_collection.json
+++ b/mod-quick-marc/mod-quick-marc.postman_collection.json
@@ -1570,7 +1570,7 @@
 									"    error = pm.response.json();",
 									"});",
 									"",
-									"pm.test(\"Record content is valid\", function() {",
+									"pm.test(\"Got expected error message\", function() {",
 									"    pm.expect(error.code).to.eql(\"HTTP_BAD_REQUEST\");",
 									"    pm.expect(error.message).to.eql(\"request id and entity id are not equal\");",
 									"});",
@@ -2029,19 +2029,19 @@
 	],
 	"variable": [
 		{
-			"id": "d07a443b-7e2b-4cea-bb11-3b9f6af609b4",
+			"id": "e4bc7cad-2dc0-48a6-b24e-2264be2e6bcd",
 			"key": "marcRecordsResourceUrl",
 			"value": "https://raw.githubusercontent.com/folio-org/mod-source-record-storage/master/mod-source-record-storage-server/src/main/resources/sampledata/sampleMarcRecords.json",
 			"type": "string"
 		},
 		{
-			"id": "838b3829-61e1-44da-b49b-b3efa13ed567",
+			"id": "9cf33a58-74e8-4aa7-8514-7355ccc14eed",
 			"key": "testTenant",
 			"value": "quick_marc_api_tests",
 			"type": "string"
 		},
 		{
-			"id": "28e70be8-1f25-4090-9f1a-2d0fe30ea03d",
+			"id": "519f76b7-70d9-4938-9624-df442c63ff4a",
 			"key": "moduleName",
 			"value": "mod-quick-marc",
 			"type": "string"


### PR DESCRIPTION
[MODQM-4](https://issues.folio.org/browse/MODQM-4) - Api Tests for PUT records-editor/marc-records/id

* added positive test
<img width="123" alt="Снимок экрана 2020-04-07 в 12 21 41" src="https://user-images.githubusercontent.com/60380420/78654065-b4311b00-78cc-11ea-9e10-cc1017a583d9.png">

* added negative tests
<img width="256" alt="Снимок экрана 2020-04-07 в 12 21 48" src="https://user-images.githubusercontent.com/60380420/78654090-be531980-78cc-11ea-96ef-8df55086b2a7.png">

Positive test:
1. Update QuickMarcJson - 204 NO_CONTENT

Negative tests:
1. Update QuickMarcJson with wrong fixed data field length - 400 BAD_REQUEST
2. Update QuickMarcJson with record and request id mismatch - 400 BAD_REQUEST, error message: "request id and entity id are not equal"
3. Update QuickMarcJson with invalid id - 400 BAD_REQUEST

Environment variables are clear:
<img width="696" alt="Снимок экрана 2020-04-07 в 12 20 44" src="https://user-images.githubusercontent.com/60380420/78655344-8f3da780-78ce-11ea-83b6-2ac4dac49b9d.png">

Verified on folio-testing-okapi.aws.indexdata.com:
<img width="1392" alt="Снимок экрана 2020-04-07 в 12 50 19" src="https://user-images.githubusercontent.com/60380420/78655847-3589ad00-78cf-11ea-8d37-73072f0b19f3.png">
