### PR TITLE
MODFISTO-114 Ledger FY totals not updated after encumbrance update

### DIFF
--- a/mod-finance/mod-finance.postman_collection.json
+++ b/mod-finance/mod-finance.postman_collection.json
@@ -11754,10 +11754,8 @@
 															"    pm.response.to.be.ok;",
 															"    let ledger = pm.response.json();",
 															"    utils.validateLedger(ledger);",
-															"    let encumbrance1 = JSON.parse(pm.environment.get(\"encumbrance1Content\"));",
-															"    let encumbrance2 = JSON.parse(pm.environment.get(\"encumbrance2Content\"));",
-															"    pm.expect(ledger.available).to.equal(2500 + 1500 - 50);",
-															"    pm.expect(ledger.unavailable).to.equal(50);",
+															"    pm.expect(ledger.available).to.equal(2500 + 1500 - 45 -110);",
+															"    pm.expect(ledger.unavailable).to.equal(45 + 110);",
 															"});"
 														],
 														"type": "text/javascript"


### PR DESCRIPTION
[MODFISTO-114](https://issues.folio.org/browse/MODFISTO-114)

Fixed "Get ledger record with summary after 2nd encumbrances update" test

Verified on folio-testing:
![image](https://user-images.githubusercontent.com/41672277/84868651-b3172980-b085-11ea-94dc-1167562e4a15.png)
