### PR TITLE
MODINVOICE-168 Populate field "voucherLine.fundDistribution.code" upon Invoice approval

### DIFF
--- a/mod-invoice/mod-invoice.postman_collection.json
+++ b/mod-invoice/mod-invoice.postman_collection.json
@@ -12088,7 +12088,8 @@
 															"    invoiceLine.subTotal = 101;",
 															"    invoiceLine.fundDistributions[0].value = 50;",
 															"    invoiceLine.fundDistributions[0].encumbrance = pm.environment.get(\"encumbranceId1\");",
-															"    let amoutDistribution = {\"fundId\": invoiceLine.fundDistributions[0].fundId, \"distributionType\": \"amount\", \"value\": 55.6, \"encumbrance\" : pm.environment.get(\"encumbranceId2\")};",
+                                                            "    delete invoiceLine.fundDistributions[0].code;",
+															"    let amoutDistribution = {\"fundId\": pm.environment.get(\"fund2Id\"), \"distributionType\": \"amount\", \"value\": 55.6, \"encumbrance\" : pm.environment.get(\"encumbranceId2\")};",
 															"    invoiceLine.fundDistributions.push(amoutDistribution);",
 															"    delete invoiceLine.poLineId;",
 															"",
@@ -12256,7 +12257,10 @@
 															"});",
 															"",
 															"pm.test(\"Check all lines have amount type distributions\", function() {",
-															"   voucherLines.voucherLines.forEach(line => line.fundDistributions.forEach(distr => pm.expect(distr.distributionType).is.to.equal(\"amount\")));",
+															"   voucherLines.voucherLines.forEach(line => line.fundDistributions.forEach(distr => { ",
+															"      pm.expect(distr.distributionType).is.to.equal(\"amount\");",
+															"      pm.expect(distr).to.have.property(\"code\");",
+															"   }));",
 															"});"
 														],
 														"type": "text/javascript"


### PR DESCRIPTION
[MODINVOICE-168](https://issues.folio.org/browse/MODINVOICE-168)

Fixed invoiceLine creation for workflow tests to not use same fundId
Added verification that voucherLines have fund code after approval

Verified on folio-snapshot
![image](https://user-images.githubusercontent.com/41672277/85004600-6d7b5f00-b160-11ea-91dc-84b3db82f27a.png)
