### PR TITLE
MODKBEKBJ-423 Add API tests for managing kb-credentials

### DIFF
--- a/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
+++ b/mod-kb-ebsco-java/mod-kb-ebsco-java.postman_collection.json
@@ -1006,6 +1006,82 @@
 					"_postman_isSubFolder": true
 				},
 				{
+					"name": "setup for kb-credentials",
+					"item": [
+						{
+							"name": "POST credentials",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+										"exec": [
+											"//Check that status is 200",
+											"pm.test(\"Status is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"Response must have a json body\", function () {",
+											"    pm.response.to.be.withBody;",
+											"    pm.response.to.be.json; ",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.environment.set(\"kb-credentials-id1\", jsonData.id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.api+json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Massachusettss\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"kb-credentials"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
 					"name": "setup for tags",
 					"item": [
 						{
@@ -4165,6 +4241,2113 @@
 			"protocolProfileBehavior": {}
 		},
 		{
+			"name": "kb-credentials",
+			"item": [
+				{
+					"name": "GET kb-credentials collection",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "GET credentials collection",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"    pm.response.to.be.ok;",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_kbCredentialsCollection\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check data array is of type providers if not null",
+													"if(response.data) {",
+													"    let len = response.data.length;",
+													"    if(len > 0){",
+													"        //Get first record",
+													"        let firstRecord = response.data[0];",
+													"        //Test that type is kbCredentials",
+													"        pm.expect(firstRecord.type).eq('kbCredentials');",
+													"",
+													"        //Test that object has the expected keys",
+													"        pm.expect(firstRecord).to.include.all.keys(\"id\", \"type\", \"attributes\", \"meta\");",
+													"         ",
+													"         //Test that data.attributes has expected attributes",
+													"        pm.test('expected data.attributes are present', function() {",
+													"            pm.expect(firstRecord.attributes).to.be.an('object');",
+													"            pm.expect(firstRecord.attributes).to.include.all.keys(\"name\", \"apiKey\", \"customerId\", \"url\");",
+													"        });",
+													"    } else {",
+													"        console.log(\"No credentials exist\");",
+													"    }",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "12a52873-660e-4d00-93ed-d14042c755c5",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "f48169e2-790e-4535-9deb-74f1e2c56d2a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "POST kb-credentials",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "POST credentials valid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 201",
+													"pm.test(\"Status is 201\", function () {",
+													"    pm.response.to.have.status(201);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_kbCredentials\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that type is kbCredentials",
+													"pm.expect(response.type).eq('kbCredentials');",
+													"",
+													"//Test that object has the expected keys",
+													"pm.expect(response).to.include.all.keys(\"id\", \"type\", \"attributes\", \"meta\");",
+													"         ",
+													" //Test that data.attributes has expected attributes",
+													"pm.test('expected data.attributes are present', function() {",
+													"        pm.expect(response.attributes).to.be.an('object');",
+													"        pm.expect(response.attributes).to.include.all.keys(\"name\", \"apiKey\", \"customerId\", \"url\");",
+													"});",
+													"        ",
+													" //Test that data.attributes are expected attributes",
+													"pm.test('expected data.attributes are as expected', function() {",
+													"        pm.expect(response.attributes.name).to.be.equals('University of Illinois');",
+													"        pm.expect(response.attributes.apiKey).to.be.equals('****************************************');",
+													"        pm.expect(response.attributes.customerId).to.be.equals(pm.environment.get('rm-api-custid-value'));",
+													"        pm.expect(response.attributes.url).to.be.equals(pm.environment.get('rm-api-url-value'));",
+													"});",
+													"",
+													"pm.test('expected meta are present', function() {",
+													"        pm.expect(response.meta).to.be.an('object');",
+													"        pm.expect(response.meta).to.include.all.keys(\"createdDate\", \"createdByUserId\", \"createdByUsername\");",
+													"});",
+													"",
+													"pm.environment.set(\"kb-credentials-id2\", response.id);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "POST credentials invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"KB API Credentials are invalid\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"invalid key\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "POST credentials with name longer than 255",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid name\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"name is too long (maximum is 255 characters)\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"zxehyhvsiucipujicjhuziczzjvqhwmaepkvdmupcaqrscjiilqlnumrxyttwgfoqlxztlpsosldoqjcbrkyvvaxzcklqlzbdkofjkqtbmvhkuyhdlvyeuqmebrulxqzryqzpcxkbezpdwbwzguwwnjswhwfexngtxgkizjdwvcnxqlhsszbavqndixyxeqvceqdssviqaotmsvnuehsmghhwsnhwktzrrqizhckmwtgpcsdhdyxhgnrgnqzxbcu\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "POST credentials with empty name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid name\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"name must not be empty\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "POST credentials with already existed name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Duplicate name\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"Credentials with name 'University of Illinois' already exist\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "POST credentials with empty url",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid url\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"url must not be empty\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "POST credentials with empty customerId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid customerId\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"customerId must not be empty\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "PUT kb-credentials",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "PUT credentials",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"success test - 204 and no body\", function() {",
+													"    pm.response.to.have.status(204);",
+													"    pm.response.to.not.be.withBody;",
+													"});",
+													"",
+													"pm.sendRequest({",
+													"    url: pm.environment.get(\"protocol\") + \"://\" + pm.environment.get(\"url\") + \":\" + pm.environment.get(\"okapiport\") + \"/eholdings/kb-credentials/\" + pm.environment.get(\"kb-credentials-id1\"),",
+													"    method: 'GET',",
+													"    header: {",
+													"        'X-Okapi-Tenant': pm.environment.get(\"xokapitenant\"),",
+													"        'X-Okapi-Token': pm.environment.get(\"xokapitoken\"),",
+													"        'Content-Type': 'application/json'",
+													"    },",
+													"}, function(err, res) {",
+													"    var response = res.json();",
+													"    pm.test(\"Check changes\", function () {",
+													"        pm.expect(response.attributes.name).to.be.equals('University of Massachusettss - Updated');",
+													"        pm.expect(response.attributes.apiKey).to.be.equals('****************************************');",
+													"        pm.expect(response.attributes.customerId).to.be.equals(pm.environment.get('rm-api-custid-value'));",
+													"        pm.expect(response.attributes.url).to.be.equals(pm.environment.get('rm-api-url-value'));",
+													"    });",
+													"    ",
+													"    pm.test('expected meta are present', function() {",
+													"        pm.expect(response.meta).to.be.an('object');",
+													"        pm.expect(response.meta).to.include.all.keys(\"createdDate\", \"createdByUserId\", \"createdByUsername\", \"updatedDate\", \"updatedByUserId\", \"updatedByUsername\");",
+													"    });",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss - Updated\",\r\n      \"apiKey\": \"{{rm-api-key-value}}\",\r\n      \"url\": \"{{rm-api-url-value}}\",\r\n      \"customerId\": \"{{rm-api-custid-value}}\"\r\n    }\r\n  }\r\n}\r\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "PUT credentials with invalid id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.be.clientError;",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check data array is of type providers if not null",
+													"if(response) {",
+													"    pm.test('expected one error with title', function() {",
+													"        pm.expect(response.errors[0]).to.be.an('object');",
+													"        pm.expect(response.errors[0].title).to.contain(\"\\'id\\' parameter is incorrect\");",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss - Updated\",\r\n      \"apiKey\": \"{{rm-api-key-value}}\",\r\n      \"url\": \"{{rm-api-url-value}}\",\r\n      \"customerId\": \"{{rm-api-custid-value}}\"\r\n    }\r\n  }\r\n}\r\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/invalid-id",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"invalid-id"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT missing credentials",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 404",
+													"pm.test(\"Status is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"    pm.response.to.be.notFound;",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check data array is of access types if not null",
+													"if(response) {",
+													"    pm.test('expected one error with title', function() {",
+													"        pm.expect(response.errors[0]).to.be.an('object');",
+													"        pm.expect(response.errors[0].title).to.equal(\"KbCredentials not found by id: 99999999-9999-1999-a999-999999999999\");",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss - Updated\",\r\n      \"apiKey\": \"{{rm-api-key-value}}\",\r\n      \"url\": \"{{rm-api-url-value}}\",\r\n      \"customerId\": \"{{rm-api-custid-value}}\"\r\n    }\r\n  }\r\n}\r\n"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/99999999-9999-1999-a999-999999999999",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"99999999-9999-1999-a999-999999999999"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT credentials invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"KB API Credentials are invalid\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"invalid key\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT credentials with name longer than 255",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid name\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"name is too long (maximum is 255 characters)\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"zxehyhvsiucipujicjhuziczzjvqhwmaepkvdmupcaqrscjiilqlnumrxyttwgfoqlxztlpsosldoqjcbrkyvvaxzcklqlzbdkofjkqtbmvhkuyhdlvyeuqmebrulxqzryqzpcxkbezpdwbwzguwwnjswhwfexngtxgkizjdwvcnxqlhsszbavqndixyxeqvceqdssviqaotmsvnuehsmghhwsnhwktzrrqizhckmwtgpcsdhdyxhgnrgnqzxbcu\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT credentials with empty name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid name\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"name must not be empty\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT credentials with already existed name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Duplicate name\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"Credentials with name 'University of Illinois' already exist\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT credentials with empty url",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid url\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"url must not be empty\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "PUT credentials with empty customerId",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"pm.test(\"Status is 422\", function () {",
+													"    pm.response.to.have.status(422);",
+													"    pm.response.to.have.body();",
+													"});",
+													"",
+													"var response = pm.response.json();",
+													"",
+													"pm.test(\"Content-Type header has expected value\", function () {",
+													"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.contain(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"pm.test(\"Errors array is as expected\", function () {",
+													"    pm.expect(response.errors).to.be.an('array').that.is.not.empty;",
+													"    pm.expect(response.errors.length).to.eql(1);",
+													"    pm.expect(response.errors[0].title).to.equal(\"Invalid customerId\");",
+													"    pm.expect(response.errors[0].detail).to.equal(\"customerId must not be empty\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"{{rm-api-key-value}}\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "50084701-a1e9-4d6f-96d4-e388c2f910cc",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "85fd9a20-4d47-447d-a9d1-628abbf0a0c6",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "GET kb-credentials by id",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "GET credentials by id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 200",
+													"pm.test(\"Status is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_kbCredentials\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Test that type is kbCredentials",
+													"pm.expect(response.type).eq('kbCredentials');",
+													"",
+													"//Test that object has the expected keys",
+													"pm.expect(response).to.include.all.keys(\"id\", \"type\", \"attributes\", \"meta\");",
+													"         ",
+													" //Test that data.attributes has expected attributes",
+													"pm.test('expected data.attributes are present', function() {",
+													"        pm.expect(response.attributes).to.be.an('object');",
+													"        pm.expect(response.attributes).to.include.all.keys(\"name\", \"apiKey\", \"customerId\", \"url\");",
+													"});",
+													"        ",
+													" //Test that data.attributes are expected attributes",
+													"pm.test('expected data.attributes are as expected', function() {",
+													"        pm.expect(response.attributes.name).to.be.equals('University of Massachusettss - Updated');",
+													"        pm.expect(response.attributes.apiKey).to.be.equals('****************************************');",
+													"        pm.expect(response.attributes.customerId).to.be.equals(pm.environment.get('rm-api-custid-value'));",
+													"        pm.expect(response.attributes.url).to.be.equals(pm.environment.get('rm-api-url-value'));",
+													"});",
+													"",
+													"pm.test('expected meta are present', function() {",
+													"        pm.expect(response.meta).to.be.an('object');",
+													"        pm.expect(response.meta).to.include.all.keys(\"createdDate\", \"createdByUserId\", \"createdByUsername\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id1}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "GET credentials with invalid id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.be.clientError;",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check data array is of type providers if not null",
+													"if(response) {",
+													"    pm.test('expected one error with title', function() {",
+													"        pm.expect(response.errors[0]).to.be.an('object');",
+													"        pm.expect(response.errors[0].title).to.contain(\"\\'id\\' parameter is incorrect\");",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"data\": {\n    \"type\": \"kbCredentials\",\n    \"attributes\": {\n      \"name\": \"University of Illinois\",\n      \"apiKey\": \"invalid key\",\n      \"url\": \"{{rm-api-url-value}}\",\n      \"customerId\": \"{{rm-api-custid-value}}\"\n    }\n  }\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/invalid-id",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"invalid-id"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "GET missing credentials",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 404",
+													"pm.test(\"Status is 404\", function () {",
+													"    pm.response.to.have.status(404);",
+													"    pm.response.to.be.notFound;",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check data array is of access types if not null",
+													"if(response) {",
+													"    pm.test('expected one error with title', function() {",
+													"        pm.expect(response.errors[0]).to.be.an('object');",
+													"        pm.expect(response.errors[0].title).to.equal(\"KbCredentials not found by id: 99999999-9999-1999-a999-999999999999\");",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/99999999-9999-1999-a999-999999999999",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"99999999-9999-1999-a999-999999999999"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "12a52873-660e-4d00-93ed-d14042c755c5",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "f48169e2-790e-4535-9deb-74f1e2c56d2a",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "DELETE kb-credentials",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "DELETE credentials",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 204",
+													"pm.test(\"Status is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    pm.response.to.be.success;",
+													"});",
+													"",
+													"pm.test(\"Response without error json body\", function () {",
+													"    pm.response.to.be.success;",
+													"    pm.response.to.not.have.body;",
+													"    pm.response.to.not.have.jsonBody('error');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss\",\r\n      \"apiKey\": \"QTh4lr58lK6RS44WI1wwY4tbXuXjHSJXaDO15wo1\",\r\n      \"url\": \"https://sandbox.ebsco.io\",\r\n      \"customerId\": \"apidvgvmt\"\r\n    }\r\n  }\r\n}\r\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id2}}",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"{{kb-credentials-id2}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "DELETE missing credentials",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 204",
+													"pm.test(\"Status is 204\", function () {",
+													"    pm.response.to.have.status(204);",
+													"    pm.response.to.be.success;",
+													"});",
+													"",
+													"pm.test(\"Response without error json body\", function () {",
+													"    pm.response.to.be.success;",
+													"    pm.response.to.not.have.body;",
+													"    pm.response.to.not.have.jsonBody('error');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-type",
+												"value": "application/vnd.api+json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss - Updated\",\r\n      \"apiKey\": \"{{rm-api-key-value}}\",\r\n      \"url\": \"{{rm-api-url-value}}\",\r\n      \"customerId\": \"{{rm-api-custid-value}}\"\r\n    }\r\n  }\r\n}\r\n"
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/99999999-9999-1999-a999-999999999999",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"99999999-9999-1999-a999-999999999999"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Negative",
+							"item": [
+								{
+									"name": "DELETE credentials with invalid id",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+												"exec": [
+													"//Check that status is 400",
+													"pm.test(\"Status is 400\", function () {",
+													"    pm.response.to.have.status(400);",
+													"    pm.response.to.be.clientError;",
+													"});",
+													"",
+													"pm.test(\"Response must have a json body\", function () {",
+													"    pm.response.to.be.withBody;",
+													"    pm.response.to.be.json; ",
+													"});",
+													"",
+													"//Check that content-type is application/vnd.api+json",
+													"pm.test(\"'Content-Type' is application/vnd.api+json\", function() { ",
+													"      pm.response.to.have.header(\"Content-Type\");",
+													"      pm.expect(pm.response.headers.get(\"Content-Type\")).to.be.equal(\"application/vnd.api+json\");",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"//Validate response against json api schema",
+													"pm.test(\"Validate schema\", function () {",
+													"    pm.expect(tv4.validate(response, JSON.parse(pm.environment.get(\"schema_jsonapiError\")))).to.equal(true, \"Schema validation error: \" + JSON.stringify(tv4.error));",
+													"    pm.expect(tv4.missing.length).to.equal(0, \"Missing schemas: \" + JSON.stringify(tv4.missing));",
+													"});",
+													"",
+													"//Check data array is of type providers if not null",
+													"if(response) {",
+													"    pm.test('expected one error with title', function() {",
+													"        pm.expect(response.errors[0]).to.be.an('object');",
+													"        pm.expect(response.errors[0].title).to.contain(\"\\'id\\' parameter is incorrect\");",
+													"    });",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-okapi-tenant",
+												"type": "text",
+												"value": "{{xokapitenant}}"
+											},
+											{
+												"key": "x-okapi-token",
+												"type": "text",
+												"value": "{{xokapitoken}}"
+											},
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/vnd.api+json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss - Updated\",\r\n      \"apiKey\": \"{{rm-api-key-value}}\",\r\n      \"url\": \"{{rm-api-url-value}}\",\r\n      \"customerId\": \"{{rm-api-custid-value}}\"\r\n    }\r\n  }\r\n}\r\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/invalid-id",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{url}}"
+											],
+											"port": "{{okapiport}}",
+											"path": [
+												"eholdings",
+												"kb-credentials",
+												"invalid-id"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "50084701-a1e9-4d6f-96d4-e388c2f910cc",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "85fd9a20-4d47-447d-a9d1-628abbf0a0c6",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "cb978df6-1c3c-4e5e-aff1-656836849aa3",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "6317941d-f62d-4179-894b-0598925f9938",
+						"type": "text/javascript",
+						"exec": [
+							"tv4.addSchema(\"schema_kbCredentialsCollection.json\",pm.variables.get(\"schema_kbCredentialsCollection\"));",
+							"tv4.addSchema(\"schema_kbCredentials.json\", pm.variables.get(\"schema_kbCredentials\"));",
+							"tv4.addSchema(\"schema_kbCredentialsDataAttributes.json\",pm.variables.get(\"schema_kbCredentialsDataAttributes\"));",
+							"tv4.addSchema(\"schema_metadata.schema\", pm.environment.get(\"schema_metadata\"));",
+							"tv4.addSchema(\"schema_metaTotalResults.json\", pm.environment.get(\"schema_metaTotalResults\"));",
+							"tv4.addSchema(\"schema_jsonapi.json\", pm.environment.get(\"schema_jsonapi\"));",
+							"tv4.addSchema(\"schema_errors.schema\", pm.environment.get(\"schema_errors\"));",
+							"tv4.addSchema(\"schema_error.schema\", pm.environment.get(\"schema_error\"));",
+							"tv4.addSchema(\"schema_jsonapiError.json\", JSON.parse(pm.variables.get(\"schema_jsonapiError\")));",
+							"tv4.addSchema(\"schema_jsonapiErrorResponse.json\", JSON.parse(pm.variables.get(\"schema_jsonapiErrorResponse\")));",
+							"tv4.addSchema(\"schema_uuid.schema\", pm.variables.get(\"schema_uuid\"));",
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
 			"name": "access-types",
 			"item": [
 				{
@@ -4438,7 +6621,7 @@
 													"if(response) {",
 													"    pm.test('expected one error with title', function() {",
 													"        pm.expect(response.errors[0]).to.be.an('object');",
-													"        pm.expect(response.errors[0].title).to.equal(\"Access type not found by id: 99999999-9999-1999-a999-999999999999\");",
+													"        pm.expect(response.errors[0].title).to.equal(\"KbCredentials not found by id: 99999999-9999-1999-a999-999999999999\");",
 													"    });",
 													"}"
 												],
@@ -4461,7 +6644,7 @@
 											}
 										],
 										"url": {
-											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/access-types/99999999-9999-1999-a999-999999999999",
+											"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/99999999-9999-1999-a999-999999999999",
 											"protocol": "{{protocol}}",
 											"host": [
 												"{{url}}"
@@ -4469,7 +6652,7 @@
 											"port": "{{okapiport}}",
 											"path": [
 												"eholdings",
-												"access-types",
+												"kb-credentials",
 												"99999999-9999-1999-a999-999999999999"
 											]
 										}
@@ -28678,7 +30861,7 @@
 															"    ",
 															"//Test that default value for rmapiBaseUrl is returned",
 															"pm.test('rmapiBaseUrl is returned with default value', function(){",
-															"    pm.expect(response.data.attributes.rmapiBaseUrl).eq(\"https://sandbox.ebsco.io\");",
+															"    pm.expect(response.data.attributes.rmapiBaseUrl).eq(\"https://api.ebsco.com\");",
 															"});",
 															"",
 															"//Test apiKey is missing when it is not configured",
@@ -35533,6 +37716,139 @@
 										"eholdings",
 										"access-types",
 										"{{access-type-id4}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "tear-down kb-credentials test",
+					"item": [
+						{
+							"name": "DELETE missing credentials 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+										"exec": [
+											"//Check that status is 204",
+											"pm.test(\"Status is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.response.to.be.success;",
+											"});",
+											"",
+											"pm.test(\"Response without error json body\", function () {",
+											"    pm.response.to.be.success;",
+											"    pm.response.to.not.have.body;",
+											"    pm.response.to.not.have.jsonBody('error');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-type",
+										"type": "text",
+										"value": "application/vnd.api+json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss - Updated\",\r\n      \"apiKey\": \"{{rm-api-key-value}}\",\r\n      \"url\": \"{{rm-api-url-value}}\",\r\n      \"customerId\": \"{{rm-api-custid-value}}\"\r\n    }\r\n  }\r\n}\r\n"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id1}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"kb-credentials",
+										"{{kb-credentials-id1}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "DELETE missing credentials 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "07dd7f7f-eede-404c-a0d5-4a9ca000802b",
+										"exec": [
+											"//Check that status is 204",
+											"pm.test(\"Status is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"    pm.response.to.be.success;",
+											"});",
+											"",
+											"pm.test(\"Response without error json body\", function () {",
+											"    pm.response.to.be.success;",
+											"    pm.response.to.not.have.body;",
+											"    pm.response.to.not.have.jsonBody('error');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-okapi-tenant",
+										"type": "text",
+										"value": "{{xokapitenant}}"
+									},
+									{
+										"key": "x-okapi-token",
+										"type": "text",
+										"value": "{{xokapitoken}}"
+									},
+									{
+										"key": "Content-type",
+										"value": "application/vnd.api+json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"data\": {\r\n    \"type\": \"kbCredentials\",\r\n    \"attributes\": {\r\n      \"name\": \"University of Massachusettss - Updated\",\r\n      \"apiKey\": \"{{rm-api-key-value}}\",\r\n      \"url\": \"{{rm-api-url-value}}\",\r\n      \"customerId\": \"{{rm-api-custid-value}}\"\r\n    }\r\n  }\r\n}\r\n"
+								},
+								"url": {
+									"raw": "{{protocol}}://{{url}}:{{okapiport}}/eholdings/kb-credentials/{{kb-credentials-id2}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{url}}"
+									],
+									"port": "{{okapiport}}",
+									"path": [
+										"eholdings",
+										"kb-credentials",
+										"{{kb-credentials-id2}}"
 									]
 								}
 							},


### PR DESCRIPTION
## Purpose
add tests to cover:
* https://issues.folio.org/browse/MODKBEKBJ-419
* https://issues.folio.org/browse/MODKBEKBJ-420
* https://issues.folio.org/browse/MODKBEKBJ-421
* https://issues.folio.org/browse/MODKBEKBJ-422
* https://issues.folio.org/browse/MODKBEKBJ-423

## Approach
Add tests for following endpoint:
 * GET /eholdings/kb-credentials
 * POST /eholdings/kb-credentials
 * GET /eholdings/kb-credentials/{id}
 * PUT /eholdings/kb-credentials/{id}
* DELETE /eholdings/kb-credentials/{id}